### PR TITLE
Add more fiction universe prompt lists

### DIFF
--- a/lists/fiction/alien-predator.yml
+++ b/lists/fiction/alien-predator.yml
@@ -1,0 +1,62 @@
+---
+title: Alien and Predator names
+category: fiction
+description: "Places, species, factions, creatures, ships, and artifacts from Alien and Predator fiction"
+---
+acheron
+alien queen
+amanda ripley
+berserker predator
+bioweapon division
+bug hunt
+chestburster
+city hunter
+clan ship
+cloaking device
+colonial administration
+colonial marines
+combistick
+deacon
+derelict ship
+drone xenomorph
+ellen ripley
+engineer
+engineer temple
+facehugger
+fiorina 161
+fury 161
+hadley's hope
+hive
+hunter's moon
+isolation
+jungle hunter
+katanga
+lv-223
+lv-426
+mars base
+neomorph
+netgun
+nostromo
+ovomorph
+praetorian
+predalien
+predator
+prometheus
+queen alien
+queen mother
+seegson
+smartgun
+space jockey
+sulaco
+synthetic
+the company
+uscss covenant
+uscss nostromo
+uscss prometheus
+weyland corporation
+weyland industries
+weyland-yutani
+xenomorph
+xenomorph hive
+yautja
+yautja prime

--- a/lists/fiction/amber.yml
+++ b/lists/fiction/amber.yml
@@ -1,0 +1,70 @@
+---
+title: Amber names
+category: fiction
+description: "Places, powers, factions, and concepts from Roger Zelazny's Chronicles of Amber"
+---
+amber
+avernus
+bayle
+benedict
+black zone
+bleys
+brand
+brial
+cabal
+cabrach
+caine
+castle amber
+chaos
+coral
+corwin
+dalt
+dara
+deirdre
+delwin
+dworkin
+eric
+faiella-bionin
+fiona
+flora
+frakir
+ganelon
+gerard
+ghostwheel
+hellrides
+jasra
+julia barnes
+julian
+kashfa
+keep of the four worlds
+lancelot
+lorraine
+luke
+mandor
+martin
+mauve zone
+merlin
+nayda
+oberon
+pattern
+patternfall
+random
+rebma
+rinaldo
+shadow
+shadow earth
+spikard
+suhuy
+the abyss
+the black road
+the courts of chaos
+the jewel of judgment
+the pattern
+the primal pattern
+the serpent
+the trumps
+the unicorn
+tir-na nog'th
+trump gate
+werewindle
+ysabel

--- a/lists/fiction/avatar.yml
+++ b/lists/fiction/avatar.yml
@@ -1,0 +1,92 @@
+---
+title: "Avatar: The Last Airbender names"
+category: fiction
+description: "Places, peoples, spirits, bending arts, and factions from Avatar: The Last Airbender and The Legend of Korra"
+---
+agni kai
+air acolytes
+air nomads
+air temple island
+airbending
+appa
+avatar kyoshi
+avatar roku
+avatar state
+azula
+ba sing se
+ba sing se lower ring
+ba sing se upper ring
+badgermole
+bending
+bloodbending
+boiling rock
+boiling rock prison
+bumi
+cabbage merchant
+chi blocking
+combustion man
+combustionbending
+dragon dance
+earth kingdom
+earth kingdom colonies
+earthbending
+ember island
+ember island players
+energybending
+equalists
+fire ferret
+fire nation
+fire nation colonies
+fire nation royal palace
+fire sages
+firebending
+firelord ozai
+foggy swamp tribe
+harmonic convergence
+hei bai
+koizilla
+kuvira's empire
+kyoshi island
+lake laogai
+lava bending
+lightning redirection
+lion turtle
+mechanist
+metalbending
+misty palms oasis
+moon spirit
+naga
+northern air temple
+northern water tribe
+omashu
+platinum mecha
+polar bear dog
+pro-bending
+pro-bending arena
+red lotus
+republic city
+republic council
+sandbenders
+secret tunnel
+serpent's pass
+southern air temple
+southern water tribe
+sozin's comet
+spirit oasis
+spirit world
+swampbenders
+the avatar
+the dai li
+the fire lord
+the red lotus
+the white lotus
+the world tree
+tui and la
+wan
+wan shi tong
+wan shi tong's library
+water tribe
+waterbending
+western air temple
+yu dao
+zaofu

--- a/lists/fiction/barsoom.yml
+++ b/lists/fiction/barsoom.yml
@@ -1,0 +1,74 @@
+---
+title: Barsoom names
+category: fiction
+description: "Places, peoples, creatures, titles, and artifacts from Edgar Rice Burroughs' Barsoom"
+---
+airships
+apt
+banth
+banths
+barsoom
+black pirates
+blue men
+calot
+carter
+carthoris
+city of helium
+dead sea bottoms
+dejah thoris
+dor
+dwar
+first born
+gars
+great thoat
+great white apes
+green martians
+gulliver jones
+helium
+holy therns
+horz
+iss
+iss valley
+issus
+jeddak
+john carter
+kaol
+kaor
+korad
+lator
+lesser thern
+llana of gathol
+malagor
+manator
+masena
+oath of issus
+ocar
+odwar
+ool
+orovar
+otar
+padwar
+panthan
+plant men
+ptarth
+red martians
+river iss
+sarkoja
+synthetic men
+tan hadron
+tars tarkas
+thark
+tharkian hordes
+tharks
+therns
+thoat
+thoats
+u-gor
+ulsio
+valley dor
+warhoon
+warhoons
+white apes
+xavarian
+xodar
+zodanga

--- a/lists/fiction/bas-lag.yml
+++ b/lists/fiction/bas-lag.yml
@@ -1,0 +1,66 @@
+---
+title: Bas-Lag names
+category: fiction
+description: "Places, peoples, creatures, factions, and concepts from China Mieville's Bas-Lag fiction"
+---
+anophelii
+armada
+bas-lag
+bohemie
+bonetown
+cactacae
+cadnebar
+chimer
+construct council
+cray
+crobuzoner
+dagger moth
+dusthouse
+faber
+garuda
+gengris
+golemetry
+grindylow
+griss twist
+gutter
+iron council
+jabber
+jabberwock
+jack half-a-prayer
+judah low
+khepri
+lin
+malachite
+marrowers
+mercantile armada
+militia towers
+motley
+mr. motley
+new crobuzon
+nomads
+parliament
+parliamentary militia
+perdido street station
+possibility mining
+railsea
+remade
+rudgutter
+rustheap
+scar
+shadrach
+slake moth
+south badlands
+spatters
+thaumaturge
+the avanc
+the cacotopic stain
+the cactus people
+the glasshouse
+the khepri
+the militia
+the vodyanoi
+tinkermen
+torque
+vodyanoi
+weaver
+wyrmen

--- a/lists/fiction/conan.yml
+++ b/lists/fiction/conan.yml
@@ -1,0 +1,76 @@
+---
+title: Hyborian Age names
+category: fiction
+description: "Places, peoples, creatures, gods, and factions from Robert E. Howard's Conan and Hyborian Age"
+---
+acheron
+akbitana
+amazon
+aquilonia
+argossean
+asgard
+atali
+belit
+black circle
+black coast
+black colossus
+black lotus
+black seers
+bossonian
+brule
+cimmeria
+cimmerians
+city of skulls
+conajohara
+conan
+corsairs
+crom
+darfar
+dark valley
+devil in iron
+gunderland
+haunted pyramids
+hyborian age
+hyperborea
+iron shadows
+jemsha
+keshan
+khawarizm
+khitai
+khoraja
+kordava
+kosala
+koth
+kull
+kush
+lost valley
+nemedia
+ophir
+picts
+pirate isles
+poitain
+red brotherhood
+red nails
+salome
+scarlet citadel
+serpent men
+set
+shan-e-sorkh
+shemites
+shumballa
+siptah
+stigia
+the black ring
+the tower of the elephant
+the tree of death
+thoth-amon
+turan
+valusia
+vendhya
+vilayet sea
+xuthal
+yamatai
+yanath
+yg
+zamora
+zingara

--- a/lists/fiction/dark-tower.yml
+++ b/lists/fiction/dark-tower.yml
@@ -1,0 +1,79 @@
+---
+title: Dark Tower names
+category: fiction
+description: "Places, peoples, creatures, factions, and powers from Stephen King's Dark Tower fiction"
+---
+algul siento
+all-world
+arthur eld
+big coffin hunters
+blaine the mono
+calla bryn sturgis
+can ka no rey
+can-toi
+charlie the choo-choo
+charyou tree
+crimson king
+cuthbert allgood
+dark tower
+dark tower rose
+devar-tete
+devar-toi
+dixie pig
+doorway cave
+eddie dean
+eyebolt canyon
+farson
+father callahan
+gan
+gilead
+guns of eld
+gunslinger
+hax
+jake chambers
+jericho hill
+ka
+ka-tet
+lobstrosities
+low men
+lud
+maerlyn
+maerlyn's grapefruit
+manni
+mejis
+mid-world
+mohaine desert
+mordred
+mordred deschain
+oy
+patricia
+prim
+rainbow bends
+rhea of the coos
+roland deschain
+rose madder
+shardik
+sheemie
+song of susannah
+susannah dean
+taheen
+the beam
+the big combination
+the breakers
+the calla
+the clearing at the end of the path
+the dogan
+the gunslingers
+the man in black
+the old people
+the rose
+the speaking demon
+the turtle
+the wolves
+thunderclap
+todash darkness
+tower road
+tull
+walter o'dim
+wizard's glass
+wolves of the calla

--- a/lists/fiction/dc.yml
+++ b/lists/fiction/dc.yml
@@ -1,0 +1,90 @@
+---
+title: DC Universe names
+category: fiction
+description: "Places, teams, species, artifacts, cosmic powers, and factions from DC fiction"
+---
+amanda waller
+amazon
+anti-monitor
+apokolips
+arkham asylum
+arkham knight
+atlantis
+bat-signal
+batcave
+bizarro world
+black lantern corps
+blue beetle scarab
+boomtube
+brainiac
+central city
+crime alley
+daily planet
+darkseid
+deathstroke
+doom patrol
+fawcett city
+fortress of solitude
+gcpd
+gotham city
+green arrow
+green lantern battery
+green lantern corps
+hall of justice
+hawkman
+intergang
+joker venom
+justice league
+kandor
+khandaq
+krypton
+kryptonite
+lantern rings
+league of assassins
+legion of doom
+legion of superheroes
+lexcorp
+mars
+metahuman
+metropolis
+monitor
+mother box
+mr. mxyzptlk
+new genesis
+nightwing
+nth metal
+nth world
+oa
+parademon
+phantom zone
+red hood
+red lantern corps
+robin
+star city
+star labs
+suicide squad
+superboy
+teen titans
+the anti-life equation
+the bat-family
+the black mercy
+the court of owls
+the endless
+the flashpoint
+the green
+the joker toxin
+the lantern corps
+the lazarus pit
+the multiverse
+the new gods
+the parliament of trees
+the question
+the red
+the rogues
+the speed force
+themyscira
+trigon
+watchtower
+wayne enterprises
+wayne manor
+yj

--- a/lists/fiction/dragon-ball.yml
+++ b/lists/fiction/dragon-ball.yml
@@ -1,0 +1,82 @@
+---
+title: Dragon Ball names
+category: fiction
+description: "Places, species, transformations, artifacts, and powers from Dragon Ball"
+---
+android 16
+android 17
+android 18
+androids
+beerus
+bulma
+capsule corp
+capsule corporation
+capsule house
+cell
+cell games
+cell juniors
+destroyer god
+dragon balls
+dragon radar
+earthlings
+frieza force
+fusion dance
+fusion reborn
+galactic patrol
+galick gun
+ginyu force
+gohan
+goku
+gotenks
+great ape
+hyperbolic time chamber
+kaio-ken
+kaioshin
+kame house
+kamehameha
+kami's lookout
+king kai's planet
+kinton
+korin tower
+krillin
+majin
+majin buu
+master roshi
+mr. satan
+namek
+namekian dragon balls
+namekians
+nimbus cloud
+oozaru
+other world
+piccolo
+piccolo jr
+pilaf gang
+planet vegeta
+porunga
+potara
+pride troopers
+raditz
+red ribbon army
+saiyans
+shenlong
+shenron
+super buu
+super dragon balls
+super saiyan
+super saiyan blue
+super saiyan god
+supreme kai
+the lookout
+time patrol
+tournament of power
+trunks
+trunks' time machine
+ultra instinct
+universe 6
+universe 7
+vegeta
+west city
+world martial arts tournament
+yardrat
+zeno

--- a/lists/fiction/dragonlance.yml
+++ b/lists/fiction/dragonlance.yml
@@ -1,0 +1,56 @@
+---
+title: Dragonlance names
+category: fiction
+description: "Places, peoples, factions, creatures, deities, and artifacts from Dragonlance"
+---
+ansalon
+balifor
+blue dragonarmy
+chromatic dragons
+citadel of light
+clerist's tower
+dark queen
+draconians
+dragon highlords
+dragon orb
+dragonarmies
+dragonlance
+ergoth
+flint fireforge
+gully dwarves
+hylo
+istari
+kender
+kharolis
+knights of neraka
+knights of solamnia
+krynn
+mithas
+mount nevermind
+neraka
+qualinesti
+raistlin
+red robes
+sancrist
+silvanesti
+solace
+solamnia
+takhasis
+tarsis
+the abyss
+the conclave of wizards
+the gods of balance
+the gods of darkness
+the gods of light
+the graygem
+the high clerist's tower
+the inn of the last home
+the order of high sorcery
+the platinum dragon
+the staff of magius
+the tower of high sorcery
+the vallenwood
+the war of the lance
+tika waylan
+white robes
+xythar

--- a/lists/fiction/elder-scrolls.yml
+++ b/lists/fiction/elder-scrolls.yml
@@ -1,0 +1,87 @@
+---
+title: Elder Scrolls names
+category: fiction
+description: "Places, peoples, factions, creatures, artifacts, and deities from The Elder Scrolls"
+---
+aedra
+akatosh
+aldmer
+aldmeri dominion
+alduin
+altmer
+an-xileel
+argonian
+arkay
+ashlander
+auriel
+azura
+balmora
+black marsh
+blackreach
+blade
+bosmer
+breton
+bruma
+cheydinhal
+chorrol
+cyrodiil
+daedra
+dark brotherhood
+dibella
+dovahkiin
+dremora
+dwemer
+ebonheart pact
+elsweyr
+falkreath
+fighters guild
+forsworn
+glass armor
+gray fox
+hermaeus mora
+high hrothgar
+imperial city
+imperials
+jarl
+khajiit
+knights of the nine
+kynareth
+mage's guild
+malacath
+markarth
+mehrunes dagon
+meridia
+molag bal
+morrowind
+morthal
+namira
+nerevarine
+nibenay
+nord
+oblivion
+ordinator
+orsimer
+paarthurnax
+red mountain
+redguard
+riften
+septim empire
+sheogorath
+skyrim
+solitude
+solstheim
+soul cairn
+thalmor
+the blades
+the companions
+the elder scrolls
+the tribunal
+thieves guild
+tsaesci
+valenwood
+vampire lord
+vivec
+whiterun
+windhelm
+winterhold
+yokuda

--- a/lists/fiction/expanse.yml
+++ b/lists/fiction/expanse.yml
@@ -1,0 +1,63 @@
+---
+title: Expanse names
+category: fiction
+description: "Places, factions, ships, peoples, and technologies from The Expanse"
+---
+anderson station
+anubis
+auberon
+behemoth
+belters
+canterbury
+ceres
+churn
+donnager
+draper station
+earth-mars coalition
+epstein drive
+eros station
+free navy
+ganymede
+gathering storm
+goliath armor
+holden
+ilus
+inazami
+jimenez
+julie mao
+jupiter system
+laconia
+laconian empire
+leonidas
+luna
+mars congressional republic
+mcrn
+mcrn donnager
+mcrn tachi
+medina station
+miller
+naomi nagata
+nauvoo
+new terra
+opa
+pella
+phoebe station
+protomolecule
+ring gate
+ring network
+ring space
+ring station
+rocinante
+slow zone
+sol gate
+sol system
+the belt
+the churn
+the tempest
+thoth station
+transport union
+tycho station
+underground
+united nations
+venus incident
+vesta blockade

--- a/lists/fiction/forgotten-realms.yml
+++ b/lists/fiction/forgotten-realms.yml
@@ -1,0 +1,70 @@
+---
+title: Forgotten Realms names
+category: fiction
+description: "Places, peoples, factions, creatures, deities, and artifacts from the Forgotten Realms"
+---
+abeir-toril
+amn
+anauroch
+ankheg
+arcane brotherhood
+asmodeus
+baldur's gate
+bane
+bhaal
+blackstaff tower
+calimshan
+candlekeep
+chult
+cormyr
+dalelands
+darkhold
+deep gnome
+demogorgon
+drizzt
+duergar
+elminster
+elturel
+evermeet
+faerun
+harpers
+icewind dale
+illithid
+luskan
+menzoberranzan
+mithral hall
+moonshae isles
+myrkul
+myth drannor
+mythallar
+netheril
+neverwinter
+nine hells
+orb of dragonkind
+phaerimm
+red wizards
+sea of fallen stars
+selune
+shadowdale
+shar
+silverymoon
+spine of the world
+szass tam
+tarrasque
+tethyr
+thay
+the abyss
+the cult of the dragon
+the emerald enclave
+the flaming fist
+the lords' alliance
+the order of the gauntlet
+the underdark
+the zhentarim
+tiamat
+torm
+undermountain
+waterdeep
+westgate
+wyrmshadow
+zhentil keep

--- a/lists/fiction/halo.yml
+++ b/lists/fiction/halo.yml
@@ -1,0 +1,57 @@
+---
+title: Halo names
+category: fiction
+description: "Places, factions, species, artifacts, ships, and installations from Halo"
+---
+alpha halo
+arbiter
+banished
+battle of reach
+brutes
+charum hakkor
+combat evolved
+cortana
+covenant
+didact
+domain
+elites
+flood
+forerunners
+forward unto dawn
+glassing
+gravemind
+great journey
+grunts
+halo array
+high charity
+infinity
+installation 00
+installation 04
+installation 05
+jackals
+keyship
+mantle of responsibility
+master chief
+maw
+new mombasa
+odst
+onyx
+pillar of autumn
+precursors
+prometheans
+reach
+reclaimer
+ringworld
+sangheili
+scarab
+silent cartographer
+spartan-ii
+spartan-iii
+the ark
+the flood
+the librarian
+the monitor
+unggoy
+unsc
+war sphinx
+zeta halo

--- a/lists/fiction/harry-potter.yml
+++ b/lists/fiction/harry-potter.yml
@@ -1,0 +1,98 @@
+---
+title: Wizarding World names
+category: fiction
+description: "Places, schools, houses, creatures, objects, and groups from the Harry Potter and Wizarding World fiction"
+---
+acromantula
+albania
+azkaban
+beauxbatons
+beedle the bard
+bezoar
+black lake
+bludger
+borgin and burkes
+buckbeak
+butterbeer
+chamber of secrets
+chudley cannons
+cockroach cluster
+cornish pixie
+death eaters
+deathly hallows
+dementor
+demiguise
+diagon alley
+durmstrang
+elder wand
+erised
+expecto patronum
+fawkes
+fidelius charm
+firebolt
+fizzing whizzbee
+flo powder
+flobberworm
+forbidden forest
+galleon
+ghoul
+gillyweed
+goblet of fire
+godric's hollow
+golden snitch
+grimmauld place
+gringotts
+gryffindor
+hogsmeade
+hogwarts
+hogwarts express
+hogwarts houses
+horcrux
+hufflepuff
+imperius curse
+invisibility cloak
+knight bus
+knockturn alley
+leaky cauldron
+little whinging
+mandrake
+marauder's map
+merpeople
+ministry of magic
+mokeskin pouch
+muggle
+nagini
+niffler
+ollivanders
+order of merlin
+order of the phoenix
+parseltongue
+patronus
+pensieve
+platform nine and three quarters
+polyjuice potion
+portkey
+privet drive
+quaffle
+quidditch
+ravenclaw
+room of requirement
+salem witches' institute
+scabbers
+slytherin
+sorting hat
+spellotape
+st mungo's
+the burrow
+the daily prophet
+the three broomsticks
+thestral
+time-turner
+triwizard tournament
+unforgivable curses
+vault 713
+veela
+whomping willow
+wizarding world
+wizengamot
+zonko's joke shop

--- a/lists/fiction/magic-multiverse.yml
+++ b/lists/fiction/magic-multiverse.yml
@@ -1,0 +1,64 @@
+---
+title: Magic multiverse names
+category: fiction
+description: "Planes, peoples, factions, creatures, and artifacts from Magic: The Gathering fiction"
+---
+alara
+amonkhet
+angel
+arcavios
+artificer
+azorius senate
+baloth
+bant
+boros legion
+capenna
+coalition
+dominaria
+dragonlord atarka
+dragonlord dromoka
+dragonlord kolaghan
+dragonlord ojutai
+dragonlord silumgar
+eldrazi
+esper
+fblthp
+firja
+garruk
+goblin
+golgari swarm
+gruul clans
+izzet league
+jace beleren
+jund
+kaldheim
+kamigawa
+karn
+kaya
+keld
+khalni
+kiora
+kithkin
+liliana vess
+lorwyn
+mirrodin
+multani
+nicol bolas
+nissa revane
+phyrexia
+phyrexian
+planeswalker
+rakdos cult
+ravnica
+selesnya conclave
+serra's realm
+shandalar
+simic combine
+strixhaven
+tarkir
+theros
+urza
+vampire nocturnus
+vedalken
+vryn
+zendikar

--- a/lists/fiction/marvel.yml
+++ b/lists/fiction/marvel.yml
@@ -1,0 +1,102 @@
+---
+title: Marvel Universe names
+category: fiction
+description: "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction"
+---
+a-force
+adamantium
+aim
+alpha flight
+annihilus
+asgard
+avengers
+avengers mansion
+baxter building
+black order
+black panther
+blackbird
+brood
+brotherhood of mutants
+celestials
+daily bugle
+danger room
+dark dimension
+darkhold
+doctor doom
+doctor strange
+ego
+ego the living planet
+eternals
+fantastic four
+galactus
+genosha
+guardians of the galaxy
+hellfire club
+hulk
+hydra
+infinity gauntlet
+infinity gems
+infinity stones
+inhumans
+iron man
+kamar-taj
+klyntar
+knowhere
+krakoa
+kree
+latveria
+living tribunal
+madripoor
+masters of evil
+midgard
+midnight sons
+mind stone
+morlocks
+mutants
+negative zone
+negative zone portal
+new avengers
+new mutants
+nova corps
+odinforce
+power stone
+quantum realm
+ravagers
+reality stone
+red room
+runaways
+sanctum sanctorum
+savage land
+secret empire
+sentinels
+shield
+sinister six
+skrull
+sokovia
+sorcerer supreme
+soul stone
+space stone
+spider-man
+stark tower
+sword
+symbiote
+the accusers
+the avengers
+the bifrost
+the blip
+the cabal
+the darkhold
+the defenders
+the hand
+the illuminati
+the phoenix force
+the snap
+thunderbolts
+time stone
+ultron
+utopia
+vibranium
+wakanda
+weapon x
+x-men
+xandar

--- a/lists/fiction/mass-effect.yml
+++ b/lists/fiction/mass-effect.yml
@@ -1,0 +1,84 @@
+---
+title: Mass Effect names
+category: fiction
+description: "Places, species, factions, ships, artifacts, and powers from Mass Effect"
+---
+anderson
+andromeda initiative
+aria
+aria t'loak
+asari
+batarians
+biotic
+c-sec
+catalyst
+cerberus
+cerebus phantom
+citadel
+citadel council
+citadel presidium
+citadel space
+citadel wards
+collector base
+collectors
+commander shepard
+crucible
+eden prime
+edi
+elcor
+element zero
+femshep
+feros
+geth
+grissom academy
+grissom academy students
+hanar
+harbinger
+illium
+illusive man
+jack
+javik
+joker
+kaidan alenko
+kasumi goto
+krogan
+leviathan
+liara t'soni
+mako
+mass effect field
+mass relay
+migrant fleet
+mordin solus
+normandy crew
+normandy sr-1
+normandy sr-2
+noveria
+omega
+omega 4 relay
+omega station
+overlord
+prothean
+quarian
+rachni
+reaper
+reaper indoctrination
+salarians
+samara
+saren
+shadow broker
+shepard
+sovereign
+spectres
+systems alliance
+tali'zorah
+thane krios
+thorian
+tuchanka
+turians
+udina
+udina's coup
+virmire
+volus
+vorcha
+wrex
+zaeed

--- a/lists/fiction/one-piece.yml
+++ b/lists/fiction/one-piece.yml
@@ -1,0 +1,85 @@
+---
+title: One Piece names
+category: fiction
+description: "Places, factions, peoples, creatures, ships, powers, and treasures from One Piece"
+---
+alabasta
+arlong park
+arlong pirates
+baratie
+blackbeard pirates
+buggy pirates
+celestial dragons
+cp9
+devil fruit
+dressrosa
+drum island
+east blue
+elbaf
+enel
+enies lobby
+fish-man island
+fish-men
+franky family
+germa 66
+going merry
+gomu gomu no mi
+grand line
+haki
+heart pirates
+impel down
+island whale
+jinbe
+kaido
+kuja pirates
+laboon
+little garden
+loguetown
+mariejois
+marine admirals
+marineford
+marines
+mary geoise
+mink tribe
+mirror world
+new fish-man pirates
+new world
+ohara
+one piece
+pacifista
+pluton
+poseidon
+punk hazard
+raftel
+red line
+revolutionary army
+roger pirates
+rumble ball
+sea kings
+seastone
+seven warlords
+shandora
+shanks
+skypiea
+smile fruit
+sogeking
+soul king
+soul pocus
+straw hat pirates
+sunny
+supernovas
+the four emperors
+the poneglyphs
+thousand sunny
+thriller bark
+thriller bark pirates
+tony tony chopper
+vinsmoke family
+void century
+wano
+water 7
+whitebeard pirates
+whole cake island
+world government
+world nobles
+zou

--- a/lists/fiction/pokemon.yml
+++ b/lists/fiction/pokemon.yml
@@ -1,0 +1,65 @@
+---
+title: Pokemon names
+category: fiction
+description: "Regions, species, legendary Pokemon, teams, and artifacts from Pokemon"
+---
+alola
+arceus
+articuno
+bulbasaur
+celebi
+charizard
+charmander
+cinderace
+darkrai
+deoxys
+dialga
+ditto
+eevee
+entei
+eternatus
+galar
+gengar
+giratina
+greninja
+groudon
+ho-oh
+hoenn
+jigglypuff
+johto
+kalos
+kanto
+kyogre
+lucario
+lugia
+lunala
+master ball
+mew
+mewtwo
+moltres
+necrozma
+paldea
+palkia
+pichu
+pikachu
+pokeball
+pokedex
+rayquaza
+reshiram
+sinnoh
+solgaleo
+squirtle
+suicune
+team aqua
+team flare
+team galactic
+team magma
+team plasma
+team rocket
+team skull
+team star
+team yell
+ultra beasts
+unova
+zapdos
+zekrom

--- a/lists/fiction/transformers.yml
+++ b/lists/fiction/transformers.yml
@@ -1,0 +1,64 @@
+---
+title: Transformers names
+category: fiction
+description: "Places, factions, species, artifacts, and groups from Transformers"
+---
+aerialbots
+allspark
+alpha trion
+ark
+autobot matrix
+autobots
+beast machines
+beast wars
+bumblebee
+combaticons
+constructicons
+cybertron
+dark energon
+decepticons
+devastator
+dinobot
+dinobots
+elita one
+energon
+galvatron
+grimlock
+hot rod
+insecticons
+ironhide
+junkions
+matrix of leadership
+maximals
+megatron
+metrobase
+metroplex
+minicons
+nemesis
+omega lock
+optimus prime
+predacons
+primus
+protoform
+quintessons
+ratchet
+rodimus prime
+seeker
+sentinel prime
+shockwave
+skyfire
+soundwave
+spark
+starscream
+stasis pod
+stunticons
+teletraan i
+the allspark
+the covenant of primus
+the matrix
+the primes
+the wreckers
+triple changer
+unicron
+vector sigma
+wheeljack

--- a/lists/fiction/warcraft.yml
+++ b/lists/fiction/warcraft.yml
@@ -1,0 +1,96 @@
+---
+title: Warcraft names
+category: fiction
+description: "Places, peoples, factions, creatures, artifacts, and powers from the Warcraft universe"
+---
+a'dal
+ahn'qiraj
+alleria
+alterac
+argus
+arthas
+ashenvale
+azeroth
+azshara
+blackrock mountain
+burning blade
+burning legion
+cenarion circle
+dalaran
+dark portal
+darnassus
+deathwing
+draenei
+draenor
+druid of the claw
+dun morogh
+durotar
+earthen ring
+eastern kingdoms
+emerald dream
+exodar
+forsaken
+frostmourne
+gallywix
+gnomeregan
+grommash hold
+gul'dan
+hellfire citadel
+highmountain
+horde
+hyjal
+illidan
+ironforge
+kalimdor
+karazhan
+kel'thuzad
+kirin tor
+kul tiras
+lich king
+lightforged draenei
+lordaeron
+maelstrom
+malfurion
+malygos
+mogu
+molten core
+naga
+nazjatar
+neltharion
+nightborne
+northrend
+orgrimmar
+outland
+pandaria
+quel'thalas
+ragnaros
+scourge
+shadowlands
+shattrath
+silvermoon
+stormwind
+stranglethorn
+sylvanas
+tauren
+the alliance
+the barrens
+the bronze dragonflight
+the cenarion expedition
+the ebon blade
+the exodar
+the forsaken
+the horde
+the scarlet crusade
+the scourge
+thrall
+thunder bluff
+titan-forged
+troll
+uldaman
+ulduar
+undercity
+val'kyr
+warchief
+well of eternity
+wyrmrest accord
+zandalar

--- a/lists/fiction/witcher.yml
+++ b/lists/fiction/witcher.yml
@@ -1,0 +1,86 @@
+---
+title: Witcher names
+category: fiction
+description: "Places, kingdoms, schools, peoples, creatures, and objects from The Witcher"
+---
+aedirn
+alder folk
+alghoul
+angren
+aretuza
+avallac'h
+ban ard
+basilisk
+beauclair
+blue mountains
+botchling
+brokilon
+bruxa
+caed myrkvid
+caer a'muirehen
+caer morhen
+cidaris
+ciri
+cockatrice
+crinfrid reavers
+crones of crookback bog
+dijkstra
+djinn
+dol blathanna
+doppler
+drowner
+dryads
+dun banner
+ellige
+endrega
+everec estate
+feline school
+fiend
+flotsam
+foglet
+francesca findabair
+ghoul
+golden dragon
+gors velen
+griffin school
+hansa
+harpy
+kaedwen
+kikimore
+kovir
+leshen
+mahakam
+mantichore school
+nilfgaard
+novigrad
+ofieri
+oxenfurt
+redania
+renfri
+rivia
+scoia'tael
+skellige
+striga
+temeria
+thanedd
+the conjunction of the spheres
+the continent
+the lodge of sorceresses
+the unseen elder
+the wild hunt
+tor lara
+toruviel
+toussaint
+tretogor
+vattier de rideaux
+velen
+vengerberg
+verden
+vesemir
+viper school
+vizima
+vrans
+wolf school
+wraith
+wyvern
+yennefer

--- a/lists/fiction/zelda.yml
+++ b/lists/fiction/zelda.yml
@@ -1,0 +1,89 @@
+---
+title: Legend of Zelda names
+category: fiction
+description: "Places, peoples, creatures, artifacts, and powers from The Legend of Zelda"
+---
+akkala
+ancient arrow
+ancient furnace
+beedle
+blight ganon
+calamity ganon
+champions
+dark world
+death mountain
+death mountain crater
+deku scrub
+demise
+din
+divine beast vah medoh
+divine beast vah naboris
+divine beast vah rudania
+divine beast vah ruta
+dragon roost island
+epona
+fairy fountain
+farore
+fi
+ganondorf
+gerudo
+gerudo desert
+gerudo valley
+goddess harp
+goron
+great deku tree
+great fairy
+great plateau
+guardian stalker
+hateno village
+hylia
+hylian
+hylian shield
+hyrule
+hyrule castle
+hyrule field
+hyrule warriors
+kakariko village
+keese
+king dodongo
+kokiri
+korok
+korok forest
+lake hylia
+lanayru
+loftwing
+lon lon ranch
+lost woods
+majora's mask
+malice
+malon
+master sword
+midna
+minish
+minish cap
+moblin
+ocarina of time
+phantom ganon
+rito
+rito village
+royal guard
+saria
+sheikah
+sheikah slate
+silver arrow
+skull kid
+skyloft
+stalfos
+stamina vessel
+tears of the kingdom
+temple of time
+termina
+the four sword
+the golden goddesses
+the great sea
+the triforce
+tingle
+twili
+twilight realm
+zora
+zora's domain


### PR DESCRIPTION
Adds a second-pass set of 24 missing high-value fiction universe lists under `lists/fiction/`, one file per universe as requested.

New lists:
- alien-predator
- amber
- avatar
- barsoom
- bas-lag
- conan
- dark-tower
- dc
- dragon-ball
- dragonlance
- elder-scrolls
- expanse
- forgotten-realms
- halo
- harry-potter
- magic-multiverse
- marvel
- mass-effect
- one-piece
- pokemon
- transformers
- warcraft
- witcher
- zelda

Selection rationale: gap pass over current `lists/fiction/` against major SFF/game/comic/anime universes with distinctive places, peoples, factions, creatures, artifacts, ships, or powers useful in image/media prompts. Expanded after review so every new list has at least 51 entries.

Verification:
- `npm run sanitise`
- `npm run build`
- `npm test`
- custom mechanical check: category is `fiction`, entries sorted/deduped, each new list has at least 50 entries

Generated indexes were rebuilt for validation and reverted before commit per repo instructions.