### PR TITLE
Expand fiction prompt lists to be exhaustive (pokemon, lotr, culture, 40k, dune)

### DIFF
--- a/list-metadata.json
+++ b/list-metadata.json
@@ -2005,14 +2005,14 @@
     "title": "Discworld names",
     "category": "fiction",
     "description": "Places, peoples, creatures, and groups from Terry Pratchett's Discworld",
-    "total": 143,
+    "total": 193,
     "examples": [
-      "bes pelargic",
-      "chelys galactica",
-      "dimwell",
-      "sea troll",
-      "re-annual grape",
-      "sto kerrig"
+      "fools' guild",
+      "nac mac feegle",
+      "muntab",
+      "pseudopolis",
+      "the tump",
+      "sourcerer"
     ]
   },
   "fiction.dragonBall": {
@@ -2021,12 +2021,12 @@
     "description": "Places, species, transformations, artifacts, and powers from Dragon Ball",
     "total": 150,
     "examples": [
-      "mr. satan",
-      "namekians",
-      "launch",
-      "moro",
-      "red ribbon army",
-      "frieza force"
+      "spirit bomb",
+      "android 19",
+      "great saiyaman",
+      "android 18",
+      "android 20",
+      "super saiyan blue"
     ]
   },
   "fiction.dragonlance": {
@@ -2035,12 +2035,12 @@
     "description": "Places, peoples, factions, creatures, deities, and artifacts from Dragonlance",
     "total": 128,
     "examples": [
-      "gasshan",
+      "tarsis",
+      "aurak draconian",
       "mount nevermind",
-      "laurana kanan",
-      "gilthanas kanan",
-      "hylo",
-      "knights of neraka"
+      "pax tharkas",
+      "silvanesti",
+      "dark queen"
     ]
   },
   "fiction.dune": {
@@ -2049,12 +2049,12 @@
     "description": "Planets, cities, factions, houses, and political groups from Frank Herbert's Dune universe",
     "total": 157,
     "examples": [
-      "glosser rabban",
-      "sietch jacurutu",
-      "abomination",
-      "duncan idaho",
+      "stilltent",
+      "farad'n corrino",
+      "arrakis",
       "butlerian jihad",
-      "alia atreides"
+      "harvester",
+      "house fenring"
     ]
   },
   "fiction.elderScrolls": {
@@ -2064,11 +2064,11 @@
     "total": 98,
     "examples": [
       "anvil",
-      "namira",
-      "imperials",
-      "an-xileel",
-      "khajiit",
-      "boethiah"
+      "soul cairn",
+      "daedra",
+      "hircine",
+      "the tribunal",
+      "dremora"
     ]
   },
   "fiction.expanse": {
@@ -2077,12 +2077,12 @@
     "description": "Places, factions, ships, peoples, and technologies from The Expanse",
     "total": 126,
     "examples": [
-      "bullet",
-      "freehold",
+      "amos burton",
+      "united nations",
+      "mcrn donnager",
       "mei meng",
-      "naomi nagata",
-      "bull",
-      "clarissa mao"
+      "earth-mars coalition",
+      "free navy"
     ]
   },
   "fiction.forgottenRealms": {
@@ -2091,12 +2091,12 @@
     "description": "Places, peoples, factions, creatures, deities, and artifacts from the Forgotten Realms",
     "total": 85,
     "examples": [
-      "luskan hosts",
-      "abeir-toril",
-      "moonshae isles",
-      "tethyr",
-      "myrkul",
-      "zhentil keep"
+      "oakhaven",
+      "red wizards of thay",
+      "ankheg",
+      "tiamat",
+      "tempus",
+      "ymeen"
     ]
   },
   "fiction.foundation": {
@@ -2105,12 +2105,12 @@
     "description": "Places, planets, factions, and groups from Isaac Asimov's Foundation universe",
     "total": 92,
     "examples": [
-      "rhodia",
-      "association of independent trading worlds",
-      "aurora",
-      "ifni",
-      "first foundation",
-      "earth"
+      "solaria",
+      "mule",
+      "psychohistory",
+      "echegaray",
+      "61 cygni",
+      "r. daneel olivaw"
     ]
   },
   "fiction.gethen": {
@@ -2119,12 +2119,12 @@
     "description": "Planets, countries, towns, cultures, and organizations from Ursula K. Le Guin's Hainish Cycle and Earthsea",
     "total": 155,
     "examples": [
-      "awabath",
-      "athshea",
-      "olleroo",
-      "gethen",
-      "bedap",
-      "sabul"
+      "othokhad",
+      "iskel",
+      "fastness",
+      "ansible",
+      "ged",
+      "cetia"
     ]
   },
   "fiction.gormenghast": {
@@ -2133,12 +2133,12 @@
     "description": "Unique names from Gormenghast (Mervyn Peake) — places, peoples, creatures, factions, and ships combined.",
     "total": 237,
     "examples": [
-      "the schoolrooms",
-      "the death-owls",
-      "muzzlehatch's zoo",
-      "cheeta's pavilion",
-      "the courtyard",
-      "the bell-ringers"
+      "the masters of ritual",
+      "the chefs",
+      "fuchsia's attic",
+      "the dark precincts",
+      "the mutants",
+      "the rust room"
     ]
   },
   "fiction.halo": {
@@ -2147,26 +2147,26 @@
     "description": "Places, factions, species, artifacts, ships, and installations from Halo",
     "total": 143,
     "examples": [
-      "343 guilty spark",
-      "miranda keyes",
-      "jameson locke",
-      "glassing",
-      "gravity hammer",
-      "keyship"
+      "flood",
+      "escharum",
+      "geas",
+      "librarian",
+      "greater ark",
+      "installation 07"
     ]
   },
   "fiction.harryPotter": {
     "title": "Wizarding World names",
     "category": "fiction",
     "description": "Places, schools, houses, creatures, objects, and groups from the Harry Potter and Wizarding World fiction",
-    "total": 93,
+    "total": 304,
     "examples": [
-      "expecto patronum",
-      "demiguise",
-      "forbidden forest",
-      "death eaters",
-      "galleon",
-      "elder wand"
+      "stupefy",
+      "occlumency",
+      "occamy",
+      "riddikulus",
+      "order of merlin",
+      "reverse pass"
     ]
   },
   "fiction.hisDarkMaterials": {
@@ -2175,12 +2175,12 @@
     "description": "Places, peoples, creatures, and concepts from Philip Pullman's His Dark Materials",
     "total": 109,
     "examples": [
+      "hester",
+      "amber spyglass",
       "armored bears",
-      "the authority",
-      "cazimi",
-      "jerry",
-      "ma costa",
-      "cittagazze"
+      "sariel",
+      "oblation board",
+      "subtle knife"
     ]
   },
   "fiction.hitchhikers": {
@@ -2189,12 +2189,12 @@
     "description": "Places, species, spacecraft, and groups from The Hitchhiker's Guide to the Galaxy",
     "total": 257,
     "examples": [
-      "sector",
-      "smash",
-      "rob mckenna",
-      "life the universe and everything",
-      "savlas",
-      "questular"
+      "constant",
+      "hactar",
+      "han",
+      "jagger",
+      "bistromath",
+      "arcturan megadonkeys"
     ]
   },
   "fiction.hyperion": {
@@ -2203,12 +2203,12 @@
     "description": "Unique names from Hyperion Cantos — places, peoples, creatures, factions, and ships combined.",
     "total": 321,
     "examples": [
-      "cybrid-human hybrid",
-      "the home guard",
-      "pacem",
-      "prometheus bug",
-      "port romance",
-      "labyrinth builder"
+      "yggdrasill",
+      "the hs force stevens",
+      "the hs force arthur clarke",
+      "the far end",
+      "the house of windsor-in-exile",
+      "new vatican"
     ]
   },
   "fiction.lotr": {
@@ -2217,12 +2217,12 @@
     "description": "Places, races, creatures, and unique names from J.R.R. Tolkien's Middle-earth",
     "total": 464,
     "examples": [
-      "archet",
-      "fili",
-      "ethril",
-      "beleriand",
-      "half-orcs",
-      "frodo baggins"
+      "minas ithil",
+      "anfalas",
+      "nirnaeth arnoediad",
+      "landroval",
+      "imladris",
+      "marish"
     ]
   },
   "fiction.magicMultiverse": {
@@ -2231,40 +2231,40 @@
     "description": "Planes, peoples, factions, creatures, and artifacts from Magic: The Gathering fiction",
     "total": 136,
     "examples": [
-      "planeswalker",
-      "house dimir",
-      "azorius senate",
-      "ashiok",
-      "artificer",
-      "firja"
+      "eldrazi",
+      "dragonlord silumgar",
+      "angel",
+      "keld",
+      "garruk wildspeaker",
+      "ashiok"
     ]
   },
   "fiction.malazan": {
     "title": "Malazan names",
     "category": "fiction",
     "description": "Places, peoples, creatures, and groups from the Malazan Book of the Fallen",
-    "total": 98,
+    "total": 163,
     "examples": [
-      "shadowkeep",
-      "omtose phellack",
-      "shake",
-      "the first throne",
-      "stormriders",
-      "jacuruku"
+      "kurald emurlahn",
+      "the whirlwind",
+      "burn",
+      "anomander rake",
+      "crimson guard",
+      "capustan"
     ]
   },
   "fiction.marvel": {
     "title": "Marvel Universe names",
     "category": "fiction",
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction",
-    "total": 97,
+    "total": 200,
     "examples": [
-      "infinity gauntlet",
-      "fantastic four",
-      "the bifrost",
-      "new mutants",
-      "spider-man",
-      "the hand"
+      "hatut zeraze",
+      "brotherhood of mutants",
+      "cancerverse",
+      "champions",
+      "ego",
+      "all-black the necrosword"
     ]
   },
   "fiction.massEffect": {
@@ -2273,12 +2273,12 @@
     "description": "Places, species, factions, ships, artifacts, and powers from Mass Effect",
     "total": 201,
     "examples": [
-      "mass effect",
-      "jaal",
-      "collector base",
-      "crucible",
-      "blood pack",
-      "batarians"
+      "militia",
+      "aria",
+      "data",
+      "aria t'loak",
+      "donnel udina",
+      "council"
     ]
   },
   "fiction.narnia": {
@@ -2287,12 +2287,12 @@
     "description": "Places, peoples, creatures, and magical beings from C.S. Lewis's Chronicles of Narnia",
     "total": 160,
     "examples": [
-      "tisroc",
-      "mr tumnus",
-      "mrs beaver",
-      "king lune",
-      "shallow lands",
-      "pattertwig"
+      "cor",
+      "terebinthia",
+      "prince caspian",
+      "aslan",
+      "minotaurs",
+      "peepiceek"
     ]
   },
   "fiction.onePiece": {
@@ -2301,12 +2301,12 @@
     "description": "Places, factions, peoples, creatures, ships, powers, and treasures from One Piece",
     "total": 160,
     "examples": [
-      "sunny",
-      "enel",
-      "bonney",
-      "brook",
-      "cp9",
-      "impel down"
+      "drum island",
+      "zou",
+      "conquerors haki",
+      "the four emperors",
+      "gomu gomu no mi",
+      "charlotte linlin"
     ]
   },
   "fiction.pokemon": {
@@ -2315,12 +2315,12 @@
     "description": "Regions, species, legendary Pokemon, teams, and artifacts from Pokemon",
     "total": 1137,
     "examples": [
-      "cobalion",
-      "exploud",
-      "eelektrik",
-      "cosmoem",
-      "kilowattrel",
-      "bruxish"
+      "naclstack",
+      "kricketune",
+      "floette",
+      "feebas",
+      "finizen",
+      "hariyama"
     ]
   },
   "fiction.starTrek": {
@@ -2329,12 +2329,12 @@
     "description": "Unique names from Star Trek — places, peoples, creatures, factions, and ships combined.",
     "total": 721,
     "examples": [
-      "sikaris",
-      "azati prime",
-      "bolian",
-      "dakhur province",
-      "borg collective",
-      "capella iv"
+      "uss bozeman",
+      "q continuum",
+      "the gatherers",
+      "talaxian resistance",
+      "shatras",
+      "romulan star empire"
     ]
   },
   "fiction.starWars": {
@@ -2343,12 +2343,12 @@
     "description": "Unique names from Star Wars — places, peoples, creatures, factions, and ships combined.",
     "total": 784,
     "examples": [
-      "colicoid",
-      "coruscant",
-      "advozse",
-      "the coruscant underworld police",
-      "dewback",
-      "bith"
+      "the death troopers",
+      "ryloth",
+      "protector",
+      "thyferra",
+      "houk",
+      "mustafarian"
     ]
   },
   "fiction.transformers": {
@@ -2357,26 +2357,26 @@
     "description": "Places, factions, species, artifacts, and groups from Transformers",
     "total": 350,
     "examples": [
-      "great war",
-      "technobots",
-      "liokaiser",
-      "pitted",
-      "rewind",
-      "pious"
+      "ratchet",
+      "bitstream",
+      "die-cast",
+      "hardhead",
+      "fracture",
+      "barricade"
     ]
   },
   "fiction.warcraft": {
     "title": "Warcraft names",
     "category": "fiction",
     "description": "Places, peoples, factions, creatures, artifacts, and powers from the Warcraft universe",
-    "total": 91,
+    "total": 335,
     "examples": [
-      "orgrimmar",
-      "the horde",
-      "northrend",
-      "shadowlands",
-      "titan-forged",
-      "ironforge"
+      "tempest keep",
+      "mag'har orc",
+      "nazjatar",
+      "warchief",
+      "razorfen downs",
+      "naxxramas"
     ]
   },
   "fiction.warhammer40k": {
@@ -2385,26 +2385,26 @@
     "description": "Unique names from Warhammer 40,000 — places, peoples, creatures, factions, and ships combined.",
     "total": 653,
     "examples": [
-      "de profundis",
-      "spear of the emperor",
-      "simulacra",
       "slaanesh",
-      "tyranid warrior",
-      "vior'la sept"
+      "altansar",
+      "ambull",
+      "divine right",
+      "canoptek scarab",
+      "cthonia"
     ]
   },
   "fiction.wheelOfTime": {
     "title": "Wheel of Time names",
     "category": "fiction",
     "description": "Places, peoples, creatures, and groups from The Wheel of Time",
-    "total": 109,
+    "total": 282,
     "examples": [
-      "s'redit",
-      "aridhol",
-      "arafel",
-      "whitecliff",
-      "deven ride",
-      "illian"
+      "whitebridge",
+      "mazrim taim",
+      "nym",
+      "raken",
+      "saldaea",
+      "sammael"
     ]
   },
   "fiction.witcher": {
@@ -2413,12 +2413,12 @@
     "description": "Places, kingdoms, schools, peoples, creatures, and objects from The Witcher",
     "total": 161,
     "examples": [
-      "the continent",
-      "eithne",
-      "gors velen",
-      "harpy",
-      "dol blathanna",
-      "filippa"
+      "endrega",
+      "tretogor",
+      "mantichore school",
+      "redania",
+      "school of the cat",
+      "the unseen elder"
     ]
   },
   "fiction.zelda": {
@@ -2427,12 +2427,12 @@
     "description": "Places, peoples, creatures, artifacts, and powers from The Legend of Zelda",
     "total": 149,
     "examples": [
-      "hilda",
-      "goddess harp",
-      "lanayru",
-      "impa",
-      "beedle",
-      "hylian shield"
+      "fi",
+      "tulin",
+      "skull kid",
+      "stamina vessel",
+      "zora's domain",
+      "snowhead"
     ]
   },
   "food.bakery": {
@@ -2441,12 +2441,12 @@
     "description": "Assorted baked goods including cakes, pies, pastries, and sweet breads",
     "total": 176,
     "examples": [
-      "baci di dama (italian lady's kisses, traditional cookie)",
-      "baguette",
-      "wienerbrød (vienna bread)",
-      "tarte aux prunes",
-      "babka",
-      "fastelavnsbolle (shrove tuesday bun)"
+      "macarons",
+      "dolmades (stuffed grape leaves)",
+      "macaron",
+      "sfogliatelle (shell-shaped pastry)",
+      "fruit sorbet",
+      "ciabatta"
     ]
   },
   "food.bbq": {
@@ -2455,12 +2455,12 @@
     "description": "Grilled meats, seafood, vegetables, and fruits typical of barbecue cooking",
     "total": 41,
     "examples": [
-      "chicken wings",
-      "grilled peaches",
-      "grilled romaine",
-      "beer can chicken",
-      "hot dogs",
-      "burgers"
+      "grilled oysters",
+      "burnt ends",
+      "burgers",
+      "veggie kebab",
+      "ribs",
+      "chicken kebab"
     ]
   },
   "food.beverage": {
@@ -2469,12 +2469,12 @@
     "description": "Various alcoholic and non-alcoholic drinks including cocktails, coffees, and teas",
     "total": 224,
     "examples": [
-      "pina colada",
-      "shandy",
-      "grape juice",
-      "club soda",
-      "green tea",
-      "london fog"
+      "vermouth",
+      "ouzo",
+      "whiskey sour",
+      "wine",
+      "pomegranate juice",
+      "pisco sour"
     ]
   },
   "food.bread": {
@@ -2483,12 +2483,12 @@
     "description": "A diverse global selection of traditional breads, biscuits, and baked rolls",
     "total": 269,
     "examples": [
-      "pane ticinese",
-      "pan de deificación",
-      "panettone",
-      "roti gambang",
-      "msemmen",
-      "mollete"
+      "tin loaf",
+      "agege bread",
+      "kulich",
+      "drop biscuit",
+      "kaiser roll",
+      "griddle scone"
     ]
   },
   "food.breakfast": {
@@ -2497,12 +2497,12 @@
     "description": "Sweet and savory breakfast dishes including eggs, waffles, and avocado toast",
     "total": 86,
     "examples": [
-      "muesli",
-      "omelette",
-      "huevos benedictos",
-      "greek yogurt with berries and honey",
-      "chia seed pudding",
-      "crab royale"
+      "pop-tarts",
+      "monte cristo sandwich",
+      "huevos rancheros",
+      "oatmeal with toppings",
+      "portobello florentine",
+      "crab benedict"
     ]
   },
   "food.cheese": {
@@ -2511,12 +2511,12 @@
     "description": "A wide variety of international cheeses from different regions and styles",
     "total": 515,
     "examples": [
-      "radamer",
-      "mish",
-      "pecorino crotonese",
-      "pepper jack",
-      "muenster",
-      "pozzetto"
+      "orval",
+      "castigliano",
+      "idiazabal",
+      "kaşar",
+      "esrom",
+      "cooleeney"
     ]
   },
   "food.cocktail": {
@@ -2525,12 +2525,12 @@
     "description": "Classic and modern mixed alcoholic drinks and cocktails",
     "total": 153,
     "examples": [
-      "casino",
-      "fitzgerald",
-      "lemon drop",
-      "white lady",
-      "negroni sbagliato",
-      "kir"
+      "pink lady",
+      "dark and stormy",
+      "brandy crusta",
+      "jack rose",
+      "hot toddy",
+      "bloody mary"
     ]
   },
   "food.cookingMethod": {
@@ -2539,12 +2539,12 @@
     "description": "Culinary techniques for preparing food, ranging from baking to dry aging",
     "total": 97,
     "examples": [
-      "browning",
-      "broiling",
-      "pit roasting",
-      "coddling",
-      "freeze-drying",
-      "confit"
+      "barbecuing",
+      "oil roasting",
+      "roasting",
+      "oil poaching",
+      "pan broiling",
+      "spit roasting"
     ]
   },
   "food.cuisine": {
@@ -2553,12 +2553,12 @@
     "description": "Specific regional and national culinary traditions from around the world",
     "total": 340,
     "examples": [
-      "goan cuisine",
-      "eritrean cuisine",
-      "cajun cuisine",
-      "andalusian cuisine",
-      "bengali cuisine",
-      "acehnese cuisine"
+      "paraguayan cuisine",
+      "ligurian cuisine",
+      "abruzzese cuisine",
+      "bhutanese cuisine",
+      "acehnese cuisine",
+      "chilean cuisine"
     ]
   },
   "food.dessert": {
@@ -2567,12 +2567,12 @@
     "description": "Global sweet treats including cakes, puddings, pastries, and confections",
     "total": 174,
     "examples": [
-      "qatayef",
-      "alfajores",
-      "chocolate fondant",
-      "coconut macaroon",
-      "butter tart",
-      "baked alaska"
+      "shortbread",
+      "rum cake",
+      "anmitsu",
+      "pineapple upside-down cake",
+      "beignet",
+      "turrón"
     ]
   },
   "food.drink": {
@@ -2581,12 +2581,12 @@
     "description": "Assorted beverages including sodas, juices, teas, milks, and alcoholic drinks",
     "total": 289,
     "examples": [
-      "margarita",
-      "assam tea",
+      "distilled spirits",
+      "spirits",
+      "buttermilk",
+      "calvados",
       "absinthe",
-      "americano",
-      "cafecito",
-      "brandy"
+      "clamato juice"
     ]
   },
   "food.fast": {
@@ -2595,12 +2595,12 @@
     "description": "Global fast food and street food items including burgers, fries, and rolls",
     "total": 164,
     "examples": [
-      "caramel milkshake",
-      "egg rolls",
-      "sweet potato fries",
-      "pho",
-      "yakitori",
-      "goi cuon (summer rolls)"
+      "bun bo hue",
+      "cookies and cream milkshake",
+      "com tam (broken rice)",
+      "double cheeseburger",
+      "garlic fries",
+      "bun cha"
     ]
   },
   "food.fruit": {
@@ -2609,12 +2609,12 @@
     "description": "Common and exotic fruits, berries, and melons from around the world",
     "total": 142,
     "examples": [
-      "damson",
-      "loquat",
-      "rowanberry",
-      "lychee",
-      "grapes",
-      "miracle fruit"
+      "canistel",
+      "mango",
+      "apple",
+      "blood orange",
+      "boysenberry",
+      "apricot"
     ]
   },
   "food.herbSpice": {
@@ -2623,12 +2623,12 @@
     "description": "Various culinary herbs, spices, and seeds used for flavoring food",
     "total": 50,
     "examples": [
-      "basil",
-      "mint",
-      "rosemary",
-      "anise",
-      "chives",
-      "fennel seed"
+      "cumin",
+      "mustard seed",
+      "bay leaf",
+      "fenugreek",
+      "white pepper",
+      "caraway"
     ]
   },
   "food.pastaShape": {
@@ -2637,12 +2637,12 @@
     "description": "Various types of traditional and novelty pasta shapes",
     "total": 145,
     "examples": [
-      "fusilli avellinesi",
-      "rotini",
-      "sfoglini",
-      "rigatoncini",
-      "sedani",
-      "tripoline"
+      "rotelle",
+      "cannelloni",
+      "maccheroni",
+      "acini di pepe",
+      "astri",
+      "lasagnette"
     ]
   },
   "food.platingStyle": {
@@ -2651,12 +2651,12 @@
     "description": "Artistic and structural techniques for arranging and presenting food on a plate",
     "total": 104,
     "examples": [
-      "bento box",
-      "architectural",
-      "mosaic style",
-      "smorgasbord",
-      "tasting menu style",
-      "sculptural"
+      "afternoon tea style",
+      "vertical",
+      "traditional",
+      "casual",
+      "tower style",
+      "landscape"
     ]
   },
   "food.tea": {
@@ -2665,12 +2665,12 @@
     "description": "Specific varieties of traditional, herbal, and regional teas",
     "total": 193,
     "examples": [
-      "kombucha",
-      "boldo tea",
-      "chrysanthemum tea",
-      "dandelion tea",
-      "awabancha",
-      "dandelion root tea"
+      "thai tea",
+      "liubao tea",
+      "licorice root tea",
+      "jasmine green tea",
+      "assam",
+      "neem tea"
     ]
   },
   "food.vegetable": {
@@ -2679,12 +2679,12 @@
     "description": "Various vegetables, legumes, squashes, and edible plant sprouts",
     "total": 266,
     "examples": [
-      "squash blossoms",
-      "acorn squash",
-      "fushimi pepper",
-      "gai lan",
-      "bottle gourd",
-      "cipollini onion"
+      "bobby beans",
+      "spaghetti squash",
+      "sorrel",
+      "squash (vegetable)",
+      "serrano pepper",
+      "squash blossoms"
     ]
   },
   "geography.city": {
@@ -2693,12 +2693,12 @@
     "description": "Specific global cities listed with their respective regions and countries",
     "total": 22953,
     "examples": [
-      "Petrogradka, St.-Petersburg, Russia",
-      "Conversano, Apulia, Italy",
-      "Loralai, Balochistān, Pakistan",
-      "Autlán de Navarro, Jalisco, Mexico",
-      "Forlì, Emilia-Romagna, Italy",
-      "Itō, Shizuoka, Japan"
+      "Abeokuta, Ogun, Nigeria",
+      "Nicholasville, Kentucky, United States",
+      "Panauti̇̄, Central Region, Nepal",
+      "Masterton, Wellington, New Zealand",
+      "Deogarh, Odisha, India",
+      "Mexicali, Baja California, Mexico"
     ]
   },
   "geography.country": {
@@ -2707,12 +2707,12 @@
     "description": "A diverse list of sovereign nations and countries around the world",
     "total": 199,
     "examples": [
-      "Brunei",
-      "Congo (Democratic Republic)",
-      "Botswana",
-      "Cyprus",
-      "Dominican Republic",
-      "Comoros"
+      "Sierra Leone",
+      "East Germany",
+      "Bhutan",
+      "Benin",
+      "Belgium",
+      "Bulgaria"
     ]
   },
   "geography.ethnicGroup": {
@@ -2721,12 +2721,12 @@
     "description": "The following groups are commonly identified as \"ethnic groups\", as opposed to ethno-linguistic phyla, national groups, racial groups or similar.\n",
     "total": 1055,
     "examples": [
-      "silesians",
-      "kashubians",
-      "bororo",
-      "dhimal",
-      "cahuilla",
-      "kalinago"
+      "mormon",
+      "albanians",
+      "hadiya",
+      "dyula",
+      "kalinago",
+      "gujarati"
     ]
   },
   "geography.language": {
@@ -2735,12 +2735,12 @@
     "description": "A list of language names (glossonyms)",
     "total": 609,
     "examples": [
-      "tübatulabal",
-      "hazāragī",
-      "herero",
-      "karenni",
-      "ik",
-      "hindko"
+      "domari",
+      "thai",
+      "indonesian",
+      "cook islands māori",
+      "eyak",
+      "ge'ez"
     ]
   },
   "geography.nationality": {
@@ -2749,12 +2749,12 @@
     "description": "Adjectives describing nationalities and citizenships from various countries",
     "total": 206,
     "examples": [
-      "malawian",
-      "irish",
-      "croatian",
-      "cuban",
-      "cambodian",
-      "canadian"
+      "liechtensteiner",
+      "vietnamese",
+      "swedish",
+      "senegalese",
+      "luxembourger",
+      "soviet"
     ]
   },
   "geography.territory": {
@@ -2763,12 +2763,12 @@
     "description": "Global territories, dependencies, emirates, and non-sovereign geographic regions",
     "total": 79,
     "examples": [
-      "Guadeloupe",
-      "American Samoa",
-      "Howland Island",
-      "Faroe Islands",
-      "Åland Islands",
-      "Guam"
+      "Gibraltar",
+      "Greenland",
+      "Bonaire",
+      "Falkland Islands",
+      "French Polynesia",
+      "Ceuta"
     ]
   },
   "interaction.coupleNegative": {
@@ -2777,12 +2777,12 @@
     "description": "Toxic, emotional, and negative behavioral interactions between romantic partners",
     "total": 70,
     "examples": [
-      "feeling sad with each other",
-      "giving a cold stare",
-      "checking phone while being spoken to",
-      "having an argument",
+      "feeling isolated from each other",
       "accusing each other",
-      "feeling guilty with each other"
+      "bickering with each other",
+      "walking away mid-argument",
+      "harboring unspoken resentment",
+      "feeling helpless with each other"
     ]
   },
   "interaction.couple": {
@@ -2791,12 +2791,12 @@
     "description": "Positive and negative relational dynamics and activities between couples",
     "total": 69,
     "examples": [
-      "holding a grudge",
-      "having a bonding experience",
-      "support",
+      "collaboration",
       "mentoring a protégé",
-      "holding hands across a table",
-      "slow dancing"
+      "reconciliation",
+      "sharing wisdom",
+      "making a confession",
+      "giving a warm hug"
     ]
   },
   "interaction.crowd": {
@@ -2805,12 +2805,12 @@
     "description": "Collective actions, events, and emotional responses experienced by large crowds",
     "total": 64,
     "examples": [
-      "holding a peaceful protest",
-      "dancing in a mosh pit",
-      "participating in a parade",
-      "participating in a tradition",
-      "celebrating a victory",
-      "holding a protest"
+      "joining a flash mob",
+      "participating in a demonstration",
+      "participating in a march",
+      "raising fists in solidarity",
+      "celebrating a cultural tradition",
+      "attending a parade"
     ]
   },
   "interaction.danceStyle": {
@@ -2819,12 +2819,12 @@
     "description": "Diverse global dance genres, traditional styles, and modern rhythmic movements",
     "total": 266,
     "examples": [
-      "chicken dance",
-      "vals",
-      "modern dance",
-      "lezginka",
-      "kuchipudi",
-      "kompa"
+      "semba",
+      "ribbon dance",
+      "polka",
+      "quickstep",
+      "odissi",
+      "salpuri"
     ]
   },
   "interaction.group": {
@@ -2833,12 +2833,12 @@
     "description": "Collaborative group activities ranging from mundane events to dramatic fictional scenarios",
     "total": 70,
     "examples": [
-      "conducting a science experiment",
-      "throwing a big party",
-      "investigating a conspiracy",
-      "pursuing a dream",
-      "planning a wedding",
-      "performing a musical"
+      "becoming a superhero",
+      "playing a tabletop board game",
+      "participating in a protest",
+      "escaping a cult",
+      "building a campfire",
+      "dealing with a life-threatening illness"
     ]
   },
   "interaction.individualDetailed": {
@@ -2847,12 +2847,12 @@
     "description": "Highly specific, multi-step physical actions and behavioral sequences performed by individuals",
     "total": 214,
     "examples": [
-      "taps a spoon on the edge of a bowl, sets the spoon down, and then picks up the bowl to eat",
-      "points at something, gestures animatedly, and then laughs",
-      "kicks off shoes, wiggles toes, and then curls up on the couch",
-      "hiccups unexpectedly, covers mouth, and then laughs embarrassedly",
-      "cracks an egg into a bowl, tosses the shell in the trash, and then reaches for another egg",
-      "clicks a pen repeatedly, stops, and then begins to write"
+      "clears throat, takes a sip of water, and begins to speak",
+      "adjusts rearview mirror, checks blind spot, and then changes lanes",
+      "blows out a candle, watches the smoke curl up, and then waves a hand to clear the air",
+      "drums fingers on the table, looks up at the clock, and sighs impatiently",
+      "adjusts the volume on headphones, nods head to the beat, and then closes eyes to focus on the music",
+      "adjusts glasses, squints at something in the distance, then nods in understanding"
     ]
   },
   "interaction.individual": {
@@ -2861,12 +2861,12 @@
     "description": "Simple, everyday physical gestures, adjustments, and actions performed by a single person",
     "total": 424,
     "examples": [
-      "raises eyebrows",
-      "rocks back and forth on heels",
-      "peeks around a corner",
-      "rolls over onto back",
-      "rubs back of neck",
-      "squishes play dough"
+      "kisses fingertips and blows it like a chef",
+      "nods head in agreement",
+      "draws circles on a steamy window",
+      "flicks a bug off arm",
+      "arches an eyebrow",
+      "nods in agreement"
     ]
   },
   "interaction.martialArt": {
@@ -2875,12 +2875,12 @@
     "description": "Traditional and modern martial arts and combat systems from around the world",
     "total": 110,
     "examples": [
-      "khuresh",
-      "mcmap",
-      "catch wrestling",
-      "bajutsu",
-      "daito-ryu aiki-jujutsu",
-      "jodo"
+      "aikido",
+      "kendo",
+      "wing chun",
+      "silambam",
+      "laamb",
+      "tahtib"
     ]
   },
   "keyword.detailed": {
@@ -2889,12 +2889,12 @@
     "description": "Descriptive adjectives used to prompt high-resolution, intricate, and textured artwork",
     "total": 58,
     "examples": [
-      "exquisitely-detailed",
-      "lifelike",
-      "stunningly-detailed",
-      "detailed",
-      "hyper-realistic",
-      "detailed picture"
+      "ultra-high-definition",
+      "clear",
+      "artistically-detailed",
+      "detailed picture",
+      "immaculately-detailed",
+      "elaborate"
     ]
   },
   "keyword.epic": {
@@ -2903,12 +2903,12 @@
     "description": "Evocative adjectives for generating dramatic, majestic, and awe-inspiring visual atmospheres",
     "total": 129,
     "examples": [
-      "atmospheric",
-      "masterful",
-      "lifelike",
-      "empyrean",
-      "bombastic",
-      "illustrious"
+      "meticulous",
+      "delightful",
+      "venerable",
+      "dynamic",
+      "wonderful",
+      "stunning"
     ]
   },
   "keyword.genre": {
@@ -2917,12 +2917,12 @@
     "description": "Sci-fi, historical, and punk-themed aesthetic art genres and styles",
     "total": 65,
     "examples": [
-      "gothic",
-      "solarpunk",
-      "victorian",
-      "weird west",
-      "renaissance",
-      "post-apocalyptic"
+      "silkpunk",
+      "post-apocalyptic",
+      "post-cyberpunk",
+      "sword and sorcery",
+      "medieval",
+      "gothic romance"
     ]
   },
   "keyword.glitch": {
@@ -2931,12 +2931,12 @@
     "description": "Digital and analog visual artifacts, distortions, and glitch effects",
     "total": 56,
     "examples": [
-      "image corruption",
-      "burn-in",
-      "screen tear",
+      "rolling shutter effect",
       "scrambled signal",
-      "rgb split",
-      "static noise"
+      "screen tear",
+      "burn-in",
+      "bit-crushed",
+      "datamosh"
     ]
   },
   "keyword.modifier": {
@@ -2945,12 +2945,12 @@
     "description": "Keywords that modify the style of an image (Noodle Soup prompts)",
     "total": 88,
     "examples": [
-      "doge",
-      "realism",
-      "isometric projection",
-      "symbolism",
-      "synthwave",
-      "cottagecore"
+      "anaglyph filter",
+      "ambrotype",
+      "dutch golden age",
+      "bioluminescent glow",
+      "cottagecore",
+      "afrofuturism"
     ]
   },
   "keyword.negative": {
@@ -2959,12 +2959,12 @@
     "description": "Negative prompt keywords for avoiding bad anatomy, artifacts, and low quality",
     "total": 90,
     "examples": [
-      "bad proportions",
-      "asymmetry",
+      "floating limbs",
+      "extra fingers",
+      "jumbled",
+      "malformed limbs",
       "blur",
-      "long neck",
-      "tacky",
-      "disconnected limbs"
+      "poorly drawn"
     ]
   },
   "keyword.prayer": {
@@ -2973,12 +2973,12 @@
     "description": "Quality-enhancing prompt modifiers for high resolution and masterpiece renders",
     "total": 67,
     "examples": [
-      "high-end",
-      "top-notch",
-      "octane render",
-      "ultra-high definition",
-      "4k",
-      "stellar quality"
+      "award winning",
+      "16k resolution",
+      "intricate",
+      "lifelike",
+      "hdr",
+      "magnum opus"
     ]
   },
   "keyword.trending": {
@@ -2987,12 +2987,12 @@
     "description": "Keywords referencing trending or featured artwork on popular portfolio websites",
     "total": 35,
     "examples": [
+      "featured on artstation",
+      "trending on pixiv",
       "trending on unsplash",
-      "trending on deviantart",
-      "trending on conceptartworld",
-      "featured on flickr",
-      "contest winner on artstation",
-      "featured on midjourney"
+      "trending on midjourney",
+      "featured on getty images",
+      "trending on behance"
     ]
   },
   "keyword.unusual": {
@@ -3001,12 +3001,12 @@
     "description": "Adjectives describing weird, unique, unusual, or abnormal subjects",
     "total": 62,
     "examples": [
+      "eccentric",
       "unique",
-      "crazy",
-      "weird",
-      "nutty",
-      "puzzling",
-      "extra-terrestrial"
+      "out-there",
+      "curiosity-inducing",
+      "unusual",
+      "curiouser-and-curiouser"
     ]
   },
   "music.artist": {
@@ -3015,12 +3015,12 @@
     "description": "Diverse musical artists and bands with distinct musical styles",
     "total": 114,
     "examples": [
-      "massive attack",
-      "captain beefheart",
-      "laurie anderson",
-      "burial",
-      "portishead",
-      "the doors"
+      "erykah badu",
+      "astrud gilberto",
+      "enya",
+      "billie holiday",
+      "chuck berry",
+      "gogol bordello"
     ]
   },
   "music.bpm": {
@@ -3029,12 +3029,12 @@
     "description": "Various musical tempos measured in beats per minute",
     "total": 42,
     "examples": [
-      "105 bpm",
-      "170 bpm",
-      "140 bpm",
-      "260 bpm",
-      "145 bpm",
-      "190 bpm"
+      "190 bpm",
+      "150 bpm",
+      "115 bpm",
+      "160 bpm",
+      "165 bpm",
+      "170 bpm"
     ]
   },
   "music.composer": {
@@ -3043,12 +3043,12 @@
     "description": "Famous classical and contemporary music composers",
     "total": 190,
     "examples": [
-      "wojciech kilar",
-      "jan ladislav dussek",
-      "jean sibelius",
-      "mario davidovsky",
-      "louis andriessen",
-      "leoš janáček"
+      "franz xaver süssmayr",
+      "alan hovhaness",
+      "ignaz pleyel",
+      "benjamin britten",
+      "dmitri shostakovich",
+      "antonio vivaldi"
     ]
   },
   "music.drop": {
@@ -3057,12 +3057,12 @@
     "description": "Specific electronic dance music subgenre drops and rhythmic transitions",
     "total": 39,
     "examples": [
-      "acid techno 303 squelch drop",
-      "glitch hop synth drop",
-      "progressive house melodic drop",
-      "techno minimal drop",
+      "gabber distorted kick drop",
+      "psytrance triplets drop",
+      "uk garage speed garage bassline drop",
       "minimal techno sub-bass rumble drop",
-      "synthwave retro gated snare drop"
+      "big room drop",
+      "hardstyle reverse bass drop"
     ]
   },
   "music.dynamic": {
@@ -3071,12 +3071,12 @@
     "description": "Musical tempo, dynamic, and articulation terms with their definitions",
     "total": 89,
     "examples": [
-      "col legno (using the wood of the bow to strike the strings)",
-      "ritenuto (immediately slower tempo)",
-      "senza sordino (without mute)",
-      "grave (slow, solemn and serious)",
-      "animato (animated, lively and spirited)",
-      "con moto (with motion, a moderate and flowing tempo)"
+      "dolce (sweetly, with a gentle and tender expression)",
+      "con fuoco (with fire, with great passion and energy)",
+      "morendo (dying away, gradually softer and slower)",
+      "decrescendo poco a poco (gradually getting softer little by little)",
+      "scherzando (playfully, jokingly and lightheartedly)",
+      "sforzando forte (sudden emphasis followed by loud)"
     ]
   },
   "music.feature": {
@@ -3085,12 +3085,12 @@
     "description": "Specific instrumental, vocal, and atmospheric musical elements and techniques",
     "total": 206,
     "examples": [
-      "searing guitar leads",
-      "ornate piano melodies",
-      "lively accordion riffs",
-      "jazzy chord progressions",
-      "ornamental guitar solos",
-      "polyrhythms"
+      "booming 808 sub-bass kicks",
+      "airy flute melodies",
+      "breakdown sections",
+      "counterpoint melodies",
+      "acoustic guitars",
+      "driving country fiddle solos"
     ]
   },
   "music.genre": {
@@ -3099,12 +3099,12 @@
     "description": "Diverse music genres ranging from electronic and rock to folk",
     "total": 305,
     "examples": [
-      "french house",
-      "chiptune",
-      "soca",
-      "boogie-woogie",
-      "boogie",
-      "christian hip-hop"
+      "breakbeat",
+      "zydeco punk",
+      "death-doom metal",
+      "deathcore",
+      "ambient dub",
+      "mathcore"
     ]
   },
   "music.harmony": {
@@ -3113,12 +3113,12 @@
     "description": "Various types of musical harmonies and chordal structures",
     "total": 38,
     "examples": [
-      "gospel harmony",
-      "dominant harmony",
-      "contrapuntal harmony",
-      "diminished harmony",
-      "diatonic harmony",
-      "extended harmony"
+      "spectral harmony",
+      "chromatic harmony",
+      "polyphonic harmony",
+      "vocal harmony",
+      "consonant harmony",
+      "triadic harmony"
     ]
   },
   "music.instrument": {
@@ -3127,12 +3127,12 @@
     "description": "Traditional, classical, and world music instruments",
     "total": 216,
     "examples": [
-      "cajón",
-      "kanun",
-      "balafon",
-      "mridangam",
-      "gamelan",
-      "fortepiano"
+      "kalimba thumb piano",
+      "dulcimer",
+      "trumpet",
+      "guitar",
+      "requinto",
+      "mellophone"
     ]
   },
   "music.key": {
@@ -3141,12 +3141,12 @@
     "description": "Major and minor musical keys",
     "total": 35,
     "examples": [
-      "gb major",
-      "e minor",
-      "a minor",
-      "c minor",
-      "d major",
-      "d minor"
+      "a major",
+      "b minor",
+      "g# major",
+      "db minor",
+      "ab major",
+      "gb major"
     ]
   },
   "music.melody": {
@@ -3155,12 +3155,12 @@
     "description": "Descriptive types of musical melodies with their definitions",
     "total": 94,
     "examples": [
-      "jazzy melody (incorporating jazz-style elements)",
-      "bouncy melody (lively, upbeat, and rhythmically syncopated)",
+      "antiphonal melody (alternating phrases between different groups)",
       "cannon melody (melodic imitation at different times)",
-      "conjunct melody (stepwise motion)",
-      "flutter-tonguing melody (rapid fluttering articulation)",
-      "dreamy melody (ethereal, nostalgic, and gently drifting)"
+      "delicate melody (gentle and fragile)",
+      "falling melody (descending motion with gradual decrease in pitch)",
+      "legato melody (smooth and connected)",
+      "jazzy melody (incorporating jazz-style elements)"
     ]
   },
   "music.mode": {
@@ -3170,11 +3170,11 @@
     "total": 55,
     "examples": [
       "acoustic scale mode",
-      "lydian dominant mode",
-      "ionian mode (major)",
-      "neapolitan minor mode",
-      "hungarian minor mode",
-      "persian scale mode"
+      "double harmonic scale mode",
+      "japanese scale mode",
+      "half-whole diminished mode",
+      "pentatonic minor mode",
+      "maqam saba mode"
     ]
   },
   "music.mood": {
@@ -3183,12 +3183,12 @@
     "description": "Emotional and atmospheric musical moods or vibes",
     "total": 117,
     "examples": [
-      "evocative",
-      "gentle",
-      "delicate",
-      "atmospheric",
-      "introspective",
-      "thrilling"
+      "ecstatic",
+      "enigmatic",
+      "abrasive",
+      "comforting",
+      "energetic",
+      "bouncy"
     ]
   },
   "music.musicGenre": {
@@ -3197,12 +3197,12 @@
     "description": "Diverse global music genres and subgenres",
     "total": 63,
     "examples": [
+      "baroque pop",
+      "krautrock",
+      "psychobilly",
+      "flamenco",
       "amapiano",
-      "synthpop",
-      "bluegrass",
-      "trance",
-      "trip hop",
-      "doom metal"
+      "vaporwave"
     ]
   },
   "music.percussive": {
@@ -3211,12 +3211,12 @@
     "description": "Specific percussion instruments and percussive sound makers",
     "total": 145,
     "examples": [
-      "bamboo wind chimes",
-      "ratchet",
-      "drumstick",
-      "djembe slap",
-      "gong",
-      "frame drum"
+      "agogo bells",
+      "bamboo tube",
+      "flexatone",
+      "bass drum",
+      "caxixi",
+      "boomwhackers"
     ]
   },
   "music.recording": {
@@ -3225,12 +3225,12 @@
     "description": "Various formats and styles of audio recordings",
     "total": 72,
     "examples": [
-      "mashup recording",
-      "broadcast recording",
-      "demo reel recording",
-      "experimental recording",
-      "battle rap recording",
-      "cassette recording"
+      "acapella recording",
+      "digital recording",
+      "high-fidelity recording",
+      "analog recording",
+      "live recording",
+      "bootleg recording"
     ]
   },
   "music.rhythm": {
@@ -3239,12 +3239,12 @@
     "description": "Specific rhythmic patterns and timing structures in music",
     "total": 27,
     "examples": [
-      "cross rhythm",
-      "driving rhythm",
-      "tresillo rhythm",
-      "offbeat rhythm",
-      "free rhythm",
-      "backbeat rhythm"
+      "broken rhythm",
+      "additive rhythm",
+      "dotted rhythm",
+      "stutter rhythm",
+      "compound rhythm",
+      "shuffle rhythm"
     ]
   },
   "music.songSection": {
@@ -3253,12 +3253,12 @@
     "description": "Structural components and sections of a musical composition",
     "total": 37,
     "examples": [
-      "call and response",
-      "drop",
-      "chorus",
+      "middle eight",
+      "solo",
+      "breakdown",
       "pre-chorus",
-      "fade-out",
-      "variation"
+      "variation",
+      "pre-verse"
     ]
   },
   "music.vocalStyle": {
@@ -3267,12 +3267,12 @@
     "description": "Specific vocal techniques, styles, and singing methods",
     "total": 187,
     "examples": [
-      "egressive singing",
-      "overtone singing",
-      "a cappella",
-      "choral singing",
-      "grunt",
-      "guttural"
+      "tenuto",
+      "field holler",
+      "diphonic singing",
+      "fall",
+      "enka",
+      "cante alentejano"
     ]
   },
   "music.vocal": {
@@ -3281,12 +3281,12 @@
     "description": "Descriptive styles and textures of vocal performances",
     "total": 119,
     "examples": [
-      "belting vocals",
-      "screamed vocals",
-      "a cappella vocals",
-      "call-and-response vocals",
-      "distorted shouts",
-      "husky vocals"
+      "breathy vocals",
+      "vibrant falsetto",
+      "vocal harmonies",
+      "theatrical vocals",
+      "shimmering vocal layers",
+      "hushed ethereal vocals"
     ]
   },
   "mythical.artifact": {
@@ -3295,12 +3295,12 @@
     "description": "Mythological, religious, and fictional magical items and artifacts",
     "total": 215,
     "examples": [
-      "seven-league boots",
-      "staff of hermes",
-      "sword of damocles",
-      "tyrfing",
-      "shears of atropos",
-      "shield of achilles"
+      "arkenstone",
+      "mirror of opposition",
+      "ameno-nuhoko",
+      "aladdin's lamp",
+      "kantele of väinämöinen",
+      "crystal orb"
     ]
   },
   "mythical.chinese": {
@@ -3309,12 +3309,12 @@
     "description": "Deities, creatures, and figures from Chinese mythology",
     "total": 83,
     "examples": [
-      "chang'e (嫦娥)",
-      "yinglong (應龍)",
-      "sun wukong (孫悟空)",
-      "chiyou's brothers (蚩尤兄弟)",
-      "taotie (饕餮)",
-      "kui xing (魁星)"
+      "qilin (麒麟)",
+      "di jun (帝俊)",
+      "ba she (巴蛇)",
+      "lei gong (雷公)",
+      "nine sons of the dragon (龍生九子)",
+      "kui (夔)"
     ]
   },
   "mythical.dndRace": {
@@ -3323,12 +3323,12 @@
     "description": "Playable character races from Dungeons and Dragons",
     "total": 66,
     "examples": [
-      "half-elf",
-      "aarakocra",
-      "bariaur",
-      "duergar",
-      "kobold",
-      "reborn"
+      "orc",
+      "loxodon",
+      "plasmoid",
+      "astral elf",
+      "bugbear",
+      "tortle"
     ]
   },
   "mythical.dragon": {
@@ -3337,12 +3337,12 @@
     "description": "Specific named dragons and dragon types from global mythologies",
     "total": 86,
     "examples": [
-      "chinese long dragon",
-      "russian zmei gorynych dragon",
-      "hungarian sárkány dragon",
-      "hebrew leviathan dragon",
-      "french gargouille dragon",
-      "french peluda dragon"
+      "cherokee uktena dragon",
+      "babylonian tiamat dragon",
+      "greek ismenian dragon",
+      "chinese zhulong dragon",
+      "egyptian apep dragon",
+      "hittite illuyanka dragon"
     ]
   },
   "mythical.magicTheGathering": {
@@ -3351,12 +3351,12 @@
     "description": "Specific card names from the game Magic: The Gathering",
     "total": 32340,
     "examples": [
-      "diregraf escort",
-      "katilda and lier",
-      "mind unbound",
-      "do or die",
-      "death-rattle oni",
-      "davvol's birthdaymobile"
+      "auger spree",
+      "rift sower",
+      "gale force",
+      "clawing torment",
+      "dune drifter",
+      "aether revolt"
     ]
   },
   "mythical.magicType": {
@@ -3365,12 +3365,12 @@
     "description": "Various schools, disciplines, and types of magical arts",
     "total": 53,
     "examples": [
-      "light magic",
-      "geomancy",
-      "sorcery",
+      "hydromancy",
+      "nature magic",
+      "banishment",
+      "soul magic",
       "angelology",
-      "biomancy",
-      "cosmic magic"
+      "pyromancy"
     ]
   },
   "mythical.mythicalCreature": {
@@ -3379,12 +3379,12 @@
     "description": "Famous monsters and creatures from global mythology and folklore",
     "total": 61,
     "examples": [
-      "banshee",
-      "sasquatch",
-      "nessie",
-      "fenrir",
-      "unicorn",
-      "pegasus"
+      "phoenix",
+      "jersey devil",
+      "werewolf",
+      "gorgon",
+      "cockatrice",
+      "cerberus"
     ]
   },
   "nature.areaOfNaturalBeauty": {
@@ -3393,12 +3393,12 @@
     "description": "Specific national parks, landmarks, and natural wonders worldwide",
     "total": 625,
     "examples": [
-      "the mont blanc",
-      "loma mountains national park",
-      "antelope canyon",
-      "monte fitz roy",
-      "mekong river delta",
-      "kerið crater lake"
+      "wulingyuan national park",
+      "great wall",
+      "aberdare national park",
+      "ai-ais/richtersveld transfrontier park",
+      "beomeosa temple",
+      "cape point"
     ]
   },
   "nature.biome": {
@@ -3407,12 +3407,12 @@
     "description": "Diverse ecological biomes and natural environmental zones",
     "total": 62,
     "examples": [
-      "hydrothermal vent",
-      "flooded grasslands",
-      "moorland",
-      "badlands",
-      "abyssal zone",
-      "savanna"
+      "desert",
+      "cave system",
+      "coral reef",
+      "cold desert",
+      "maquis",
+      "desert shrubland"
     ]
   },
   "nature.cloudType": {
@@ -3421,12 +3421,12 @@
     "description": "Specific meteorological cloud formations and types",
     "total": 40,
     "examples": [
+      "lenticular cloud",
+      "undulatus",
       "pileus cloud",
-      "contrail",
-      "nacreous cloud",
-      "fallstreak cloud",
-      "funnel cloud",
-      "arcus"
+      "nacreous",
+      "stratus",
+      "pyrocumulus"
     ]
   },
   "nature.flower": {
@@ -3435,12 +3435,12 @@
     "description": "Various flowering plants, herbs, and ornamental garden blooms",
     "total": 547,
     "examples": [
-      "flying duck orchid",
-      "butterfly pea (clitoria ternatea)",
-      "chinese lantern (physalis alkekengi)",
-      "black bat flower (tacca chantrieri)",
-      "bee orchid",
-      "alkanet (anchusa)"
+      "marigold (tagetes)",
+      "parrot's beak (lotus berthelotii)",
+      "oxalis (oxalis)",
+      "impatiens (impatiens walleriana)",
+      "jewelweed (impatiens capensis)",
+      "franklin tree flower"
     ]
   },
   "nature.fungus": {
@@ -3449,12 +3449,12 @@
     "description": "Assorted species of wild mushrooms and fungi",
     "total": 214,
     "examples": [
-      "shaggy scalycap mushroom",
-      "enoki mushroom",
-      "butter cap mushroom",
-      "chanterelle mushroom",
-      "chaga mushroom",
-      "bleeding fairy helmet mushroom"
+      "conifer tuft mushroom",
+      "red-belted polypore fungus",
+      "shiitake mushroom",
+      "poison pie mushroom",
+      "oak bracket fungus",
+      "panther cap mushroom"
     ]
   },
   "nature.gemstone": {
@@ -3463,12 +3463,12 @@
     "description": "Various precious gemstones, crystals, and mineral specimens",
     "total": 375,
     "examples": [
-      "grandidierite",
-      "black spinel",
-      "arsenopyrite",
-      "augelite",
-      "apophyllite",
-      "hambergite"
+      "schorl",
+      "heliodor",
+      "dravite",
+      "blue calcite",
+      "alexandrite",
+      "augelite"
     ]
   },
   "nature.landscape": {
@@ -3477,12 +3477,12 @@
     "description": "Geological formations and large-scale geographical landscape features",
     "total": 51,
     "examples": [
-      "butte",
-      "arch",
-      "plateau",
-      "cove",
-      "atoll",
-      "sinkhole"
+      "dune",
+      "bay",
+      "pass",
+      "gulf",
+      "escarpment",
+      "caldera"
     ]
   },
   "nature.mineral": {
@@ -3491,12 +3491,12 @@
     "description": "Specific mineral specimens, crystals, and semi-precious stones",
     "total": 275,
     "examples": [
-      "anorthite",
-      "labradorite",
-      "turquoise",
-      "pyrophyllite",
-      "jadeite",
-      "microcline"
+      "greenockite",
+      "franklinite",
+      "howlite",
+      "grossular",
+      "garnet",
+      "gibbsite"
     ]
   },
   "nature.moonPhase": {
@@ -3505,12 +3505,12 @@
     "description": "Traditional, seasonal, and descriptive names for lunar phases",
     "total": 117,
     "examples": [
-      "ivy moon",
-      "waxing crescent",
-      "bright moon",
-      "egg moon",
-      "chaste moon",
-      "first quarter"
+      "young moon",
+      "last quarter",
+      "lenten moon",
+      "quarter moon",
+      "wet moon",
+      "milk moon"
     ]
   },
   "nature.naturalPhenomenon": {
@@ -3519,12 +3519,12 @@
     "description": "Rare atmospheric, meteorological, and natural optical phenomena",
     "total": 45,
     "examples": [
-      "murmuration",
-      "fata morgana",
-      "aurora australis",
-      "blue jets",
-      "afterglow",
-      "solar eclipse"
+      "rainbow",
+      "geyser",
+      "moonbow",
+      "elves",
+      "dust devil",
+      "ball lightning"
     ]
   },
   "nature.plant": {
@@ -3533,12 +3533,12 @@
     "description": "Common indoor houseplants and decorative potted foliage",
     "total": 55,
     "examples": [
-      "zz plant",
-      "air plant",
-      "dieffenbachia",
-      "succulent",
-      "maranta",
-      "bonsai"
+      "dumb cane",
+      "staghorn fern",
+      "bromeliad",
+      "prayer plant",
+      "fiddle leaf fig",
+      "snake plant"
     ]
   },
   "nature.sceneModifier": {
@@ -3547,12 +3547,12 @@
     "description": "Atmospheric conditions, weather, and mood modifiers for scenes",
     "total": 49,
     "examples": [
-      "hurricane",
-      "foggy",
-      "glistening",
-      "aurora",
-      "apocalyptic",
-      "peaceful"
+      "crepuscular rays",
+      "rugged",
+      "windswept",
+      "pristine",
+      "arid",
+      "cloudy"
     ]
   },
   "nature.scene": {
@@ -3561,12 +3561,12 @@
     "description": "Diverse natural environments, biomes, and landscape settings",
     "total": 84,
     "examples": [
-      "cliffs",
-      "beach",
-      "long grass",
-      "fjord",
-      "lake",
-      "estuary"
+      "marsh",
+      "town",
+      "cavern",
+      "archipelago",
+      "flowers",
+      "delta"
     ]
   },
   "nature.sky": {
@@ -3575,12 +3575,12 @@
     "description": "Specific sky conditions, times of day, and cloud formations",
     "total": 198,
     "examples": [
-      "typhoon sky",
-      "asperity cloud sky",
-      "gloaming sky",
-      "copper dawn sky",
-      "fogbow sky",
-      "iridescent cloud sky"
+      "smoggy sky",
+      "sulfur-yellow sky",
+      "wind-swept sky",
+      "tornado sky",
+      "sepia sunrise sky",
+      "nebula sky"
     ]
   },
   "nature.texture": {
@@ -3589,12 +3589,12 @@
     "description": "Assorted natural and artificial surface textures and patterns",
     "total": 167,
     "examples": [
-      "iridescent beetle wing",
-      "stained glass",
-      "weathered sandstone",
-      "shattered glass",
-      "porous volcanic rock",
-      "wasp nest paper"
+      "shattered sea ice",
+      "fabric folds",
+      "alligator skin",
+      "cork",
+      "leaf veins",
+      "distressed leather"
     ]
   },
   "nature.treeType": {
@@ -3603,12 +3603,12 @@
     "description": "Various species of deciduous, coniferous, and tropical trees",
     "total": 71,
     "examples": [
-      "quaking aspen",
-      "coast redwood",
-      "aspen",
-      "eucalyptus",
-      "date palm",
-      "ebony"
+      "acacia",
+      "mahogany",
+      "ash",
+      "joshua tree",
+      "fan palm",
+      "banyan"
     ]
   },
   "nature.tree": {
@@ -3617,12 +3617,12 @@
     "description": "Assorted tree species, fruiting trees, and woody plants",
     "total": 158,
     "examples": [
-      "chestnut",
-      "arizona cypress",
-      "tamarack",
-      "plum",
-      "magnolia",
-      "persimmon"
+      "walnut",
+      "fir",
+      "northern white cedar",
+      "beech",
+      "pecan",
+      "honeylocust"
     ]
   },
   "nature.tropicalHouseplant": {
@@ -3631,12 +3631,12 @@
     "description": "Tropical flowering plants, orchids, and decorative botanicals",
     "total": 104,
     "examples": [
-      "codiaeum",
+      "billbergia",
+      "salvia farinacea",
+      "aechmea",
+      "chamaedorea",
       "euphorbia",
-      "abutilon",
-      "dieffenbachia",
-      "amaranthus",
-      "chamaedorea"
+      "catasetum"
     ]
   },
   "nature.waterBody": {
@@ -3645,12 +3645,12 @@
     "description": "Various types of natural and artificial water formations",
     "total": 109,
     "examples": [
-      "hot spring",
-      "anabranch",
-      "gulf",
-      "loch",
-      "headwaters",
-      "liman"
+      "swamp",
+      "lagoon",
+      "chute",
+      "aquifer",
+      "boiling lake",
+      "salt marsh"
     ]
   },
   "nature.weather": {
@@ -3659,12 +3659,12 @@
     "description": "Meteorological events, cloud types, and severe weather conditions",
     "total": 156,
     "examples": [
-      "altostratus clouds",
-      "overcast",
-      "heat lightning",
-      "virga",
-      "snowdrift",
-      "snow squall"
+      "fog",
+      "snow flurry",
+      "smoggy",
+      "hail",
+      "icicles",
+      "warm front"
     ]
   },
   "nature.wood": {
@@ -3673,12 +3673,12 @@
     "description": "Specific types of hardwood and softwood timber materials",
     "total": 66,
     "examples": [
-      "ironwood",
-      "iroko",
-      "jatoba",
+      "lacewood",
+      "cedar",
+      "aspen",
+      "cork",
       "hemlock",
-      "ipe",
-      "alder"
+      "beech"
     ]
   },
   "people.accent": {
@@ -3687,12 +3687,12 @@
     "description": "Various global and regional spoken accents and dialects",
     "total": 126,
     "examples": [
-      "yiddish",
-      "irish",
-      "estuary",
-      "bengali",
-      "punjabi",
-      "swiss"
+      "hebrew",
+      "korean",
+      "canadian",
+      "appalachian",
+      "caribbean",
+      "finnish"
     ]
   },
   "people.beautifulFeminine": {
@@ -3701,12 +3701,12 @@
     "description": "Adjectives describing feminine beauty, grace, and physical attractiveness",
     "total": 48,
     "examples": [
-      "pretty",
+      "lovely",
+      "ravishing",
       "stylish",
-      "attractive",
+      "gorgeous",
       "fashionable",
-      "graceful",
-      "resplendent"
+      "sensational"
     ]
   },
   "people.beautifulMasculine": {
@@ -3715,12 +3715,12 @@
     "description": "Personality traits and physical characteristics associated with masculine appeal",
     "total": 106,
     "examples": [
-      "dark skin",
-      "in the moment",
-      "at ease",
-      "thick, dark hair",
-      "toned",
-      "considerate"
+      "insightful",
+      "devoted",
+      "glowing skin",
+      "debonair",
+      "well mannered",
+      "content"
     ]
   },
   "people.bodyType": {
@@ -3729,12 +3729,12 @@
     "description": "Detailed descriptions of various human body shapes, builds, and proportions",
     "total": 115,
     "examples": [
-      "petite frame with curves",
-      "very fat with a robust physique",
-      "slender frame with delicate bone structure",
-      "tall, thin build",
-      "pear-shaped lower body with toned upper body",
-      "triangle shape with muscular legs"
+      "banana-shaped with straight hips and shoulders",
+      "burly and thickset with a wide frame",
+      "curvy silhouette with balanced proportions",
+      "inverted triangle with lean lower body",
+      "fat with an oval silhouette",
+      "fat with soft, rounded contours"
     ]
   },
   "people.celebrity": {
@@ -3743,12 +3743,12 @@
     "description": "Famous actors, singers, influencers, and members of British royalty",
     "total": 646,
     "examples": [
-      "benedict cumberbatch",
-      "sara underwood",
-      "bryce dallas howard",
-      "julia garner",
-      "emily bett rickards",
-      "christina hendricks"
+      "queen elizabeth ii",
+      "evangeline lilly",
+      "elle fanning",
+      "alejandra guilmant",
+      "brie larson",
+      "bruno mars"
     ]
   },
   "people.common": {
@@ -3757,12 +3757,12 @@
     "description": "Broad age groups, life stages, and general demographic categories",
     "total": 34,
     "examples": [
-      "schoolboy",
-      "adolescent",
+      "gen-zer",
+      "toddler girl",
       "adult",
-      "person",
-      "baby",
-      "baby boomer"
+      "woman",
+      "millennial",
+      "lady"
     ]
   },
   "people.couple": {
@@ -3771,11 +3771,11 @@
     "description": "Various romantic, platonic, and professional two-person relationship dynamics",
     "total": 36,
     "examples": [
-      "dating partners",
-      "friends",
-      "dance partners",
-      "newlyweds",
-      "husband and wife",
+      "colleagues",
+      "roommates",
+      "spouses",
+      "romantic partners",
+      "married couple",
       "acquaintances"
     ]
   },
@@ -3787,10 +3787,10 @@
     "examples": [
       "merengue",
       "ballroom dance",
-      "cumbia",
-      "jazz dance",
-      "finnish tango",
-      "butoh dance"
+      "jive",
+      "khmer classical dance",
+      "foxtrot",
+      "electric slide dance"
     ]
   },
   "people.expression": {
@@ -3799,12 +3799,12 @@
     "description": "Highly detailed descriptions of facial expressions and emotional body language",
     "total": 471,
     "examples": [
-      "tittering behind a raised hand with eyes darting around",
-      "nervous giggle with blushing cheeks and eyes looking away",
-      "open-mouthed laugh with thrown-back head and closed eyes",
-      "blank stare with slightly parted lips and a relaxed brow",
-      "goofy smile with crossed eyes and stuck-out tongue",
-      "lip trembling, on the verge of tears"
+      "wrinkled nose with curled upper lip",
+      "frown with downturned corners of the mouth and furrowed brow",
+      "open-mouthed gasp with raised eyebrows and widened eyes",
+      "scowl with narrowed eyes and a slightly jutted chin",
+      "quivering chin with watery eyes and slightly parted lips",
+      "boisterous laugh with clapping hands and stomping feet"
     ]
   },
   "people.eyeColor": {
@@ -3813,12 +3813,12 @@
     "description": "Natural and fantasy eye colors including gem-like and vivid shades",
     "total": 46,
     "examples": [
-      "royal blue eyes",
-      "aquamarine eyes",
-      "chocolate brown eyes",
-      "dark brown eyes",
-      "charcoal eyes",
-      "blue eyes"
+      "amethyst eyes",
+      "brown eyes",
+      "violet eyes",
+      "deep brown eyes",
+      "electric blue eyes",
+      "sky blue eyes"
     ]
   },
   "people.festival": {
@@ -3827,12 +3827,12 @@
     "description": "Major international cultural, religious, and seasonal festivals and holidays",
     "total": 59,
     "examples": [
-      "calgary stampede",
-      "baisakhi",
+      "albuquerque international balloon fiesta",
+      "inty raymi",
+      "hanukkah",
       "festival of colors",
-      "cherry blossom festival",
-      "diwali",
-      "carnival"
+      "pingxi sky lantern festival",
+      "holi"
     ]
   },
   "people.group": {
@@ -3841,12 +3841,12 @@
     "description": "Collective nouns and terms for various groups or gatherings of people",
     "total": 71,
     "examples": [
-      "unit",
-      "fans",
-      "clique",
-      "assembly",
-      "ensemble",
-      "caravan"
+      "flock",
+      "individuals",
+      "guild",
+      "travelers",
+      "people",
+      "coalition"
     ]
   },
   "people.hairstyle": {
@@ -3855,12 +3855,12 @@
     "description": "Diverse haircuts, styling techniques, and hair textures for men and women",
     "total": 58,
     "examples": [
-      "undercut",
-      "cornrows",
-      "perm",
-      "quiff",
-      "bantu knots",
-      "french braid"
+      "bob cut",
+      "chignon",
+      "pigtails",
+      "mohawk",
+      "flat top",
+      "bantu knots"
     ]
   },
   "people.hobby": {
@@ -3869,12 +3869,12 @@
     "description": "Wide range of creative, physical, and intellectual hobbies and interests",
     "total": 291,
     "examples": [
-      "painting",
-      "hunting",
-      "herbalism",
-      "kite flying",
-      "ice skating",
-      "engraving"
+      "video game streaming",
+      "writing therapy",
+      "qigong",
+      "lock picking",
+      "palm reading",
+      "writing"
     ]
   },
   "people.job": {
@@ -3883,12 +3883,12 @@
     "description": "Various professional occupations, roles, and employment titles",
     "total": 612,
     "examples": [
-      "waiter/waitress",
-      "able-bodied seaman",
-      "fire inspector",
-      "computer programmer",
-      "broadcaster",
-      "manufacturing engineer"
+      "groundskeeper",
+      "purchasing manager",
+      "pararescuemen",
+      "neurologist",
+      "school bus driver",
+      "teacher assistant"
     ]
   },
   "people.makeupStyle": {
@@ -3897,12 +3897,12 @@
     "description": "Historical, trendy, and artistic makeup styles and cosmetic techniques",
     "total": 73,
     "examples": [
-      "metallic makeup",
-      "flawless matte",
-      "drag makeup",
-      "foxy eye makeup",
-      "gothic makeup",
-      "avant-garde makeup"
+      "1920s flapper makeup",
+      "1950s pin-up makeup",
+      "draping blush",
+      "bronzed makeup",
+      "90s brown lip",
+      "matte makeup"
     ]
   },
   "people.posePortrait": {
@@ -3911,12 +3911,12 @@
     "description": "Specific camera angles, body positioning, and framing for portrait photography",
     "total": 45,
     "examples": [
-      "against a wall",
-      "leaning back against a railing",
-      "sitting",
-      "crouched portrait",
-      "hand on hip",
-      "lying on their back"
+      "looking through window",
+      "close-up",
+      "looking off into the distance",
+      "back turned to camera looking over shoulder",
+      "propped up on one elbow (resting)",
+      "leaning against a wall"
     ]
   },
   "people.pose": {
@@ -3925,12 +3925,12 @@
     "description": "Dynamic body postures, gestures, and physical actions for characters",
     "total": 201,
     "examples": [
-      "perched",
-      "curled up",
-      "leaning against a wall",
-      "kneeling with both knees on ground and hands clasped in front of body",
-      "leaning against a railing or fence",
-      "holding hands in prayer position"
+      "dancing or jumping in mid-air with a joyful expression",
+      "crouching down with hands on ground in front of body",
+      "looking confident with hands on hips",
+      "crouching with one hand on the knee",
+      "sitting on the ground with knees hugged to chest",
+      "looking straight into the camera"
     ]
   },
   "people.profession": {
@@ -3939,12 +3939,12 @@
     "description": "Specific historical, scientific, and specialized professions and trades",
     "total": 60,
     "examples": [
-      "baker",
-      "archivist",
-      "judge",
-      "lepidopterist",
-      "lighthouse keeper",
-      "tanner"
+      "brewmaster",
+      "bookbinder",
+      "distiller",
+      "watchmaker",
+      "archaeologist",
+      "librarian"
     ]
   },
   "photography.apertureLook": {
@@ -3953,12 +3953,12 @@
     "description": "Photographic effects related to bokeh, depth of field, focus, and lens flares",
     "total": 52,
     "examples": [
-      "infinite focus",
-      "out of focus",
+      "bubble bokeh",
+      "swirly bokeh",
       "hyperfocal focus",
-      "shallow depth of field",
-      "f/1.4 creamy background",
-      "rack focus"
+      "anamorphic bokeh",
+      "rack focus",
+      "focus stacking"
     ]
   },
   "photography.cameraMovement": {
@@ -3967,12 +3967,12 @@
     "description": "Cinematography terms for dynamic camera movements, rigs, and tracking shots",
     "total": 50,
     "examples": [
-      "hyperlapse",
       "shaky cam",
-      "tracking shot",
-      "slow zoom",
-      "dutch tilt movement",
-      "whip tilt"
+      "camera roll",
+      "steadicam shot",
+      "roll",
+      "sweeping pan",
+      "snorricam shot"
     ]
   },
   "photography.camera": {
@@ -3981,12 +3981,12 @@
     "description": "Specific models of professional cinema cameras, DSLRs, and digital cameras",
     "total": 187,
     "examples": [
-      "samsung nx100",
-      "sony pdw-f800 xdcam",
+      "canon 5d mark iii",
+      "sony f65",
+      "sony a6000",
+      "ricoh gr ii",
       "sony alpha nex-7 body only compact system camera",
-      "sony",
-      "xiaomi mi sphere 360 camera",
-      "ricoh gr digital iv compact digital camera"
+      "sony"
     ]
   },
   "photography.composition": {
@@ -3995,12 +3995,12 @@
     "description": "Visual composition techniques, framing styles, and spatial balance methods",
     "total": 117,
     "examples": [
-      "juxtaposition",
-      "frame within a frame",
-      "l-shape composition",
-      "concentric circles",
-      "layered composition",
-      "compositional anchor"
+      "left-to-right rule",
+      "pyramid composition",
+      "vertical lines",
+      "o-shape composition",
+      "minimalist composition",
+      "open composition"
     ]
   },
   "photography.filmStock": {
@@ -4009,12 +4009,12 @@
     "description": "Specific brands, models, and ISO speeds of analog photographic film stocks",
     "total": 52,
     "examples": [
-      "ilford xp2",
-      "foma fapan 100",
-      "fujichrome provia 100f",
-      "kodak ektachrome e100",
-      "rollei retro 80s",
-      "kodak gold 200"
+      "fujicolor industrial 100",
+      "ilford delta 400",
+      "cinestill 50d",
+      "polaroid originals film",
+      "kodak portra 160",
+      "kodak ektar 100"
     ]
   },
   "photography.film": {
@@ -4023,12 +4023,12 @@
     "description": "Specific analog photography film types, brands, and ISO speeds",
     "total": 102,
     "examples": [
-      "ultrafine xtreme film",
-      "kodak aps film",
-      "fuji superia xtra 400 film",
-      "ilford xp2 super 400 film",
-      "fuji provia 400f film",
-      "fuji velvia 100 film"
+      "kodak portra 400 film",
+      "adox pan 100 film",
+      "fuji velvia 100 film",
+      "fuji provia 400x rdpiii film",
+      "fuji superia reala 100 film",
+      "kodak professional portra 800 film"
     ]
   },
   "photography.landscapeKeyword": {
@@ -4037,12 +4037,12 @@
     "description": "Broad photography concepts, subjects, and techniques related to outdoor photography",
     "total": 81,
     "examples": [
-      "forests",
-      "balance",
-      "color",
-      "exposure",
-      "composition",
-      "flowers"
+      "objects",
+      "graveyards",
+      "leaves",
+      "canyons",
+      "b&w",
+      "fire"
     ]
   },
   "photography.landscapeSubjectDetailed": {
@@ -4051,12 +4051,12 @@
     "description": "Highly descriptive, full-sentence prompts of vivid nature and landscape scenes",
     "total": 158,
     "examples": [
-      "a peaceful river delta with a variety of bird species",
-      "a serene lake surrounded by dense forests and snow-capped peaks",
-      "a picturesque meadow filled with wildflowers",
-      "a picturesque highland lake with snow-capped peaks in the background",
-      "a quiet birch forest in winter with a fresh blanket of powdery snow",
-      "a massive sandstone arch carved by the wind and water"
+      "a dramatic thunderstorm brewing over a vast golden wheat field",
+      "a peaceful river with calm waters and rocky banks",
+      "a dense jungle with a variety of primates and other wildlife",
+      "a colorful hot spring with steam rising from the water",
+      "a peaceful river valley with a variety of bird species",
+      "a misty mountain peak surrounded by clouds"
     ]
   },
   "photography.landscapeSubject": {
@@ -4065,12 +4065,12 @@
     "description": "Various natural and man-made outdoor locations, structures, and landscape features",
     "total": 132,
     "examples": [
-      "vineyard",
+      "outcropping",
+      "cove",
+      "botanical garden",
       "fountain",
-      "footpath",
-      "marsh",
-      "forest",
-      "covered bridge"
+      "ghost town",
+      "footpath"
     ]
   },
   "photography.lensType": {
@@ -4079,12 +4079,12 @@
     "description": "General categories, optical designs, and specialized styles of photographic lenses",
     "total": 52,
     "examples": [
-      "bellows",
-      "macro",
-      "speed-booster",
-      "apochromatic",
-      "cine lens",
-      "perspective control lens"
+      "wide-angle",
+      "prime",
+      "pinhole lens",
+      "achromatic doublet",
+      "telephoto",
+      "perspective-control"
     ]
   },
   "photography.lens": {
@@ -4093,12 +4093,12 @@
     "description": "Specific focal lengths and exact branded camera lens models",
     "total": 87,
     "examples": [
-      "300mm",
-      "sigma 50mm",
-      "nikon z 24-70mm",
-      "sigma 10-20mm",
+      "nikon af-s 17-35mm",
       "sony fe 16-35mm",
-      "sony fe 50mm"
+      "sony fe 24-70mm",
+      "tamron sp 45mm",
+      "nikon z 24-70mm",
+      "sony fe 70-200mm"
     ]
   },
   "photography.lightSource": {
@@ -4107,12 +4107,12 @@
     "description": "Natural, artificial, and specialized light sources and lighting equipment",
     "total": 64,
     "examples": [
-      "bioluminescence",
-      "photoflood lamp",
-      "window light",
-      "neon light",
-      "flashlight",
-      "umbrella light"
+      "matchstick",
+      "starlight",
+      "skylight",
+      "campfire",
+      "light emitting diode",
+      "phosphorescence"
     ]
   },
   "photography.light": {
@@ -4121,12 +4121,12 @@
     "description": "Descriptive lighting styles, natural light conditions, and illumination techniques",
     "total": 136,
     "examples": [
-      "soft lighting",
-      "lit by butterfly light",
-      "blacklight",
+      "lit by street light",
+      "glowing radioactivity",
       "evening",
-      "dim dark light",
-      "lit by aurora borealis"
+      "light reflecting",
+      "split lighting",
+      "lit by fluorescent lamps"
     ]
   },
   "photography.lightingSetup": {
@@ -4135,12 +4135,12 @@
     "description": "Studio lighting techniques, setups, and directional illumination styles",
     "total": 52,
     "examples": [
-      "fill lighting",
-      "hat lighting",
-      "window lighting",
-      "low-key lighting",
-      "high-key lighting",
-      "available lighting"
+      "badger lighting",
+      "loop lighting",
+      "bounce lighting",
+      "butterfly lighting",
+      "moody lighting",
+      "soft lighting"
     ]
   },
   "photography.perspective": {
@@ -4149,12 +4149,12 @@
     "description": "Camera angles, viewpoints, and geometric perspective techniques for visual framing",
     "total": 129,
     "examples": [
-      "exaggerated perspective",
-      "horizontal perspective",
-      "low-level view",
-      "dutch angle",
-      "bird's-eye perspective",
-      "extreme close-up perspective"
+      "zero-point perspective",
+      "extreme wide-angle perspective",
+      "bottom-up view",
+      "cylindrical perspective",
+      "cutaway view",
+      "expanded perspective"
     ]
   },
   "photography.photographer": {
@@ -4163,12 +4163,12 @@
     "description": "Names of famous photographers paired with their specific genres or styles",
     "total": 960,
     "examples": [
-      "henri cartier-bresson (street photographer)",
-      "rania matar (portrait photographer)",
-      "zack arias (portrait and editorial photographer)",
-      "eduardo muñoz ordoqui (documentary photographer)",
-      "zwelethu mthethwa (documentary and portrait photographer)",
-      "bahman jalali (documentary photographer)"
+      "nada harib (documentary photographer)",
+      "richard mosse (documentary photographer)",
+      "sigmar polke (conceptual and fine art photographer)",
+      "tracey moffatt (conceptual photographer)",
+      "wolfgang tillmans (conceptual photographer)",
+      "max dupain (documentary and commercial photographer)"
     ]
   },
   "photography.portraitPhotographer": {
@@ -4177,12 +4177,12 @@
     "description": "Names of renowned portrait, fine art, and fashion photographers",
     "total": 79,
     "examples": [
-      "rania matar",
-      "walker evans",
-      "william eggleston",
-      "sally mann",
-      "martin parr",
-      "man ray"
+      "peter lindbergh",
+      "jimmy nelson",
+      "jürgen teller",
+      "elliott erwitt",
+      "bill brandt",
+      "andres serrano"
     ]
   },
   "photography.shotType": {
@@ -4191,12 +4191,12 @@
     "description": "Various camera angles and framing techniques for photography and film",
     "total": 43,
     "examples": [
-      "group shot",
-      "panoramic shot",
-      "over-the-shoulder",
-      "ground level shot",
-      "worm's-eye view",
-      "medium shot"
+      "dutch angle",
+      "close-up",
+      "high angle shot",
+      "extreme wide shot",
+      "satellite shot",
+      "medium close-up"
     ]
   },
   "photography.summerScene": {
@@ -4205,12 +4205,12 @@
     "description": "Idyllic, warm-weather outdoor scenes, landscapes, and summer activities",
     "total": 47,
     "examples": [
-      "a winding boardwalk leading through coastal sand dunes to the ocean",
+      "a quaint village with flower boxes in every window",
+      "a rustic beach shack surrounded by sand dunes and sea grass",
+      "a beach at sunset",
+      "a tropical beach with hammocks strung between leaning coconut palms",
       "a pathway lined with blooming hydrangeas leading to a seaside cottage",
-      "a sunrise over a wheat field",
-      "a rolling green hill dotted with grazing sheep",
-      "a beachside boardwalk lined with palm trees",
-      "a vineyard with rows of grapevines stretching towards the horizon"
+      "a village fair with games, rides, and cotton candy"
     ]
   },
   "photography.summerTropicalBeach": {
@@ -4219,12 +4219,12 @@
     "description": "Sensory details and vibrant scenes of a tropical beach vacation",
     "total": 67,
     "examples": [
-      "the feel of warm sand between your toes as you walk along the shore",
-      "a sun-kissed beach populated by happy vacationers and locals alike",
-      "a collection of brightly colored fishing boats bobbing in the water",
-      "a school of playful dolphins jumping and diving in the distance",
-      "a collection of colorful beach towels draped over chairs and umbrellas",
-      "crystal clear turquoise waters lapping gently against the shore"
+      "coconut shells and tropical fruit platters arranged on a woven picnic mat",
+      "the sound of laughter and joy from vacationers enjoying themselves",
+      "soft, powdery white sand stretching as far as the eye can see",
+      "a collection of starfish resting in a shallow, sun-warmed tidal pool",
+      "a wooden signpost pointing to different exotic tropical destinations",
+      "the silhouette of a catamaran sailing across a blazing golden sunset"
     ]
   },
   "photojournalism.newsExtreme": {
@@ -4233,12 +4233,12 @@
     "description": "Catastrophic, world-altering, and extreme global news events and disasters",
     "total": 68,
     "examples": [
-      "a global agricultural blight rapidly destroys half of the world's wheat and corn crops",
-      "a team of astronauts discovers a new habitable planet",
-      "a military coup overthrows the government of a nuclear-armed nation in a sudden overnight raid",
-      "a major economic recession hits the global economy",
-      "the first human brain-computer interface is successfully implanted, allowing telepathic communication",
-      "a massive earthquake strikes a major metropolitan area"
+      "a massive synthetic biology lab leak creates a highly aggressive, invasive plant species that destroys concrete",
+      "a revolutionary new form of renewable energy is discovered",
+      "a new form of social media changes the world",
+      "a major city is hit by a massive blizzard, shutting down transportation and power",
+      "a sudden, massive sinkhole swallows an entire city block during rush hour",
+      "a major new discovery in the world of astronomy"
     ]
   },
   "photojournalism.newsNormal": {
@@ -4247,12 +4247,12 @@
     "description": "Standard major news headlines covering science, politics, business, and society",
     "total": 57,
     "examples": [
-      "a major environmental crisis, such as deforestation or coral reef destruction",
+      "a historic museum heist occurs, with thieves stealing priceless masterpieces overnight",
+      "a major labor union goes on a nationwide strike, halting public transit and shipping",
       "a breakthrough in agricultural technology allows crops to be grown in arid, desert conditions",
-      "a high-stakes corporate merger between two tech giants sparks anti-trust protests",
+      "a major development in international relations, such as a new trade deal or a new peace treaty",
       "a major cultural festival, celebrating the traditions and customs of a particular group or region",
-      "a major sporting event, such as the olympics or world cup, that brings together athletes from around the world",
-      "a major natural disaster, such as a hurricane or earthquake, that leaves thousands of people displaced"
+      "a major climate change summit, bringing together world leaders to discuss solutions to the crisis"
     ]
   },
   "photojournalism.newsSpecific": {
@@ -4261,12 +4261,12 @@
     "description": "Highly detailed, specific descriptions of major global news events and crises",
     "total": 38,
     "examples": [
-      "a critical space rescue: an international crew of astronauts executes a daring spacewalk to repair a damaged life-support system",
-      "a historic election: a record number of women are elected to congress, marking a major milestone in the fight for gender equality in politics",
-      "a major climate change summit: leaders from around the world gather in paris to discuss a new global agreement on reducing carbon emissions and slowing the effects of climate change",
-      "a mass protest against police brutality and systemic racism: thousands march through the streets of new york city, demanding justice for victims of police violence and systemic racism in the criminal justice system",
-      "a mass shooting or act of domestic terrorism: a gunman opens fire at a crowded concert in las vegas, killing dozens and injuring hundreds more",
-      "a devastating building collapse: a multi-story residential building in mumbai collapses overnight, triggering a frantic search for survivors"
+      "a bold environmental protest: activists scale a major oil rig in the north sea, unfurling a massive banner protesting deep-sea drilling",
+      "a massive wildfire: a fire sweeps through the australian outback, destroying homes and forcing thousands of residents to evacuate",
+      "a new scientific discovery: scientists discover a new species of dinosaur, providing new insights into the prehistoric world and sparking excitement among paleontologists and the public alike",
+      "a breakthrough in the fight against cancer: researchers develop a new type of cancer treatment that uses the body's own immune system to target and destroy cancer cells",
+      "a landmark supreme court ruling: justices hand down a historic decision on privacy rights in the digital age, limiting government surveillance",
+      "a historic environmental recovery: the bald eagle population is officially declared fully recovered and removed from the endangered species list"
     ]
   },
   "photojournalism.styleProtest": {
@@ -4275,12 +4275,12 @@
     "description": "Various photographic styles and techniques used in photojournalism and documentary photography",
     "total": 38,
     "examples": [
-      "analog film photography: using traditional 35mm or medium format film to create a raw, grain-textured aesthetic with natural color tones",
-      "double exposure photography: combining two distinct images, such as a protester's face and a crowded street, to create a layered, symbolic narrative",
-      "telephoto lens photography: using long focal lengths to compress the perspective, making the crowd appear denser and bringing distant action closer",
-      "macro photography: focusing on the small details of protests and individual participants",
+      "action photography: capturing the movement and energy of the protesters in action",
+      "intentional camera movement: deliberately moving the camera during a longer exposure to create a dynamic, abstract representation of chaos and action",
+      "documentary photography: providing a historical record of the protests and the people involved",
+      "cinematic photojournalism: utilizing anamorphic lenses, wide aspect ratios, and dramatic color grading to evoke a movie-like atmosphere",
       "monochrome photojournalism: stripping away color to emphasize form, texture, shadow, and the pure raw emotion of the moment",
-      "intentional camera movement: deliberately moving the camera during a longer exposure to create a dynamic, abstract representation of chaos and action"
+      "first-person point-of-view photography: shooting from eye-level within the thick of the crowd, giving the viewer an immersive sense of being there"
     ]
   },
   "photojournalism.types": {
@@ -4289,12 +4289,12 @@
     "description": "Diverse subjects and thematic beats covered in photojournalism and documentary reporting",
     "total": 87,
     "examples": [
-      "community and neighborhood storytelling, highlighting the everyday lives and challenges of local residents",
-      "energy and resource extraction",
-      "family and relationships",
-      "marine conservation and ocean plastic pollution",
-      "immigration and refugees",
-      "wildlife and conservation"
+      "advocacy photojournalism, documenting specific causes to raise awareness and inspire social change",
+      "environmental photojournalism, focusing on the impact of industry on natural habitats",
+      "aging and retirement",
+      "aging infrastructure and maintenance issues",
+      "gender identity and gender expression",
+      "scientific research and discoveries"
     ]
   },
   "places.home": {
@@ -4303,12 +4303,12 @@
     "description": "Various types of residential dwellings and architectural housing styles",
     "total": 103,
     "examples": [
-      "motorhome",
-      "quonset hut",
-      "midcentury modern",
-      "tower",
-      "underwater home",
-      "thatched roof home"
+      "trullo",
+      "guest house",
+      "brownstone",
+      "earth sheltered home",
+      "cob home",
+      "bungalow"
     ]
   },
   "places.interiorSpace": {
@@ -4317,12 +4317,12 @@
     "description": "Diverse indoor environments ranging from mundane rooms to specialized workspaces",
     "total": 481,
     "examples": [
-      "radio broadcast booth",
-      "ship bridge",
-      "monastery library",
-      "loft bedroom",
-      "jewelry store",
-      "mihrab alcove"
+      "botanical conservatory",
+      "sauna",
+      "cloisters walk",
+      "infirmary",
+      "dry cleaner",
+      "classroom"
     ]
   },
   "places.public": {
@@ -4331,12 +4331,12 @@
     "description": "Common public venues, recreational areas, and civic facilities",
     "total": 94,
     "examples": [
-      "train station",
-      "auditorium",
-      "seafront promenade",
+      "city hall",
       "art museum",
-      "subway station",
-      "boulevard"
+      "beach restaurant",
+      "lighthouse",
+      "waterfront",
+      "picnic area"
     ]
   },
   "places.roomType": {
@@ -4345,12 +4345,12 @@
     "description": "Specific, often historical or grand interior rooms and specialized chambers",
     "total": 71,
     "examples": [
-      "den",
-      "antechamber",
+      "conservatory",
+      "banquet hall",
+      "sitting room",
+      "lobby",
       "refectory",
-      "barroom",
-      "card room",
-      "billiard room"
+      "archive"
     ]
   },
   "places.room": {
@@ -4359,12 +4359,12 @@
     "description": "Standard functional rooms and spaces found in typical modern homes",
     "total": 51,
     "examples": [
-      "laundry room",
-      "pool house",
-      "corridor",
-      "bedroom",
-      "meeting room",
-      "boardroom"
+      "boardroom",
+      "guest room",
+      "cellar",
+      "closet",
+      "kitchen",
+      "copy room"
     ]
   },
   "places.urbanFeature": {
@@ -4373,12 +4373,12 @@
     "description": "Structural elements, fixtures, and infrastructure found in city environments",
     "total": 196,
     "examples": [
-      "pocket park",
-      "wrought iron fence",
-      "arcade",
-      "fire escape",
-      "market stall",
-      "staircase"
+      "pedestrian overpass",
+      "cul-de-sac",
+      "fire hydrant",
+      "billboard",
+      "balcony",
+      "cell tower"
     ]
   },
   "plot.action": {
@@ -4387,12 +4387,12 @@
     "description": "High-stakes, thrilling scenarios involving combat, heists, rescues, and survival",
     "total": 66,
     "examples": [
+      "defending against a military attack",
       "preventing a dangerous weapon from falling into the wrong hands",
-      "rescuing a captive from a jungle or wilderness",
-      "participating in a high-speed car chase",
-      "rescuing a loved one from danger",
-      "escaping from a high-speed train under enemy control",
-      "rescuing a stranded or lost team or crew"
+      "participating in a heist or caper",
+      "escaping from a burning building or other disaster",
+      "infiltrating a cartel or organized crime group",
+      "stopping a political uprising or revolution"
     ]
   },
   "plot.arthouse": {
@@ -4401,12 +4401,12 @@
     "description": "Introspective narratives focusing on emotional struggles, relationships, and personal crises",
     "total": 66,
     "examples": [
+      "battling with a chronic illness",
       "being held captive",
-      "coping with the sudden silence of a solitary rural existence",
-      "going on a journey of self-discovery",
-      "exploring their sexuality",
-      "engaging in acts of rebellion",
-      "challenging the status quo"
+      "being caught in a love triangle",
+      "forming a secret society",
+      "facing an ethical dilemma",
+      "going on a dangerous adventure"
     ]
   },
   "plot.fantasy": {
@@ -4415,12 +4415,12 @@
     "description": "Magical and supernatural adventures involving mythical creatures, curses, and epic quests",
     "total": 66,
     "examples": [
-      "dealing with the consequences of using dark magic",
-      "navigating through a magical jungle or swamp",
-      "seeking audience with a reclusive mountain giant",
-      "bargaining with an ancient primordial deity",
-      "escaping from a spell-induced sleep",
-      "saving a magical creature from harm"
+      "rescuing a captive or hostage",
+      "escaping from an enchanted forest or maze",
+      "dealing with the power struggles between kingdoms",
+      "reclaiming a throne usurped by a puppet king",
+      "training to become a powerful wizard or warrior",
+      "overcoming personal demons or fears"
     ]
   },
   "plot.general": {
@@ -4429,12 +4429,12 @@
     "description": "A mix of everyday life events, personal goals, and lighthearted adventures",
     "total": 109,
     "examples": [
-      "attempting to break a world record",
-      "participating in a sporting event",
-      "participating in a protest",
-      "dealing with a family crisis",
-      "participating in a karaoke competition",
-      "helping to rebuild after a natural disaster"
+      "starting a startup",
+      "becoming a superhero",
+      "participating in a scavenger hunt",
+      "attending a high school reunion",
+      "going on a road trip",
+      "going on a cross-country road trip"
     ]
   },
   "plot.horror": {
@@ -4443,12 +4443,12 @@
     "description": "Horror and survival scenarios involving supernatural entities, monsters, and deadly environments",
     "total": 65,
     "examples": [
-      "escaping a house that rearranges its rooms overnight",
-      "investigating a mysterious ghost town",
-      "investigating a mysterious disappearance",
-      "escaping from a mad scientist's laboratory",
-      "fighting against an evil spirit",
-      "facing a parasitic entity infecting a small rural community"
+      "trapped in a haunted mansion",
+      "investigating an old videotape that curses whoever watches it",
+      "surviving a night in a museum where the exhibits come alive aggressively",
+      "trapped in a haunted hotel",
+      "staying alive in a zombie outbreak",
+      "surviving a night in a high-tech smart home that turns hostile"
     ]
   },
   "plot.musical": {
@@ -4457,12 +4457,12 @@
     "description": "Storylines focused on musical competitions, bands, solo artists, and creative collaborations",
     "total": 66,
     "examples": [
-      "finding the courage to pursue their musical dreams",
-      "staging an unauthorized underground musical",
+      "overcoming creative differences in a musical collaboration",
+      "dealing with the challenges of being a solo artist",
+      "rekindling a love of music after a period of burnout",
       "balancing a secret identity as a rising pop star and a normal student",
-      "competing for a prestigious scholarship at a music conservatory",
-      "navigating the backstage drama and romance of a broadway show",
-      "dealing with the realities of the music business"
+      "dealing with the stress of performing live",
+      "learning to work together as a musical team"
     ]
   },
   "plot.romance": {
@@ -4471,12 +4471,12 @@
     "description": "Romantic storylines about overcoming personal, social, and communication obstacles to find love",
     "total": 65,
     "examples": [
-      "building a relationship while balancing career or other commitments",
-      "navigating the awkward transition from best friends to lovers",
-      "overcoming societal or cultural expectations",
-      "finding love while pursuing personal goals",
-      "navigating the challenges of marriage or long-term commitment",
-      "surviving a long-distance relationship"
+      "falling in love while teaching each other different languages",
+      "going on a romantic adventure or journey",
+      "finding love in an unexpected place",
+      "coping with infertility or other family-related challenges",
+      "navigating the ups and downs of a long-distance relationship",
+      "dealing with jealousy or insecurity"
     ]
   },
   "plot.scifiCyberpunk": {
@@ -4485,12 +4485,12 @@
     "description": "Cyberpunk scenarios involving hacking, rogue AI, cyborgs, and dystopian corporate espionage",
     "total": 66,
     "examples": [
-      "overcoming personal limitations through technology",
-      "overcoming a technological apocalypse",
-      "rescuing a captive or hostage",
-      "investigating a cult that worships a rogue artificial intelligence",
-      "infiltrating a corporation or government facility",
-      "participating in a cyberwar or virtual battle"
+      "navigating through a cyber-controlled wasteland",
+      "discovering a ghost in the machine within a colossal city-wide mainframe",
+      "defending against a powerful ai or rogue program",
+      "escaping from a dangerous city or dystopian world",
+      "dealing with the power struggles between corporations",
+      "hacking into a corporation's computer systems"
     ]
   },
   "plot.scifi": {
@@ -4499,12 +4499,12 @@
     "description": "Science fiction scenarios featuring space exploration, alien encounters, and planetary disasters",
     "total": 185,
     "examples": [
-      "collecting valuable resources",
-      "investigating a space-based conspiracy or murder",
-      "stopping a rogue planet from destroying earth",
-      "navigating through an asteroid field or space anomaly",
-      "navigating a sentient nebula that responds to the crew's emotions",
-      "dealing with the power struggles between intergalactic nations"
+      "making first contact with an alien race",
+      "dealing with a malfunctioning spacecraft",
+      "dealing with the consequences of time travel",
+      "discovering a hidden society in space",
+      "destroying a rogue planet or moon",
+      "infiltrating a space-based military base"
     ]
   },
   "plot.war": {
@@ -4513,12 +4513,12 @@
     "description": "Military and tactical operations including covert missions, sieges, and defensive stands",
     "total": 66,
     "examples": [
-      "defending against a chemical or biological attack",
-      "conducting a covert operation",
-      "carrying out a dangerous mission",
-      "conducting a deep penetration mission",
+      "saving civilian lives during conflict",
+      "stopping a traitor or mole within the group",
+      "defending a field hospital during a surprise enemy counter-offensive",
+      "defending a strategic location from enemy forces",
       "infiltrating a coastal artillery battery to disable its guns",
-      "defending against a surprise attack"
+      "infiltrating enemy territory"
     ]
   },
   "science.astronomy": {
@@ -4527,12 +4527,12 @@
     "description": "Astronomical concepts, phenomena, and celestial structures like black holes and dark matter",
     "total": 54,
     "examples": [
-      "comet trail",
-      "neutron star",
       "star cluster",
-      "andromeda",
+      "supernova",
       "kuiper belt",
-      "red giant"
+      "meteor",
+      "neutron star",
+      "asteroid"
     ]
   },
   "science.chemicalElement": {
@@ -4541,12 +4541,12 @@
     "description": "Various chemical elements from the periodic table",
     "total": 118,
     "examples": [
-      "astatine",
-      "mendelevium",
+      "osmium",
+      "fluorine",
+      "neodymium",
       "cadmium",
-      "ytterbium",
-      "hafnium",
-      "helium"
+      "gadolinium",
+      "francium"
     ]
   },
   "science.constellation": {
@@ -4555,12 +4555,12 @@
     "description": "Names of recognized star constellations in the night sky",
     "total": 88,
     "examples": [
-      "lyra",
-      "canes venatici",
-      "aquarius",
-      "gemini",
-      "lepus",
-      "orion"
+      "corona borealis",
+      "andromeda",
+      "eridanus",
+      "chamaeleon",
+      "hercules",
+      "dorado"
     ]
   },
   "science.geometry": {
@@ -4569,12 +4569,12 @@
     "description": "Advanced mathematical shapes, fractals, attractors, and geometric concepts",
     "total": 117,
     "examples": [
-      "annulus",
-      "sacred geometry",
-      "apollonian gasket",
-      "bucky ball",
-      "barnsley fern",
-      "cellular automaton"
+      "non-crystallographic symmetry",
+      "julia set",
+      "fibonacci spiral",
+      "archimedean",
+      "fractal dimension",
+      "julia set fractal"
     ]
   },
   "science.isotope": {
@@ -4583,12 +4583,12 @@
     "description": "Specific radioactive and stable isotopes of various chemical elements",
     "total": 56,
     "examples": [
+      "molybdenum-99",
+      "uranium-235",
+      "radon-222",
       "barium-133",
-      "caesium-137",
-      "uranium-234",
-      "iridium-192",
-      "iodine-123",
-      "phosphorus-32"
+      "cobalt-60",
+      "lutetium-177"
     ]
   },
   "science.medicalImages": {
@@ -4597,12 +4597,12 @@
     "description": "Medical imaging techniques and diagnostic scanning procedures",
     "total": 45,
     "examples": [
-      "cta",
-      "4d ultrasound",
-      "phase-contrast x-ray imaging",
-      "cone beam ct",
-      "oct scan",
-      "spect scan"
+      "fundus photography",
+      "micro-ct",
+      "3d ultrasound",
+      "sonography",
+      "dexa scan",
+      "photoacoustic imaging"
     ]
   },
   "science.planetBody": {
@@ -4611,12 +4611,12 @@
     "description": "Specific planets, moons, asteroids, and other named celestial bodies",
     "total": 224,
     "examples": [
-      "altjira",
-      "geographos",
-      "hd 189733 b",
-      "enceladus",
-      "chaos",
-      "dimorphos"
+      "aeneas",
+      "ferdinand",
+      "hale-bopp",
+      "ida",
+      "perdita",
+      "lutetia"
     ]
   },
   "science.robotType": {
@@ -4625,12 +4625,12 @@
     "description": "Various types of industrial, agricultural, and specialized autonomous robots and drones",
     "total": 328,
     "examples": [
-      "tiltwing drone",
-      "tactical entry robot",
-      "space exploration robot",
-      "spot-welding robot",
-      "robotic turret",
-      "robotic submarine"
+      "serpentine robot",
+      "anthropomorphic robot",
+      "pickup-and-place robot",
+      "lunar rover",
+      "space manipulator",
+      "sewer crawler"
     ]
   },
   "science.scifiTech": {
@@ -4640,11 +4640,11 @@
     "total": 63,
     "examples": [
       "android",
-      "bionic eye",
-      "nanobot swarm",
-      "neural lace",
-      "jetpack",
-      "brain-computer interface"
+      "laser pistol",
+      "exosuit",
+      "teleporter",
+      "matter replicator",
+      "jetpack"
     ]
   },
   "set.describeStyle": {
@@ -4653,12 +4653,12 @@
     "description": "Eclectic art styles, hashtags, and artist names used in AI image generation",
     "total": 17756,
     "examples": [
-      "light magenta and light cyan",
-      "light green and dark blue",
-      "watercolor landscapes",
-      "light emerald and pink",
-      "light white and light green",
-      "light pink and dark orange"
+      "elaborate drapery",
+      "dark and dramatic chiaroscuro portraits",
+      "dark purple and dark bronze",
+      "eugène boudin",
+      "david welker",
+      "dark white and yellow"
     ]
   },
   "set.describeSubject": {
@@ -4667,12 +4667,12 @@
     "description": "Highly specific, random AI-generated image prompts and surreal subject descriptions",
     "total": 139614,
     "examples": [
-      "2001 nissan versa sxt gdi manual 4",
-      "anime character pictures",
-      "a close up shot of cloth with white netting",
-      "a light in a glass aquarium with purple lights",
-      "'the knight and the shield' artbook cover",
-      "a credit card in an image on a pink background"
+      "a cartoon with a man standing in a white suit",
+      "a drawing of a female vampire with sword",
+      "a man with a colored face and chest",
+      "a female figure dressed in black hat with swords and a star pendant",
+      "a man faces the camera and wears a device",
+      "an abstract colorful splashed stream of paint coming out of a notebook"
     ]
   },
   "set.memeDescription": {
@@ -4681,12 +4681,12 @@
     "description": "Popular internet memes paired with brief descriptions of their visual content",
     "total": 44,
     "examples": [
-      "ceiling cat meme - cat peering through hole in ceiling",
-      "expectation vs. reality meme - two images contrasting ideal and actual outcomes",
-      "dolan meme - poorly drawn donald duck with absurd captions",
       "american chopper argument meme - father and son yelling, throwing chair",
-      "ancient aliens guy meme - man with wild hair gesturing \"aliens",
-      "coffin dance meme - same as dancing pallbearers"
+      "felt cute might delete later meme - selfie caption, often used ironically",
+      "ceiling cat meme - cat peering through hole in ceiling",
+      "gibby on icarly \"i don't care if you broke your elbow\" meme - gibby responding callously",
+      "harlem shake meme - group suddenly dancing wildly to song",
+      "ancient aliens guy meme - man with wild hair gesturing \"aliens"
     ]
   },
   "set.meme": {
@@ -4695,12 +4695,12 @@
     "description": "Popular internet memes and viral image macros",
     "total": 44,
     "examples": [
-      "chad vs. virgin meme",
-      "crying michael jordan meme",
-      "bad luck brian meme",
-      "doge meme",
-      "confused math lady meme",
-      "dab meme"
+      "baby yoda meme",
+      "change my mind meme",
+      "american chopper argument meme",
+      "condescending wonka meme",
+      "harlem shake meme",
+      "ceiling cat meme"
     ]
   },
   "set.moviegenBench": {
@@ -4709,12 +4709,12 @@
     "description": "MovieGen Video Bench contains 1003 diverse prompts testing various aspects including human activities (motion, emotions), animals, nature/scenery, physics (fluids, gravity, collisions), and unusual subjects/activities. The prompts provide comprehensive coverage across high, medium and low motion scenarios.\n",
     "total": 1003,
     "examples": [
-      "A person making pottery from clay that changes colors with each touch.",
-      "A low-angle shot of a towering skyscraper against a blue sky, giving a sense of its immense height.",
-      "An over-the-shoulder perspective of a chef meticulously plating a dish in a bustling kitchen.",
-      "The mesmerizing dance of boiling water in a pot, with bubbles rising, bursting, and sending ripples across the surface.",
-      "A magical forest with trees that have faces and whisper to each other.",
-      "an adorable kangaroo wearing blue jeans and a white t shirt taking a pleasant stroll in Mumbai India during a winter storm"
+      "A haunted mansion with flickering candles and eerie shadows.",
+      "A cyclist powering up a steep hill in a road race.",
+      "a real girl franatically running a dense forest with bushes, trees, in rainy day, the animals are running after her and she is screaming and shouting",
+      "A high-speed video of raindrops hitting a puddle, causing ripples and splashes.",
+      "A fox wearing a pirate hat and eyepatch, steering a ship through a stormy sea.",
+      "Static camera shot. A dinasour running near some lions and chasing them away."
     ]
   },
   "set.parti": {
@@ -4723,12 +4723,12 @@
     "description": "PartiPrompts (P2) is a rich set of over 1600 prompts in English. P2 can be used to measure model capabilities across various categories and challenge aspects.\n",
     "total": 1632,
     "examples": [
-      "A high resolution photo of a large bowl of ramen. There are several origami boats in the ramen of different colors.",
-      "a child eating a birthday cake near some palm trees",
-      "a roast turkey being taken out of the oven",
-      "a cow eating a green leafy plant",
-      "a bamboo ladder",
-      "a politician giving a speech at a podium"
+      "an eagle swooping down to catch a mouse",
+      "A richly textured oil painting of a young badger delicately sniffing a yellow rose next to a tree trunk. A small waterfall can be seen in the background.",
+      "The Great Pyramid of Giza situated in front of Mount Everest",
+      "beautiful fireworks in the sky with red, white and blue",
+      "the United States flag next to the flag of Texas",
+      "a photograph of a blue porsche 356 coming around a bend in the road"
     ]
   },
   "sport.all": {
@@ -4737,12 +4737,12 @@
     "description": "Various athletic sports, gymnastics, and competitive physical activities",
     "total": 470,
     "examples": [
-      "roller hockey",
-      "deep-water soloing",
-      "field hockey",
-      "ice fishing",
-      "finswimming",
-      "basque pelota"
+      "freestyle bmx",
+      "laser tag",
+      "javelin throw",
+      "sumo",
+      "skydiving",
+      "air racing"
     ]
   },
   "thing.adjective": {
@@ -4751,12 +4751,12 @@
     "description": "Adjectives describing physical textures and material conditions",
     "total": 71,
     "examples": [
-      "silky",
-      "crinkled",
-      "dull",
-      "fuzzy",
-      "hard",
-      "mushy"
+      "flaky",
+      "pliable",
+      "springy",
+      "prickly",
+      "smoothed",
+      "worn"
     ]
   },
   "thing.armor": {
@@ -4765,12 +4765,12 @@
     "description": "Historical and modern protective armor, helmets, and tactical vests",
     "total": 171,
     "examples": [
-      "cabasset helmet",
-      "scale barding",
-      "plate mail",
-      "tassets",
-      "ringmail barding",
-      "kabuto helmet"
+      "surcoat",
+      "cabasset",
+      "dragon skin armor",
+      "gardbrace",
+      "combat helmet",
+      "corinthian helmet"
     ]
   },
   "thing.city": {
@@ -4779,12 +4779,12 @@
     "description": "Urban infrastructure, commercial buildings, and city street elements",
     "total": 216,
     "examples": [
-      "dentist",
-      "thrift store",
-      "bus",
-      "ambulance",
-      "alleyway",
-      "swimming pool"
+      "school",
+      "cafe",
+      "bar",
+      "botanical conservatory",
+      "fire escape",
+      "street sweeper"
     ]
   },
   "thing.everyday": {
@@ -4793,12 +4793,12 @@
     "description": "Common household objects, appliances, and everyday personal items",
     "total": 243,
     "examples": [
-      "sink",
-      "frying pan",
-      "desk lamp",
-      "oven",
-      "bottle opener",
-      "earrings"
+      "pillow",
+      "sofa",
+      "tarp",
+      "towel rack",
+      "roller",
+      "paper"
     ]
   },
   "thing.fabric": {
@@ -4807,12 +4807,12 @@
     "description": "Various natural and synthetic textiles and fabric materials",
     "total": 56,
     "examples": [
+      "felt",
       "fleece",
-      "elastane",
-      "merino wool",
-      "bamboo fabric",
-      "angora",
-      "alpaca"
+      "organza",
+      "duck cloth",
+      "crepe",
+      "taffeta"
     ]
   },
   "thing.fantasy": {
@@ -4821,12 +4821,12 @@
     "description": "Fantasy characters, magical items, and mythical creatures",
     "total": 146,
     "examples": [
-      "countermeasure",
-      "armor",
-      "sword",
-      "castle",
-      "dwarf",
-      "archer"
+      "goblins",
+      "castle wall",
+      "skeletons",
+      "elven princess",
+      "apprentice",
+      "elves"
     ]
   },
   "thing.furniture": {
@@ -4835,12 +4835,12 @@
     "description": "Various types of indoor and outdoor seating and storage furniture",
     "total": 58,
     "examples": [
-      "display cabinet",
-      "dining table",
-      "loveseat",
-      "bench",
-      "headboard",
-      "armchair"
+      "wingback chair",
+      "futon",
+      "end table",
+      "console table",
+      "eames chair",
+      "chesterfield sofa"
     ]
   },
   "thing.gadget": {
@@ -4849,12 +4849,12 @@
     "description": "Electronic devices, musical gadgets, and modern technological equipment",
     "total": 417,
     "examples": [
-      "massage chair",
-      "electronic organizer",
-      "electronic drum pad",
-      "3d scanner",
-      "access control system",
-      "electronic keyboard (computer input device)"
+      "ultrasonic pest repeller",
+      "hydroponics controller",
+      "nintendo switch",
+      "guitar amplifier",
+      "game console",
+      "label maker"
     ]
   },
   "thing.gemstone": {
@@ -4863,12 +4863,12 @@
     "description": "Precious and semi-precious gemstones and mineral crystals",
     "total": 59,
     "examples": [
-      "hiddenite",
-      "aventurine",
-      "jasper",
-      "nephrite jade",
-      "kunzite",
-      "onyx"
+      "azurite",
+      "chrysolite",
+      "demantoid",
+      "jadeite",
+      "hawk's eye",
+      "spinel"
     ]
   },
   "thing.icon": {
@@ -4877,12 +4877,12 @@
     "description": "Common digital interface icons and simple graphic symbols",
     "total": 132,
     "examples": [
-      "tennis",
-      "calendar",
-      "telescope",
-      "star",
-      "book",
-      "document"
+      "soccer",
+      "lock",
+      "magnifying glass",
+      "chess",
+      "download",
+      "headphones"
     ]
   },
   "thing.material": {
@@ -4891,12 +4891,12 @@
     "description": "Various raw materials, plastics, stones, and crafting substances",
     "total": 68,
     "examples": [
-      "bamboo",
-      "brass",
-      "limestone",
-      "concrete",
-      "gold",
-      "acrylic"
+      "steel",
+      "platinum",
+      "copper material",
+      "silver",
+      "plaster",
+      "concrete"
     ]
   },
   "thing.metal": {
@@ -4905,12 +4905,12 @@
     "description": "Various metallic elements, alloys, and metal finishes",
     "total": 273,
     "examples": [
-      "shibuichi",
-      "aluminum",
-      "polished stainless steel",
-      "matte brass",
-      "chromium",
-      "brushed steel"
+      "brushed bronze",
+      "hastelloy",
+      "cerium",
+      "chrome plating",
+      "copper-nickel",
+      "alnico"
     ]
   },
   "thing.office": {
@@ -4919,12 +4919,12 @@
     "description": "Financial tools, office supplies, and business-related items",
     "total": 68,
     "examples": [
+      "bank vault",
+      "stock certificate",
+      "monitor",
+      "desk lamp",
       "rubber stamp",
-      "computer mouse",
-      "folder",
-      "envelope",
-      "banknote",
-      "adding machine"
+      "hole punch"
     ]
   },
   "thing.pattern": {
@@ -4933,12 +4933,12 @@
     "description": "Decorative geometric, textile, and camouflage visual patterns",
     "total": 115,
     "examples": [
-      "botanical",
-      "kanoko",
-      "snake print",
-      "houndstooth",
-      "jacquard",
-      "arabesque"
+      "brocade",
+      "cow print",
+      "tortoiseshell",
+      "zigzag",
+      "buffalo check",
+      "starry night"
     ]
   },
   "thing.scary": {
@@ -4947,12 +4947,12 @@
     "description": "Creepy locations, paranormal entities, and horror-themed concepts",
     "total": 211,
     "examples": [
-      "wraiths",
-      "plague doctors",
-      "living nightmares",
-      "mists and fog",
-      "seances",
-      "phantom shadow"
+      "hidden rooms",
+      "whispers in the dark",
+      "black magic",
+      "disembodied laughter",
+      "blood curdling screams",
+      "nightmares"
     ]
   },
   "thing.sciFi": {
@@ -4961,12 +4961,12 @@
     "description": "Futuristic technology, AI systems, and science fiction transportation",
     "total": 204,
     "examples": [
-      "climate stabilization device",
-      "asteroid deflector device",
-      "gravity shield",
-      "mind mapping device",
-      "ai construction machine",
-      "autonomous robots"
+      "arc reactor",
+      "hoverbike",
+      "3d printing",
+      "mars terraforming machine",
+      "time machine",
+      "deep space data relay"
     ]
   },
   "thing.space": {
@@ -4975,12 +4975,12 @@
     "description": "Celestial bodies, nebulae, moons, stars, and cosmic phenomena",
     "total": 158,
     "examples": [
-      "galactic halo",
-      "star",
-      "europa",
-      "large magellanic cloud",
-      "hoag's object",
-      "iocaste"
+      "reflection nebula",
+      "kuiper belt",
+      "galaxies",
+      "black hole",
+      "dark cloud",
+      "euanthe"
     ]
   },
   "thing.summer": {
@@ -4989,12 +4989,12 @@
     "description": "Summer recreation items, beach gear, and outdoor accessories",
     "total": 70,
     "examples": [
-      "canoe",
-      "fishing pole",
+      "corn on the cob",
       "kite",
-      "seashell",
-      "baseball cap",
-      "sprinkler"
+      "portable speaker",
+      "tank top",
+      "pool float",
+      "campfire"
     ]
   },
   "thing.surfaceFinish": {
@@ -5003,12 +5003,12 @@
     "description": "Material surface treatments, textures, and manufacturing finishes",
     "total": 164,
     "examples": [
-      "zinc-plated",
-      "luster-glazed",
-      "distressed",
-      "lustre",
-      "nappa",
-      "machined"
+      "hammered",
+      "bead-blasted",
+      "crackled",
+      "machined",
+      "blued",
+      "bleached"
     ]
   },
   "thing.weapon": {
@@ -5017,12 +5017,12 @@
     "description": "Historical melee, ranged, and medieval combat weapons",
     "total": 55,
     "examples": [
-      "composite bow",
-      "zweihander",
-      "poignard",
-      "warhammer",
-      "mace",
-      "glaive"
+      "rapier",
+      "billhook",
+      "longsword",
+      "club",
+      "bow",
+      "greatsword"
     ]
   },
   "thing.woodType": {
@@ -5031,11 +5031,11 @@
     "description": "Various tree species and types of woodworking lumber",
     "total": 150,
     "examples": [
-      "lacewood",
-      "sandalwood",
-      "okoume",
-      "larch",
-      "lignum vitae",
+      "agarwood",
+      "kurogaki",
+      "ipe",
+      "anegre",
+      "cocobolo",
       "monkeypod"
     ]
   },
@@ -5045,12 +5045,12 @@
     "description": "Specific centuries spanning BC and AD historical timelines",
     "total": 37,
     "examples": [
-      "25th century",
-      "10th century",
-      "10th century bc",
-      "4th century bc",
-      "8th century",
-      "11th century"
+      "17th century",
+      "18th century",
+      "24th century",
+      "6th century bc",
+      "21st century",
+      "8th century bc"
     ]
   },
   "time.dayOfYear": {
@@ -5059,12 +5059,12 @@
     "description": "Specific calendar dates and notable days of the year",
     "total": 387,
     "examples": [
-      "september 12",
-      "july 13",
-      "august 7",
-      "august 19",
-      "december 7",
-      "april 10"
+      "december 12",
+      "december 16",
+      "june 11",
+      "december 6",
+      "june 27",
+      "february 21"
     ]
   },
   "time.decade": {
@@ -5073,11 +5073,11 @@
     "description": "Specific decades ranging from the 1800s to the 2050s",
     "total": 35,
     "examples": [
-      "1880s",
-      "60s",
-      "1870s",
-      "1990s",
-      "2040s",
+      "1810s",
+      "1820s",
+      "2020s",
+      "1830s",
+      "1860s",
       "1960s"
     ]
   },
@@ -5087,12 +5087,12 @@
     "description": "Historical periods, cultural eras, and specific global conflicts",
     "total": 118,
     "examples": [
-      "gilded age",
-      "dark ages",
-      "post-modern era",
-      "philippine revolution",
-      "belle époque",
-      "roaring twenties"
+      "crusades",
+      "italian renaissance",
+      "enlightenment",
+      "glorious revolution",
+      "high middle ages",
+      "french and indian war"
     ]
   },
   "time.festival": {
@@ -5101,12 +5101,12 @@
     "description": "Global cultural, religious, and film festivals and holidays",
     "total": 196,
     "examples": [
-      "hemis festival",
-      "fete des citrons",
-      "janmashtami",
-      "krampusnacht",
-      "hanami",
-      "sundance film festival"
+      "edinburgh fringe",
+      "hogmanay",
+      "lantern festival",
+      "epiphany",
+      "holi",
+      "durga puja"
     ]
   },
   "time.historicalEra": {
@@ -5115,12 +5115,12 @@
     "description": "Historical empires, dynasties, and major technological or cultural ages",
     "total": 148,
     "examples": [
-      "jin dynasty",
-      "iron age",
-      "jomon period",
-      "elizabethan era",
-      "edwardian era",
-      "ming dynasty"
+      "dot-com bubble",
+      "renaissance",
+      "muromachi period",
+      "colonial america",
+      "maurya empire",
+      "maratha empire"
     ]
   },
   "time.season": {
@@ -5129,12 +5129,12 @@
     "description": "Astronomical, cultural, commercial, agricultural, and natural seasons",
     "total": 241,
     "examples": [
-      "autumnal season",
-      "hockey season",
-      "berry season",
-      "festival season",
+      "ski season",
+      "hunting season",
+      "late autumn",
       "election season",
-      "legislative season"
+      "football season",
+      "fishing season"
     ]
   },
   "time.timeOfDay": {
@@ -5143,12 +5143,12 @@
     "description": "Specific times of day and associated lighting or atmospheric conditions",
     "total": 201,
     "examples": [
-      "local midnight",
-      "magic hour",
-      "green flash",
-      "midnight fog",
-      "evening chill",
-      "belt of venus"
+      "mid-morning",
+      "early night",
+      "crepuscule",
+      "early morning",
+      "breakfast time",
+      "evening dew"
     ]
   },
   "time.year": {
@@ -5157,12 +5157,12 @@
     "description": "Specific individual years spanning the 19th to 21st centuries",
     "total": 251,
     "examples": [
-      "2019",
-      "1964",
-      "1905",
-      "1850",
-      "1869",
-      "1865"
+      "1924",
+      "1907",
+      "2003",
+      "1908",
+      "1856",
+      "1976"
     ]
   },
   "typography.feature": {
@@ -5171,12 +5171,12 @@
     "description": "Typographic design features, spacing, and specific letterform characteristics",
     "total": 69,
     "examples": [
-      "double-story g",
-      "ball terminals",
-      "light weight",
-      "tight kerning",
-      "extended width",
-      "angular terminals"
+      "consistent stroke width",
+      "generous leading",
+      "playful swashes",
+      "ink traps",
+      "closed counters",
+      "overshooting"
     ]
   },
   "typography.fontType": {
@@ -5185,12 +5185,12 @@
     "description": "Typographic design movements and historical font classifications",
     "total": 62,
     "examples": [
-      "gothic sans typography",
-      "art deco typography",
-      "dadaist typography",
-      "rounded typography",
-      "comic typography",
-      "tuscan typography"
+      "condensed typography",
+      "grotesque typography",
+      "schwabacher typography",
+      "psychedelic typography",
+      "script typography",
+      "calligraphic typography"
     ]
   },
   "typography.font": {
@@ -5199,12 +5199,12 @@
     "description": "Specific named typefaces and popular font families",
     "total": 89,
     "examples": [
-      "montserrat font",
-      "merriweather sans font",
-      "tahoma font",
-      "lato font",
-      "ubuntu font",
-      "zapfino font"
+      "century gothic font",
+      "noto sans font",
+      "barlow font",
+      "roboto font",
+      "lora font",
+      "space mono font"
     ]
   },
   "typography.style": {
@@ -5213,12 +5213,12 @@
     "description": "Font weights, widths, and specific stylistic typeface variations",
     "total": 76,
     "examples": [
+      "expanded style font",
+      "italic style font",
       "book style font",
-      "display style font",
-      "all caps style font",
-      "book italic style font",
-      "compact style font",
-      "extra expanded style font"
+      "debossed style font",
+      "fat style font",
+      "compressed style font"
     ]
   },
   "typography.typefaceStyle": {
@@ -5227,12 +5227,12 @@
     "description": "Various font styles, historical typefaces, and typographic classifications",
     "total": 69,
     "examples": [
-      "bubble letter font",
-      "bastarda",
-      "display typeface",
-      "neo-grotesque",
-      "fraktur",
-      "bitmap"
+      "old style",
+      "inline",
+      "rotunda",
+      "egyptienne",
+      "expanded",
+      "geometric sans"
     ]
   },
   "typography.wordArt": {
@@ -5241,12 +5241,12 @@
     "description": "Textures, materials, and visual effects applied to text and typography",
     "total": 137,
     "examples": [
-      "diamond-encrusted text",
-      "warped text",
+      "beaded text",
+      "slanted text",
       "anaglyph 3d text",
+      "kaleidoscopic text",
       "cloudy text",
-      "concrete text",
-      "argyle text"
+      "floral text"
     ]
   },
   "vehicle.aircraft": {
@@ -5255,12 +5255,12 @@
     "description": "Various types of airplanes, helicopters, and specialized aerial vehicles",
     "total": 126,
     "examples": [
-      "stealth drone",
-      "stealth fighter",
-      "ekranoplan",
-      "tiltrotor",
-      "swing-wing aircraft",
-      "maritime patrol aircraft"
+      "passenger plane",
+      "airborne early warning aircraft",
+      "hang glider",
+      "flying saucer",
+      "experimental aircraft",
+      "ground effect vehicle"
     ]
   },
   "vehicle.car": {
@@ -5269,12 +5269,12 @@
     "description": "Specific modern car makes and models from various automotive manufacturers",
     "total": 329,
     "examples": [
-      "buick lacrosse",
-      "dacia logan",
-      "bentley mulsanne",
-      "audi a4",
-      "buick enclave",
-      "ferrari 488"
+      "ford ecosport",
+      "hyundai santa fe",
+      "jaguar xe",
+      "bmw x3",
+      "bmw i4",
+      "buick encore"
     ]
   },
   "vehicle.classicCar": {
@@ -5283,12 +5283,12 @@
     "description": "Specific vintage, antique, and classic car models with their production years",
     "total": 161,
     "examples": [
-      "1905 renault type ag",
-      "1982 lamborghini countach lp500 s",
-      "1930 cord l-29",
+      "1987 buick gnx",
+      "1918 ford model t",
+      "1929 cadillac series 341a",
       "1903 oldsmobile curved dash runabout",
-      "1926 duesenberg model a",
-      "1912 cadillac model thirty"
+      "1907 rolls-royce 40/50 hp",
+      "1933 pierce-arrow silver arrow"
     ]
   },
   "vehicle.famousCar": {
@@ -5297,12 +5297,12 @@
     "description": "Iconic cars and fictional vehicles from popular movies and film franchises",
     "total": 50,
     "examples": [
-      "christine from christine",
-      "professor zündapp from cars 2",
-      "optimus prime from transformers",
-      "the 1961 ferrari 250 gt california spyder from ferris bueller's day off",
-      "the a-team van from the a-team",
-      "the delorean from back to the future"
+      "the bluesmobile from the blues brothers",
+      "magnum's ferrari from magnum, p.i",
+      "eleanor from gone in 60 seconds",
+      "the ford explorer from jurassic world",
+      "mater from cars 2",
+      "finn mcmissile from cars 2"
     ]
   },
   "vehicle.fastCar": {
@@ -5311,12 +5311,12 @@
     "description": "Specific models of high-performance sports cars, supercars, and luxury vehicles",
     "total": 98,
     "examples": [
-      "audi rs6 avant",
-      "porsche 918 spyder",
-      "bugatti chiron",
-      "lamborghini aventador sv",
-      "rolls-royce phantom",
-      "ferrari fxx evoluzione"
+      "aston martin db11",
+      "maserati mc12",
+      "aston martin vanquish",
+      "bentley bentayga mulliner",
+      "bugatti veyron",
+      "ferrari daytona sp3"
     ]
   },
   "vehicle.motorcycle": {
@@ -5325,12 +5325,12 @@
     "description": "Various styles, classes, and specialized types of motorcycles and motorbikes",
     "total": 121,
     "examples": [
-      "land speed record motorcycle",
-      "dragster",
-      "hardtail",
-      "fire motorcycle",
-      "enduro bike",
-      "motocross"
+      "scrambler",
+      "tracker",
+      "sidecar",
+      "rat bike",
+      "super naked",
+      "speedway bike"
     ]
   },
   "vehicle.spacecraft": {
@@ -5339,12 +5339,12 @@
     "description": "Sci-fi spacecraft, starships, and specialized futuristic space vehicles",
     "total": 56,
     "examples": [
-      "flyby spacecraft",
-      "ark ship",
-      "orbital shuttle",
-      "mining barge",
+      "cargo hauler",
+      "research vessel",
+      "carrier",
+      "cargo hauler spacecraft",
       "fusion rocket ship",
-      "rover"
+      "colony transport"
     ]
   },
   "vehicle.type": {
@@ -5353,12 +5353,12 @@
     "description": "Broad categories of land, air, and water transportation vehicles",
     "total": 116,
     "examples": [
-      "lunar module",
-      "amphibious vehicle",
-      "ambulance",
-      "rickshaw",
-      "blimp",
-      "snow plow"
+      "zamboni",
+      "monorail",
+      "limousine",
+      "bulldozer",
+      "bicycle",
+      "yacht"
     ]
   },
   "vehicle.watercraft": {
@@ -5367,12 +5367,12 @@
     "description": "Various types of boats, ships, and marine vessels",
     "total": 188,
     "examples": [
-      "ark",
-      "scow",
-      "deck boat",
-      "jet boat",
-      "destroyer",
-      "galleon"
+      "amphibious vehicle",
+      "hospital ship",
+      "hovercraft",
+      "jukung",
+      "flyboat",
+      "clipper ship"
     ]
   },
   "videoGame.action": {
@@ -5381,12 +5381,12 @@
     "description": "In-game character actions, abilities, and mechanics in video games",
     "total": 314,
     "examples": [
-      "cloaking in invisibility",
-      "unlocking doors",
-      "kneeling",
-      "creating magical barriers",
-      "harnessing magical artifacts",
-      "manipulating time"
+      "buffing allies",
+      "stealing",
+      "slide jumping",
+      "scrapping items",
+      "riding",
+      "opening a door"
     ]
   },
   "videoGame.designer": {
@@ -5395,12 +5395,12 @@
     "description": "Names of prominent real-world video game designers and directors",
     "total": 68,
     "examples": [
-      "chris avellone",
       "masahiro sakurai",
-      "suda51",
-      "neil druckmann",
-      "yuji naka",
-      "ron gilbert"
+      "alex rigopulos",
+      "gunpei yokoi",
+      "amy hennig",
+      "ed boon",
+      "chris hecker"
     ]
   },
   "videoGame.engine": {
@@ -5409,12 +5409,12 @@
     "description": "Software frameworks and game engines used for developing video games",
     "total": 68,
     "examples": [
-      "xenko",
-      "redengine",
-      "renderware",
-      "eclipse engine",
-      "havok vision engine",
-      "mt framework"
+      "libgdx",
+      "adventure game studio",
+      "rage",
+      "marmalade sdk",
+      "source engine",
+      "renderware graphics"
     ]
   },
   "videoGame.game": {
@@ -5423,12 +5423,12 @@
     "description": "Titles of popular video game franchises and specific game releases",
     "total": 319,
     "examples": [
-      "the witcher 3: wild hunt - hearts of stone",
-      "call of duty: black ops",
-      "borderlands 2",
-      "candy crush",
-      "alan wake",
-      "call of duty: modern warfare 2"
+      "soulcalibur iii",
+      "starcraft",
+      "star wars: knights of the old republic",
+      "tekken 6",
+      "super smash bros",
+      "the elder scrolls v: skyrim"
     ]
   },
   "videoGame.region": {
@@ -5437,12 +5437,12 @@
     "description": "Fictional environments, biomes, and level themes found in video games",
     "total": 118,
     "examples": [
-      "desert region",
-      "cityscape kingdom",
-      "canyon region",
-      "mystic kingdom",
-      "canopy kingdom",
-      "undersea kingdom"
+      "sunset kingdom",
+      "ruins region",
+      "steampunk city",
+      "mushroom kingdom",
+      "mythical kingdom",
+      "rainbow isles"
     ]
   },
   "word.adjective": {
@@ -5451,12 +5451,12 @@
     "description": "Various descriptive adjectives ranging from anatomical to behavioral",
     "total": 4980,
     "examples": [
-      "cosmopolitan",
-      "speculative",
-      "innermost",
-      "fertile",
-      "appalling",
-      "enviable"
+      "frailest",
+      "consultative",
+      "rousing",
+      "elder",
+      "discretionary",
+      "dromozootic"
     ]
   },
   "word.adverb": {
@@ -5465,12 +5465,12 @@
     "description": "Assorted adverbs modifying actions, states, or qualities",
     "total": 1798,
     "examples": [
-      "wrongly",
-      "immeasurably",
-      "awful",
-      "bravely",
-      "cold",
-      "approximately"
+      "unknowingly",
+      "abroad",
+      "aloft",
+      "cheaply",
+      "accidentally",
+      "chronically"
     ]
   },
   "word.noun": {
@@ -5479,12 +5479,12 @@
     "description": "A diverse mix of concrete objects, animals, and abstract conceptual nouns",
     "total": 24389,
     "examples": [
-      "skeptic",
-      "hypostasis",
-      "breaking",
-      "eggnog",
-      "animosity",
-      "fen"
+      "celeriac",
+      "buy",
+      "deviation",
+      "visitors",
+      "ditty",
+      "donkey"
     ]
   },
   "word.onomatopoeia": {
@@ -5493,12 +5493,12 @@
     "description": "Sound-imitating words including animal noises, human vocalizations, and impact sounds",
     "total": 159,
     "examples": [
-      "chomp",
-      "ping",
-      "croak",
-      "honk",
-      "caw",
-      "bong"
+      "gobble",
+      "purr",
+      "bash",
+      "ahem",
+      "buzz",
+      "cough"
     ]
   },
   "word.verb": {
@@ -5507,12 +5507,12 @@
     "description": "Action words and verb forms across various tenses including past and gerunds",
     "total": 9950,
     "examples": [
-      "crooned",
-      "buckle",
-      "savoring",
-      "belts",
-      "guarantee",
-      "exhausts"
+      "distributes",
+      "erupting",
+      "scream",
+      "lull",
+      "lasts",
+      "lingers"
     ]
   }
 }

--- a/list-metadata.json
+++ b/list-metadata.json
@@ -1893,14 +1893,14 @@
     "title": "Bas-Lag names",
     "category": "fiction",
     "description": "Places, peoples, creatures, factions, and concepts from China Mieville's Bas-Lag fiction",
-    "total": 80,
+    "total": 147,
     "examples": [
-      "grindylow",
-      "torque",
-      "yagharek",
-      "bohemie",
-      "oriel",
-      "wyrmen"
+      "the militia",
+      "rust",
+      "perdido",
+      "scabmettlers",
+      "salacus fields",
+      "scar"
     ]
   },
   "fiction.bookOfTheNewSun": {
@@ -1909,12 +1909,12 @@
     "description": "Unique names from The Book of the New Sun (Gene Wolfe) — places, peoples, creatures, factions, and ships combined.",
     "total": 227,
     "examples": [
-      "the bellkeep",
-      "apheta",
-      "the water garden",
-      "blood bat",
-      "the village of the sorcerers",
-      "the septs"
+      "the curtain wall",
+      "the house of absolute",
+      "the picture room",
+      "the septs",
+      "the piteous gate",
+      "the manse"
     ]
   },
   "fiction.brokenEarth": {
@@ -1923,12 +1923,12 @@
     "description": "Unique names from The Broken Earth (N.K. Jemisin) — places, peoples, creatures, factions, and ships combined.",
     "total": 184,
     "examples": [
-      "the arctics",
-      "kilen",
-      "cuur",
-      "the flint node",
-      "the roggas",
-      "the coastles"
+      "the tuners",
+      "the tourmaline",
+      "the doctors",
+      "wire-chair",
+      "the coastles",
+      "the six-rings"
     ]
   },
   "fiction.conan": {
@@ -1937,12 +1937,12 @@
     "description": "Places, peoples, creatures, gods, and factions from Robert E. Howard's Conan and Hyborian Age",
     "total": 107,
     "examples": [
-      "scarlet citadel",
-      "red brotherhood",
-      "vilayet sea",
-      "thoth-amon",
-      "ophir",
-      "the tree of death"
+      "kushites",
+      "western ocean",
+      "shem",
+      "shemites",
+      "the tree of death",
+      "pirate isles"
     ]
   },
   "fiction.cthulhuMythos": {
@@ -1951,12 +1951,12 @@
     "description": "Unique names from Cthulhu Mythos — places, peoples, creatures, factions, and ships combined.",
     "total": 758,
     "examples": [
-      "smithtown",
-      "wells",
-      "the cult of the thousand young",
-      "stony brook",
-      "the chthonic society",
-      "the cult of yig"
+      "warwick",
+      "tcho-tcho",
+      "rat-thing",
+      "sefton asylum",
+      "shterot",
+      "shelter island"
     ]
   },
   "fiction.culture": {
@@ -1965,12 +1965,12 @@
     "description": "Starship names, orbitals, planets, systems, species, and factions from Iain M. Banks' Culture series",
     "total": 198,
     "examples": [
-      "size isn't everything",
-      "compromised integrity",
-      "flere-imsaho",
+      "a series of unlikely explanations",
+      "a ship with a view",
+      "good fences",
+      "jernau morat gurgeh",
       "demi-mind",
-      "falling outside the normal moral constraints",
-      "empiricist"
+      "charitable view, a"
     ]
   },
   "fiction.darkTower": {
@@ -1979,12 +1979,12 @@
     "description": "Places, peoples, creatures, factions, and powers from Stephen King's Dark Tower fiction",
     "total": 143,
     "examples": [
-      "aaron deepneau",
-      "outer-world",
-      "blue heaven",
-      "shardik",
-      "lud",
-      "alain johns"
+      "susannah dean",
+      "fedoras",
+      "balazar",
+      "calla sench",
+      "arthur eld",
+      "can ka no rey"
     ]
   },
   "fiction.dc": {
@@ -1993,12 +1993,12 @@
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from DC fiction",
     "total": 95,
     "examples": [
-      "blue beetle scarab",
-      "crime alley",
-      "intergang",
+      "parademon",
+      "justice society of america",
+      "apokolips",
       "bat-signal",
-      "batcave",
-      "green arrow"
+      "gcpd",
+      "hall of justice"
     ]
   },
   "fiction.discworld": {
@@ -2007,26 +2007,26 @@
     "description": "Places, peoples, creatures, and groups from Terry Pratchett's Discworld",
     "total": 143,
     "examples": [
-      "naiads",
-      "the rim",
-      "trolls",
-      "unseen university",
-      "sapient pearwood",
-      "the auditors"
+      "bes pelargic",
+      "chelys galactica",
+      "dimwell",
+      "sea troll",
+      "re-annual grape",
+      "sto kerrig"
     ]
   },
   "fiction.dragonBall": {
     "title": "Dragon Ball names",
     "category": "fiction",
     "description": "Places, species, transformations, artifacts, and powers from Dragon Ball",
-    "total": 77,
+    "total": 150,
     "examples": [
-      "trunks",
-      "capsule corporation",
-      "bulma",
-      "gohan",
-      "ginyu force",
-      "majin buu"
+      "mr. satan",
+      "namekians",
+      "launch",
+      "moro",
+      "red ribbon army",
+      "frieza force"
     ]
   },
   "fiction.dragonlance": {
@@ -2036,11 +2036,11 @@
     "total": 128,
     "examples": [
       "gasshan",
-      "magius",
-      "abanasinia",
-      "the gods of darkness",
-      "kapak draconian",
-      "dragon highlords"
+      "mount nevermind",
+      "laurana kanan",
+      "gilthanas kanan",
+      "hylo",
+      "knights of neraka"
     ]
   },
   "fiction.dune": {
@@ -2049,12 +2049,12 @@
     "description": "Planets, cities, factions, houses, and political groups from Frank Herbert's Dune universe",
     "total": 157,
     "examples": [
-      "alia atreides",
-      "golden path",
-      "chaumas",
-      "ix",
-      "burseg",
-      "coom"
+      "glosser rabban",
+      "sietch jacurutu",
+      "abomination",
+      "duncan idaho",
+      "butlerian jihad",
+      "alia atreides"
     ]
   },
   "fiction.elderScrolls": {
@@ -2063,12 +2063,12 @@
     "description": "Places, peoples, factions, creatures, artifacts, and deities from The Elder Scrolls",
     "total": 98,
     "examples": [
+      "anvil",
       "namira",
-      "oblivion",
-      "aldmer",
-      "alduin",
-      "bruma",
-      "solstheim"
+      "imperials",
+      "an-xileel",
+      "khajiit",
+      "boethiah"
     ]
   },
   "fiction.expanse": {
@@ -2077,12 +2077,12 @@
     "description": "Places, factions, ships, peoples, and technologies from The Expanse",
     "total": 126,
     "examples": [
-      "fred johnson",
-      "behemoth",
-      "leonidas",
-      "phoebe",
-      "luna",
-      "iapetus"
+      "bullet",
+      "freehold",
+      "mei meng",
+      "naomi nagata",
+      "bull",
+      "clarissa mao"
     ]
   },
   "fiction.forgottenRealms": {
@@ -2091,12 +2091,12 @@
     "description": "Places, peoples, factions, creatures, deities, and artifacts from the Forgotten Realms",
     "total": 85,
     "examples": [
-      "red wizards of thay",
-      "baldur's gate",
-      "kezef",
-      "auril",
+      "luskan hosts",
       "abeir-toril",
-      "drizzt"
+      "moonshae isles",
+      "tethyr",
+      "myrkul",
+      "zhentil keep"
     ]
   },
   "fiction.foundation": {
@@ -2105,12 +2105,12 @@
     "description": "Places, planets, factions, and groups from Isaac Asimov's Foundation universe",
     "total": 92,
     "examples": [
-      "61 cygni",
-      "arcturus",
       "rhodia",
-      "independents",
-      "echegaray",
-      "tithonus"
+      "association of independent trading worlds",
+      "aurora",
+      "ifni",
+      "first foundation",
+      "earth"
     ]
   },
   "fiction.gethen": {
@@ -2119,12 +2119,12 @@
     "description": "Planets, countries, towns, cultures, and organizations from Ursula K. Le Guin's Hainish Cycle and Earthsea",
     "total": 155,
     "examples": [
-      "taka",
-      "hare",
-      "atuan",
-      "handdara",
-      "eorviny",
-      "mesk"
+      "awabath",
+      "athshea",
+      "olleroo",
+      "gethen",
+      "bedap",
+      "sabul"
     ]
   },
   "fiction.gormenghast": {
@@ -2133,12 +2133,12 @@
     "description": "Unique names from Gormenghast (Mervyn Peake) — places, peoples, creatures, factions, and ships combined.",
     "total": 237,
     "examples": [
-      "the little kitchen",
-      "the lords of groan",
-      "the salt mines",
-      "the subjects",
-      "the nobles",
-      "the south wing"
+      "the schoolrooms",
+      "the death-owls",
+      "muzzlehatch's zoo",
+      "cheeta's pavilion",
+      "the courtyard",
+      "the bell-ringers"
     ]
   },
   "fiction.halo": {
@@ -2147,12 +2147,12 @@
     "description": "Places, factions, species, artifacts, ships, and installations from Halo",
     "total": 143,
     "examples": [
-      "spartan-ii",
-      "offensive bias",
-      "master chief",
-      "mauler",
-      "retriever sentinel",
-      "mjolnir armor"
+      "343 guilty spark",
+      "miranda keyes",
+      "jameson locke",
+      "glassing",
+      "gravity hammer",
+      "keyship"
     ]
   },
   "fiction.harryPotter": {
@@ -2161,12 +2161,12 @@
     "description": "Places, schools, houses, creatures, objects, and groups from the Harry Potter and Wizarding World fiction",
     "total": 93,
     "examples": [
-      "beedle the bard",
-      "hogsmeade",
+      "expecto patronum",
+      "demiguise",
+      "forbidden forest",
       "death eaters",
-      "scabbers",
-      "wizengamot",
-      "flobberworm"
+      "galleon",
+      "elder wand"
     ]
   },
   "fiction.hisDarkMaterials": {
@@ -2175,26 +2175,26 @@
     "description": "Places, peoples, creatures, and concepts from Philip Pullman's His Dark Materials",
     "total": 109,
     "examples": [
-      "subtle knife rift",
-      "lyra belacqua",
-      "john fane",
+      "armored bears",
+      "the authority",
       "cazimi",
-      "lord asriel",
-      "brytain"
+      "jerry",
+      "ma costa",
+      "cittagazze"
     ]
   },
   "fiction.hitchhikers": {
     "title": "Hitchhiker's Guide names",
     "category": "fiction",
     "description": "Places, species, spacecraft, and groups from The Hitchhiker's Guide to the Galaxy",
-    "total": 72,
+    "total": 257,
     "examples": [
-      "arkintoofle minor",
-      "argabuthon",
-      "lintillas",
-      "golgafrinchan ark fleet ship b",
-      "mice",
-      "milliways"
+      "sector",
+      "smash",
+      "rob mckenna",
+      "life the universe and everything",
+      "savlas",
+      "questular"
     ]
   },
   "fiction.hyperion": {
@@ -2203,12 +2203,12 @@
     "description": "Unique names from Hyperion Cantos — places, peoples, creatures, factions, and ships combined.",
     "total": 321,
     "examples": [
-      "centauri b",
-      "sol draconi septem",
-      "the ouster swarm",
-      "nevermore",
-      "the brotherhood of the muir",
-      "dolphin"
+      "cybrid-human hybrid",
+      "the home guard",
+      "pacem",
+      "prometheus bug",
+      "port romance",
+      "labyrinth builder"
     ]
   },
   "fiction.lotr": {
@@ -2217,12 +2217,12 @@
     "description": "Places, races, creatures, and unique names from J.R.R. Tolkien's Middle-earth",
     "total": 464,
     "examples": [
-      "westfold",
-      "varda",
-      "menegroth",
-      "radbug",
-      "isen river",
-      "turin turambar"
+      "archet",
+      "fili",
+      "ethril",
+      "beleriand",
+      "half-orcs",
+      "frodo baggins"
     ]
   },
   "fiction.magicMultiverse": {
@@ -2231,12 +2231,12 @@
     "description": "Planes, peoples, factions, creatures, and artifacts from Magic: The Gathering fiction",
     "total": 136,
     "examples": [
-      "liliana vess",
-      "multani",
-      "vedalken",
-      "eldrazi",
-      "dragonlord atarka",
-      "grixis"
+      "planeswalker",
+      "house dimir",
+      "azorius senate",
+      "ashiok",
+      "artificer",
+      "firja"
     ]
   },
   "fiction.malazan": {
@@ -2245,12 +2245,12 @@
     "description": "Places, peoples, creatures, and groups from the Malazan Book of the Fallen",
     "total": 98,
     "examples": [
-      "aren",
-      "barghast",
-      "tiste liosan",
-      "quon tali",
-      "tiste edur",
-      "the wastelands"
+      "shadowkeep",
+      "omtose phellack",
+      "shake",
+      "the first throne",
+      "stormriders",
+      "jacuruku"
     ]
   },
   "fiction.marvel": {
@@ -2259,54 +2259,54 @@
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction",
     "total": 97,
     "examples": [
-      "avengers mansion",
-      "infinity stones",
-      "aim",
-      "avengers",
-      "mind stone",
-      "annihilus"
+      "infinity gauntlet",
+      "fantastic four",
+      "the bifrost",
+      "new mutants",
+      "spider-man",
+      "the hand"
     ]
   },
   "fiction.massEffect": {
     "title": "Mass Effect names",
     "category": "fiction",
     "description": "Places, species, factions, ships, artifacts, and powers from Mass Effect",
-    "total": 79,
+    "total": 201,
     "examples": [
-      "hanar",
-      "mass effect field",
+      "mass effect",
+      "jaal",
+      "collector base",
       "crucible",
-      "mako",
-      "cerberus",
-      "samara"
+      "blood pack",
+      "batarians"
     ]
   },
   "fiction.narnia": {
     "title": "Narnia names",
     "category": "fiction",
     "description": "Places, peoples, creatures, and magical beings from C.S. Lewis's Chronicles of Narnia",
-    "total": 80,
+    "total": 160,
     "examples": [
-      "castle of miraz",
-      "world's end",
-      "dryads",
-      "fauns",
-      "salamanders",
-      "fords of beruna"
+      "tisroc",
+      "mr tumnus",
+      "mrs beaver",
+      "king lune",
+      "shallow lands",
+      "pattertwig"
     ]
   },
   "fiction.onePiece": {
     "title": "One Piece names",
     "category": "fiction",
     "description": "Places, factions, peoples, creatures, ships, powers, and treasures from One Piece",
-    "total": 80,
+    "total": 160,
     "examples": [
-      "enies lobby",
-      "jinbe",
-      "mariejois",
-      "alabasta",
-      "devil fruit",
-      "drum island"
+      "sunny",
+      "enel",
+      "bonney",
+      "brook",
+      "cp9",
+      "impel down"
     ]
   },
   "fiction.pokemon": {
@@ -2315,12 +2315,12 @@
     "description": "Regions, species, legendary Pokemon, teams, and artifacts from Pokemon",
     "total": 1137,
     "examples": [
-      "spoink",
-      "charmander",
-      "lumineon",
-      "flaaffy",
-      "love ball",
-      "cobalion"
+      "cobalion",
+      "exploud",
+      "eelektrik",
+      "cosmoem",
+      "kilowattrel",
+      "bruxish"
     ]
   },
   "fiction.starTrek": {
@@ -2329,12 +2329,12 @@
     "description": "Unique names from Star Trek — places, peoples, creatures, factions, and ships combined.",
     "total": 721,
     "examples": [
-      "j'naii",
-      "ss robert fox",
-      "karigan",
-      "bzzit khaht",
+      "sikaris",
+      "azati prime",
       "bolian",
-      "nausicaa"
+      "dakhur province",
+      "borg collective",
+      "capella iv"
     ]
   },
   "fiction.starWars": {
@@ -2343,26 +2343,26 @@
     "description": "Unique names from Star Wars — places, peoples, creatures, factions, and ships combined.",
     "total": 784,
     "examples": [
-      "lambda-class t-4a shuttle",
-      "marian",
-      "kel dor",
-      "negotiator",
-      "mos pelgo",
-      "neimoidian"
+      "colicoid",
+      "coruscant",
+      "advozse",
+      "the coruscant underworld police",
+      "dewback",
+      "bith"
     ]
   },
   "fiction.transformers": {
     "title": "Transformers names",
     "category": "fiction",
     "description": "Places, factions, species, artifacts, and groups from Transformers",
-    "total": 59,
+    "total": 350,
     "examples": [
-      "minicons",
-      "ratchet",
-      "autobots",
-      "megatron",
-      "quintessons",
-      "the allspark"
+      "great war",
+      "technobots",
+      "liokaiser",
+      "pitted",
+      "rewind",
+      "pious"
     ]
   },
   "fiction.warcraft": {
@@ -2371,12 +2371,12 @@
     "description": "Places, peoples, factions, creatures, artifacts, and powers from the Warcraft universe",
     "total": 91,
     "examples": [
-      "the bronze dragonflight",
-      "alleria",
-      "lordaeron",
-      "alterac",
-      "illidan",
-      "kul tiras"
+      "orgrimmar",
+      "the horde",
+      "northrend",
+      "shadowlands",
+      "titan-forged",
+      "ironforge"
     ]
   },
   "fiction.warhammer40k": {
@@ -2385,12 +2385,12 @@
     "description": "Unique names from Warhammer 40,000 — places, peoples, creatures, factions, and ships combined.",
     "total": 653,
     "examples": [
-      "the great rift",
-      "lucius",
-      "nicassar",
-      "perturabo",
-      "masque of the veiled path",
-      "hive fleet behemoth"
+      "de profundis",
+      "spear of the emperor",
+      "simulacra",
+      "slaanesh",
+      "tyranid warrior",
+      "vior'la sept"
     ]
   },
   "fiction.wheelOfTime": {
@@ -2399,40 +2399,40 @@
     "description": "Places, peoples, creatures, and groups from The Wheel of Time",
     "total": 109,
     "examples": [
-      "gholam",
-      "toman head",
-      "baerlon",
-      "to'raken",
-      "mayene",
-      "aridhol"
+      "s'redit",
+      "aridhol",
+      "arafel",
+      "whitecliff",
+      "deven ride",
+      "illian"
     ]
   },
   "fiction.witcher": {
     "title": "Witcher names",
     "category": "fiction",
     "description": "Places, kingdoms, schools, peoples, creatures, and objects from The Witcher",
-    "total": 81,
+    "total": 161,
     "examples": [
-      "harpy",
-      "aretuza",
-      "angren",
+      "the continent",
+      "eithne",
       "gors velen",
-      "ciri",
-      "feline school"
+      "harpy",
+      "dol blathanna",
+      "filippa"
     ]
   },
   "fiction.zelda": {
     "title": "Legend of Zelda names",
     "category": "fiction",
     "description": "Places, peoples, creatures, artifacts, and powers from The Legend of Zelda",
-    "total": 84,
+    "total": 149,
     "examples": [
-      "great fairy",
-      "divine beast vah rudania",
-      "dark world",
-      "hyrule field",
-      "farore",
-      "din"
+      "hilda",
+      "goddess harp",
+      "lanayru",
+      "impa",
+      "beedle",
+      "hylian shield"
     ]
   },
   "food.bakery": {
@@ -2441,12 +2441,12 @@
     "description": "Assorted baked goods including cakes, pies, pastries, and sweet breads",
     "total": 176,
     "examples": [
-      "pain au chocolat",
-      "eclairs",
-      "cassata",
-      "apple pie",
-      "æbleskive (apple slice)",
-      "chiffon cake"
+      "baci di dama (italian lady's kisses, traditional cookie)",
+      "baguette",
+      "wienerbrød (vienna bread)",
+      "tarte aux prunes",
+      "babka",
+      "fastelavnsbolle (shrove tuesday bun)"
     ]
   },
   "food.bbq": {
@@ -2455,12 +2455,12 @@
     "description": "Grilled meats, seafood, vegetables, and fruits typical of barbecue cooking",
     "total": 41,
     "examples": [
-      "grilled oysters",
+      "chicken wings",
+      "grilled peaches",
       "grilled romaine",
-      "steak",
-      "grilled zucchini",
-      "grilled shrimp skewers",
-      "smoked turkey leg"
+      "beer can chicken",
+      "hot dogs",
+      "burgers"
     ]
   },
   "food.beverage": {
@@ -2469,12 +2469,12 @@
     "description": "Various alcoholic and non-alcoholic drinks including cocktails, coffees, and teas",
     "total": 224,
     "examples": [
-      "atole",
+      "pina colada",
       "shandy",
-      "affogato",
-      "sazerac",
-      "cola",
-      "cherry cola"
+      "grape juice",
+      "club soda",
+      "green tea",
+      "london fog"
     ]
   },
   "food.bread": {
@@ -2483,12 +2483,12 @@
     "description": "A diverse global selection of traditional breads, biscuits, and baked rolls",
     "total": 269,
     "examples": [
-      "kulcha",
+      "pane ticinese",
       "pan de deificación",
-      "spelt bread",
-      "lompe",
-      "steamed bread",
-      "julekake"
+      "panettone",
+      "roti gambang",
+      "msemmen",
+      "mollete"
     ]
   },
   "food.breakfast": {
@@ -2497,12 +2497,12 @@
     "description": "Sweet and savory breakfast dishes including eggs, waffles, and avocado toast",
     "total": 86,
     "examples": [
-      "quiche",
-      "veggie florentine",
-      "blintzes",
-      "quiche lorraine",
-      "frittata",
-      "boiled eggs"
+      "muesli",
+      "omelette",
+      "huevos benedictos",
+      "greek yogurt with berries and honey",
+      "chia seed pudding",
+      "crab royale"
     ]
   },
   "food.cheese": {
@@ -2511,12 +2511,12 @@
     "description": "A wide variety of international cheeses from different regions and styles",
     "total": 515,
     "examples": [
-      "livarot",
-      "leyden",
-      "azeitão",
-      "coquetdale",
-      "olivet cendré",
-      "lyme bay"
+      "radamer",
+      "mish",
+      "pecorino crotonese",
+      "pepper jack",
+      "muenster",
+      "pozzetto"
     ]
   },
   "food.cocktail": {
@@ -2525,12 +2525,12 @@
     "description": "Classic and modern mixed alcoholic drinks and cocktails",
     "total": 153,
     "examples": [
-      "vesper",
-      "amaretto sour",
-      "pimm's cup",
-      "espresso martini",
-      "last word",
-      "air mail"
+      "casino",
+      "fitzgerald",
+      "lemon drop",
+      "white lady",
+      "negroni sbagliato",
+      "kir"
     ]
   },
   "food.cookingMethod": {
@@ -2539,12 +2539,12 @@
     "description": "Culinary techniques for preparing food, ranging from baking to dry aging",
     "total": 97,
     "examples": [
-      "canning",
-      "tempering",
-      "pasteurizing",
-      "oil roasting",
-      "torching",
-      "parching"
+      "browning",
+      "broiling",
+      "pit roasting",
+      "coddling",
+      "freeze-drying",
+      "confit"
     ]
   },
   "food.cuisine": {
@@ -2553,12 +2553,12 @@
     "description": "Specific regional and national culinary traditions from around the world",
     "total": 340,
     "examples": [
-      "maritime cuisine",
-      "nepalese cuisine",
-      "palestinian cuisine",
-      "oaxacan cuisine",
-      "maharashtrian cuisine",
-      "sarawakian cuisine"
+      "goan cuisine",
+      "eritrean cuisine",
+      "cajun cuisine",
+      "andalusian cuisine",
+      "bengali cuisine",
+      "acehnese cuisine"
     ]
   },
   "food.dessert": {
@@ -2567,12 +2567,12 @@
     "description": "Global sweet treats including cakes, puddings, pastries, and confections",
     "total": 174,
     "examples": [
-      "cranachan",
-      "affogato",
-      "carrot cake",
-      "mince pie",
-      "parfait",
-      "coconut macaroon"
+      "qatayef",
+      "alfajores",
+      "chocolate fondant",
+      "coconut macaroon",
+      "butter tart",
+      "baked alaska"
     ]
   },
   "food.drink": {
@@ -2581,12 +2581,12 @@
     "description": "Assorted beverages including sodas, juices, teas, milks, and alcoholic drinks",
     "total": 289,
     "examples": [
-      "whiskey",
-      "ouzo",
-      "mead",
-      "mai tai",
       "margarita",
-      "merlot"
+      "assam tea",
+      "absinthe",
+      "americano",
+      "cafecito",
+      "brandy"
     ]
   },
   "food.fast": {
@@ -2595,12 +2595,12 @@
     "description": "Global fast food and street food items including burgers, fries, and rolls",
     "total": 164,
     "examples": [
-      "crinkle cut fries",
+      "caramel milkshake",
       "egg rolls",
-      "gyoza",
-      "garlic fries",
-      "currywurst",
-      "siciliana pizza"
+      "sweet potato fries",
+      "pho",
+      "yakitori",
+      "goi cuon (summer rolls)"
     ]
   },
   "food.fruit": {
@@ -2609,12 +2609,12 @@
     "description": "Common and exotic fruits, berries, and melons from around the world",
     "total": 142,
     "examples": [
-      "ugli fruit",
-      "acerola",
-      "currant",
-      "blackcurrant",
-      "blackberry",
-      "cherry guava"
+      "damson",
+      "loquat",
+      "rowanberry",
+      "lychee",
+      "grapes",
+      "miracle fruit"
     ]
   },
   "food.herbSpice": {
@@ -2623,12 +2623,12 @@
     "description": "Various culinary herbs, spices, and seeds used for flavoring food",
     "total": 50,
     "examples": [
-      "paprika",
-      "sumac",
-      "green pepper",
-      "sichuan pepper",
       "basil",
-      "parsley"
+      "mint",
+      "rosemary",
+      "anise",
+      "chives",
+      "fennel seed"
     ]
   },
   "food.pastaShape": {
@@ -2637,12 +2637,12 @@
     "description": "Various types of traditional and novelty pasta shapes",
     "total": 145,
     "examples": [
-      "gramigna",
-      "spaghettini",
-      "marille",
-      "mostaccioli",
-      "passatelli",
-      "pici"
+      "fusilli avellinesi",
+      "rotini",
+      "sfoglini",
+      "rigatoncini",
+      "sedani",
+      "tripoline"
     ]
   },
   "food.platingStyle": {
@@ -2651,12 +2651,12 @@
     "description": "Artistic and structural techniques for arranging and presenting food on a plate",
     "total": 104,
     "examples": [
-      "kaiseki",
-      "family style",
-      "modern",
-      "cast-iron style",
-      "plated dessert",
-      "mediterranean style"
+      "bento box",
+      "architectural",
+      "mosaic style",
+      "smorgasbord",
+      "tasting menu style",
+      "sculptural"
     ]
   },
   "food.tea": {
@@ -2665,12 +2665,12 @@
     "description": "Specific varieties of traditional, herbal, and regional teas",
     "total": 193,
     "examples": [
-      "nilgiri",
-      "feverfew tea",
-      "blue tea",
-      "high mountain oolong",
-      "chun mee",
-      "jujube tea"
+      "kombucha",
+      "boldo tea",
+      "chrysanthemum tea",
+      "dandelion tea",
+      "awabancha",
+      "dandelion root tea"
     ]
   },
   "food.vegetable": {
@@ -2679,12 +2679,12 @@
     "description": "Various vegetables, legumes, squashes, and edible plant sprouts",
     "total": 266,
     "examples": [
-      "shallot",
-      "burdock root",
-      "hubbard squash",
-      "carrot",
-      "brussels sprouts",
-      "alfalfa sprouts"
+      "squash blossoms",
+      "acorn squash",
+      "fushimi pepper",
+      "gai lan",
+      "bottle gourd",
+      "cipollini onion"
     ]
   },
   "geography.city": {
@@ -2693,12 +2693,12 @@
     "description": "Specific global cities listed with their respective regions and countries",
     "total": 22953,
     "examples": [
-      "Goražde, Federation of Bosnia and Herzegovina, Bosnia and Herzegovina",
-      "Chachapoyas, Amazonas, Peru",
-      "Jaunpur, Uttar Pradesh, India",
-      "João Câmara, Rio Grande do Norte, Brazil",
-      "Itamarandiba, Minas Gerais, Brazil",
-      "Villa Gesell, Buenos Aires, Argentina"
+      "Petrogradka, St.-Petersburg, Russia",
+      "Conversano, Apulia, Italy",
+      "Loralai, Balochistān, Pakistan",
+      "Autlán de Navarro, Jalisco, Mexico",
+      "Forlì, Emilia-Romagna, Italy",
+      "Itō, Shizuoka, Japan"
     ]
   },
   "geography.country": {
@@ -2707,12 +2707,12 @@
     "description": "A diverse list of sovereign nations and countries around the world",
     "total": 199,
     "examples": [
-      "Kuwait",
-      "Croatia",
       "Brunei",
-      "Czechoslovakia",
-      "Honduras",
-      "Indonesia"
+      "Congo (Democratic Republic)",
+      "Botswana",
+      "Cyprus",
+      "Dominican Republic",
+      "Comoros"
     ]
   },
   "geography.ethnicGroup": {
@@ -2721,12 +2721,12 @@
     "description": "The following groups are commonly identified as \"ethnic groups\", as opposed to ethno-linguistic phyla, national groups, racial groups or similar.\n",
     "total": 1055,
     "examples": [
-      "kalmyks",
-      "banjara",
-      "chuanqing",
-      "newars",
-      "aragonese",
-      "buryats"
+      "silesians",
+      "kashubians",
+      "bororo",
+      "dhimal",
+      "cahuilla",
+      "kalinago"
     ]
   },
   "geography.language": {
@@ -2735,12 +2735,12 @@
     "description": "A list of language names (glossonyms)",
     "total": 609,
     "examples": [
-      "gilbertese",
-      "kurdish (southern)",
-      "dolgan",
-      "haida",
-      "assamese",
-      "aari"
+      "tübatulabal",
+      "hazāragī",
+      "herero",
+      "karenni",
+      "ik",
+      "hindko"
     ]
   },
   "geography.nationality": {
@@ -2749,12 +2749,12 @@
     "description": "Adjectives describing nationalities and citizenships from various countries",
     "total": 206,
     "examples": [
-      "honduran",
-      "singaporean",
-      "estonian",
-      "german",
-      "antiguan",
-      "beninese"
+      "malawian",
+      "irish",
+      "croatian",
+      "cuban",
+      "cambodian",
+      "canadian"
     ]
   },
   "geography.territory": {
@@ -2763,12 +2763,12 @@
     "description": "Global territories, dependencies, emirates, and non-sovereign geographic regions",
     "total": 79,
     "examples": [
-      "Réunion",
-      "Cocos (Keeling) Islands",
-      "Guam",
-      "Aruba",
-      "Antarctica",
-      "Johnston Atoll"
+      "Guadeloupe",
+      "American Samoa",
+      "Howland Island",
+      "Faroe Islands",
+      "Åland Islands",
+      "Guam"
     ]
   },
   "interaction.coupleNegative": {
@@ -2777,12 +2777,12 @@
     "description": "Toxic, emotional, and negative behavioral interactions between romantic partners",
     "total": 70,
     "examples": [
+      "feeling sad with each other",
+      "giving a cold stare",
+      "checking phone while being spoken to",
+      "having an argument",
       "accusing each other",
-      "snapping over a minor detail",
-      "criticizing each other's family",
-      "feeling guilty with each other",
-      "speaking with a sharp tongue",
-      "feeling abandoned by each other"
+      "feeling guilty with each other"
     ]
   },
   "interaction.couple": {
@@ -2791,12 +2791,12 @@
     "description": "Positive and negative relational dynamics and activities between couples",
     "total": 69,
     "examples": [
-      "holding hands across a table",
-      "showing compassion",
-      "mentorship",
       "holding a grudge",
-      "reconciliation",
-      "romance"
+      "having a bonding experience",
+      "support",
+      "mentoring a protégé",
+      "holding hands across a table",
+      "slow dancing"
     ]
   },
   "interaction.crowd": {
@@ -2805,12 +2805,12 @@
     "description": "Collective actions, events, and emotional responses experienced by large crowds",
     "total": 64,
     "examples": [
-      "attending a religious ceremony",
-      "protesting against injustice",
-      "clapping to a rhythm",
-      "celebrating a birthday",
-      "holding a concert",
-      "watching a play"
+      "holding a peaceful protest",
+      "dancing in a mosh pit",
+      "participating in a parade",
+      "participating in a tradition",
+      "celebrating a victory",
+      "holding a protest"
     ]
   },
   "interaction.danceStyle": {
@@ -2819,12 +2819,12 @@
     "description": "Diverse global dance genres, traditional styles, and modern rhythmic movements",
     "total": 266,
     "examples": [
-      "isicathamiya",
-      "tarraxinha",
-      "ballroom",
-      "horon",
-      "bachata",
-      "house dance"
+      "chicken dance",
+      "vals",
+      "modern dance",
+      "lezginka",
+      "kuchipudi",
+      "kompa"
     ]
   },
   "interaction.group": {
@@ -2833,12 +2833,12 @@
     "description": "Collaborative group activities ranging from mundane events to dramatic fictional scenarios",
     "total": 70,
     "examples": [
-      "rehearsing a theater play",
-      "taking part in a paranormal investigation",
-      "finding inner peace",
-      "becoming a superhero",
-      "competing in a trivia night",
-      "training for a marathon together"
+      "conducting a science experiment",
+      "throwing a big party",
+      "investigating a conspiracy",
+      "pursuing a dream",
+      "planning a wedding",
+      "performing a musical"
     ]
   },
   "interaction.individualDetailed": {
@@ -2847,12 +2847,12 @@
     "description": "Highly specific, multi-step physical actions and behavioral sequences performed by individuals",
     "total": 214,
     "examples": [
-      "adjusts glasses, squints at something in the distance, then nods in understanding",
-      "leans against a wall, folds arms, and then tilts head to the side to listen",
-      "furrows brow, rubs chin thoughtfully, and then nods in agreement",
-      "balances on one foot, hops a few times, and then switches to the other foot",
-      "clicks tongue, shakes head, and then tries again",
-      "checks wrist watch, sighs in frustration, and peers down the street"
+      "taps a spoon on the edge of a bowl, sets the spoon down, and then picks up the bowl to eat",
+      "points at something, gestures animatedly, and then laughs",
+      "kicks off shoes, wiggles toes, and then curls up on the couch",
+      "hiccups unexpectedly, covers mouth, and then laughs embarrassedly",
+      "cracks an egg into a bowl, tosses the shell in the trash, and then reaches for another egg",
+      "clicks a pen repeatedly, stops, and then begins to write"
     ]
   },
   "interaction.individual": {
@@ -2861,12 +2861,12 @@
     "description": "Simple, everyday physical gestures, adjustments, and actions performed by a single person",
     "total": 424,
     "examples": [
-      "sneaks up behind someone",
-      "crumples a piece of paper in frustration",
-      "combs beard with fingers",
-      "counts on fingers",
-      "gives a thumbs up",
-      "creeps down a hallway"
+      "raises eyebrows",
+      "rocks back and forth on heels",
+      "peeks around a corner",
+      "rolls over onto back",
+      "rubs back of neck",
+      "squishes play dough"
     ]
   },
   "interaction.martialArt": {
@@ -2875,12 +2875,12 @@
     "description": "Traditional and modern martial arts and combat systems from around the world",
     "total": 110,
     "examples": [
-      "ssireum",
-      "baguazhang",
-      "kali",
-      "canne de combat",
-      "hung gar",
-      "iaido"
+      "khuresh",
+      "mcmap",
+      "catch wrestling",
+      "bajutsu",
+      "daito-ryu aiki-jujutsu",
+      "jodo"
     ]
   },
   "keyword.detailed": {
@@ -2889,12 +2889,12 @@
     "description": "Descriptive adjectives used to prompt high-resolution, intricate, and textured artwork",
     "total": 58,
     "examples": [
-      "carefully-detailed",
-      "multifaceted",
-      "ultra-fine-detail",
+      "exquisitely-detailed",
       "lifelike",
-      "ultra-realistic",
-      "beautifully-rendered"
+      "stunningly-detailed",
+      "detailed",
+      "hyper-realistic",
+      "detailed picture"
     ]
   },
   "keyword.epic": {
@@ -2903,12 +2903,12 @@
     "description": "Evocative adjectives for generating dramatic, majestic, and awe-inspiring visual atmospheres",
     "total": 129,
     "examples": [
-      "majestic",
-      "unforgettable",
-      "awe-inspiring",
-      "gorgeous",
-      "intricate",
-      "exquisite"
+      "atmospheric",
+      "masterful",
+      "lifelike",
+      "empyrean",
+      "bombastic",
+      "illustrious"
     ]
   },
   "keyword.genre": {
@@ -2917,12 +2917,12 @@
     "description": "Sci-fi, historical, and punk-themed aesthetic art genres and styles",
     "total": 65,
     "examples": [
-      "mid-century",
+      "gothic",
+      "solarpunk",
       "victorian",
-      "neo-victorian",
-      "weird fiction",
-      "post-apocalyptic",
-      "retro-futurism"
+      "weird west",
+      "renaissance",
+      "post-apocalyptic"
     ]
   },
   "keyword.glitch": {
@@ -2931,12 +2931,12 @@
     "description": "Digital and analog visual artifacts, distortions, and glitch effects",
     "total": 56,
     "examples": [
-      "stutter",
-      "bug",
+      "image corruption",
+      "burn-in",
+      "screen tear",
       "scrambled signal",
-      "datamosh",
-      "interlacing",
-      "refraction"
+      "rgb split",
+      "static noise"
     ]
   },
   "keyword.modifier": {
@@ -2945,12 +2945,12 @@
     "description": "Keywords that modify the style of an image (Noodle Soup prompts)",
     "total": 88,
     "examples": [
-      "stippling",
-      "dutch golden age",
-      "graffiti",
-      "double exposure effect",
-      "calotype",
-      "fractalism"
+      "doge",
+      "realism",
+      "isometric projection",
+      "symbolism",
+      "synthwave",
+      "cottagecore"
     ]
   },
   "keyword.negative": {
@@ -2959,12 +2959,12 @@
     "description": "Negative prompt keywords for avoiding bad anatomy, artifacts, and low quality",
     "total": 90,
     "examples": [
-      "low-res",
+      "bad proportions",
       "asymmetry",
-      "double face",
-      "extra fingers",
-      "signature",
-      "surreal"
+      "blur",
+      "long neck",
+      "tacky",
+      "disconnected limbs"
     ]
   },
   "keyword.prayer": {
@@ -2973,12 +2973,12 @@
     "description": "Quality-enhancing prompt modifiers for high resolution and masterpiece renders",
     "total": 67,
     "examples": [
-      "unreal engine 5 render",
-      "advanced",
-      "cutting-edge",
+      "high-end",
+      "top-notch",
+      "octane render",
       "ultra-high definition",
-      "masterpiece",
-      "premium-quality"
+      "4k",
+      "stellar quality"
     ]
   },
   "keyword.trending": {
@@ -2987,12 +2987,12 @@
     "description": "Keywords referencing trending or featured artwork on popular portfolio websites",
     "total": 35,
     "examples": [
-      "trending on pixiv",
-      "trending on dribbble",
-      "featured on behance",
-      "trending on getty images",
       "trending on unsplash",
-      "zbrush central"
+      "trending on deviantart",
+      "trending on conceptartworld",
+      "featured on flickr",
+      "contest winner on artstation",
+      "featured on midjourney"
     ]
   },
   "keyword.unusual": {
@@ -3001,12 +3001,12 @@
     "description": "Adjectives describing weird, unique, unusual, or abnormal subjects",
     "total": 62,
     "examples": [
-      "eccentric",
-      "baffling",
       "unique",
-      "wild",
-      "rare",
-      "atypical"
+      "crazy",
+      "weird",
+      "nutty",
+      "puzzling",
+      "extra-terrestrial"
     ]
   },
   "music.artist": {
@@ -3015,12 +3015,12 @@
     "description": "Diverse musical artists and bands with distinct musical styles",
     "total": 114,
     "examples": [
-      "outkast",
-      "joanna newsom",
-      "erykah badu",
-      "billie holiday",
-      "alan stivell",
-      "grimes"
+      "massive attack",
+      "captain beefheart",
+      "laurie anderson",
+      "burial",
+      "portishead",
+      "the doors"
     ]
   },
   "music.bpm": {
@@ -3029,12 +3029,12 @@
     "description": "Various musical tempos measured in beats per minute",
     "total": 42,
     "examples": [
-      "50 bpm",
-      "280 bpm",
-      "80 bpm",
-      "150 bpm",
-      "85 bpm",
-      "100 bpm"
+      "105 bpm",
+      "170 bpm",
+      "140 bpm",
+      "260 bpm",
+      "145 bpm",
+      "190 bpm"
     ]
   },
   "music.composer": {
@@ -3043,12 +3043,12 @@
     "description": "Famous classical and contemporary music composers",
     "total": 190,
     "examples": [
-      "john dowland",
-      "jean-baptiste lully",
-      "joan tower",
-      "zhou long",
-      "johann stamitz",
-      "john cage"
+      "wojciech kilar",
+      "jan ladislav dussek",
+      "jean sibelius",
+      "mario davidovsky",
+      "louis andriessen",
+      "leoš janáček"
     ]
   },
   "music.drop": {
@@ -3057,12 +3057,12 @@
     "description": "Specific electronic dance music subgenre drops and rhythmic transitions",
     "total": 39,
     "examples": [
-      "uk garage speed garage bassline drop",
-      "deep house groove drop",
-      "hardstyle kick drop",
-      "trance uplifting drop",
-      "darkpsy intense hypnotic drop",
-      "drumstep fast drum drop"
+      "acid techno 303 squelch drop",
+      "glitch hop synth drop",
+      "progressive house melodic drop",
+      "techno minimal drop",
+      "minimal techno sub-bass rumble drop",
+      "synthwave retro gated snare drop"
     ]
   },
   "music.dynamic": {
@@ -3071,12 +3071,12 @@
     "description": "Musical tempo, dynamic, and articulation terms with their definitions",
     "total": 89,
     "examples": [
+      "col legno (using the wood of the bow to strike the strings)",
+      "ritenuto (immediately slower tempo)",
       "senza sordino (without mute)",
-      "con sordino (with mute)",
-      "glissando (sliding smoothly from one pitch to another)",
-      "crescendo poco a poco (gradually getting louder little by little)",
-      "brillante ma non troppo (brilliant but not too much)",
-      "brillante (brilliantly, with dazzling and sparkling quality)"
+      "grave (slow, solemn and serious)",
+      "animato (animated, lively and spirited)",
+      "con moto (with motion, a moderate and flowing tempo)"
     ]
   },
   "music.feature": {
@@ -3085,12 +3085,12 @@
     "description": "Specific instrumental, vocal, and atmospheric musical elements and techniques",
     "total": 206,
     "examples": [
-      "floating electronic arpeggiators",
-      "distorted synth bass drops",
-      "energetic percussion",
-      "acoustic guitars",
-      "fretless bass melodies",
-      "ethereal vocal falsettos"
+      "searing guitar leads",
+      "ornate piano melodies",
+      "lively accordion riffs",
+      "jazzy chord progressions",
+      "ornamental guitar solos",
+      "polyrhythms"
     ]
   },
   "music.genre": {
@@ -3099,12 +3099,12 @@
     "description": "Diverse music genres ranging from electronic and rock to folk",
     "total": 305,
     "examples": [
-      "experimental rock",
-      "gothic metal",
-      "noise rock",
-      "klezmer",
-      "jersey club",
-      "reggae"
+      "french house",
+      "chiptune",
+      "soca",
+      "boogie-woogie",
+      "boogie",
+      "christian hip-hop"
     ]
   },
   "music.harmony": {
@@ -3113,12 +3113,12 @@
     "description": "Various types of musical harmonies and chordal structures",
     "total": 38,
     "examples": [
-      "minor harmony",
-      "tonal harmony",
-      "microtonal harmony",
-      "vocal harmony",
-      "subdominant harmony",
-      "polyphonic harmony"
+      "gospel harmony",
+      "dominant harmony",
+      "contrapuntal harmony",
+      "diminished harmony",
+      "diatonic harmony",
+      "extended harmony"
     ]
   },
   "music.instrument": {
@@ -3127,12 +3127,12 @@
     "description": "Traditional, classical, and world music instruments",
     "total": 216,
     "examples": [
-      "toubeleki",
-      "cello",
-      "guitar",
-      "didgeridoo",
-      "hurdy-gurdy",
-      "french horn"
+      "cajón",
+      "kanun",
+      "balafon",
+      "mridangam",
+      "gamelan",
+      "fortepiano"
     ]
   },
   "music.key": {
@@ -3141,12 +3141,12 @@
     "description": "Major and minor musical keys",
     "total": 35,
     "examples": [
-      "a# minor",
-      "bb minor",
-      "eb major",
+      "gb major",
       "e minor",
       "a minor",
-      "g# minor"
+      "c minor",
+      "d major",
+      "d minor"
     ]
   },
   "music.melody": {
@@ -3155,12 +3155,12 @@
     "description": "Descriptive types of musical melodies with their definitions",
     "total": 94,
     "examples": [
-      "sighing melody (expressing a sense of longing or sadness)",
-      "brooding melody (dark, low-pitched, and contemplative)",
-      "harmonized melody (melody supported by accompanying harmonies)",
-      "descending melody (falling motion)",
-      "choral melody (sung by a choir or vocal ensemble)",
-      "ethereal melody (airy and otherworldly)"
+      "jazzy melody (incorporating jazz-style elements)",
+      "bouncy melody (lively, upbeat, and rhythmically syncopated)",
+      "cannon melody (melodic imitation at different times)",
+      "conjunct melody (stepwise motion)",
+      "flutter-tonguing melody (rapid fluttering articulation)",
+      "dreamy melody (ethereal, nostalgic, and gently drifting)"
     ]
   },
   "music.mode": {
@@ -3169,12 +3169,12 @@
     "description": "Various musical scales, modes, and traditional tonal systems",
     "total": 55,
     "examples": [
-      "pelog scale mode",
-      "pentatonic major mode",
-      "double harmonic scale mode",
-      "maqam bayati mode",
-      "half-whole diminished mode",
-      "lydian mode"
+      "acoustic scale mode",
+      "lydian dominant mode",
+      "ionian mode (major)",
+      "neapolitan minor mode",
+      "hungarian minor mode",
+      "persian scale mode"
     ]
   },
   "music.mood": {
@@ -3183,12 +3183,12 @@
     "description": "Emotional and atmospheric musical moods or vibes",
     "total": 117,
     "examples": [
-      "savage",
-      "exciting",
-      "dreamy",
-      "epic",
+      "evocative",
+      "gentle",
+      "delicate",
       "atmospheric",
-      "agitated"
+      "introspective",
+      "thrilling"
     ]
   },
   "music.musicGenre": {
@@ -3197,12 +3197,12 @@
     "description": "Diverse global music genres and subgenres",
     "total": 63,
     "examples": [
-      "acid jazz",
-      "kwaito",
-      "death metal",
-      "doom metal",
-      "chillwave",
-      "grime"
+      "amapiano",
+      "synthpop",
+      "bluegrass",
+      "trance",
+      "trip hop",
+      "doom metal"
     ]
   },
   "music.percussive": {
@@ -3211,12 +3211,12 @@
     "description": "Specific percussion instruments and percussive sound makers",
     "total": 145,
     "examples": [
-      "handpan",
-      "log drum mallet",
-      "surdo beater",
-      "cricket clicker",
-      "ride cymbal",
-      "bell tree"
+      "bamboo wind chimes",
+      "ratchet",
+      "drumstick",
+      "djembe slap",
+      "gong",
+      "frame drum"
     ]
   },
   "music.recording": {
@@ -3225,12 +3225,12 @@
     "description": "Various formats and styles of audio recordings",
     "total": 72,
     "examples": [
-      "spoken word recording",
-      "rehearsal recording",
-      "stereo recording",
-      "livestream concert recording",
-      "cassette recording",
-      "binaural recording"
+      "mashup recording",
+      "broadcast recording",
+      "demo reel recording",
+      "experimental recording",
+      "battle rap recording",
+      "cassette recording"
     ]
   },
   "music.rhythm": {
@@ -3239,12 +3239,12 @@
     "description": "Specific rhythmic patterns and timing structures in music",
     "total": 27,
     "examples": [
-      "broken rhythm",
-      "backbeat rhythm",
-      "polyrhythmic rhythm",
-      "straight rhythm",
       "cross rhythm",
-      "tresillo rhythm"
+      "driving rhythm",
+      "tresillo rhythm",
+      "offbeat rhythm",
+      "free rhythm",
+      "backbeat rhythm"
     ]
   },
   "music.songSection": {
@@ -3253,12 +3253,12 @@
     "description": "Structural components and sections of a musical composition",
     "total": 37,
     "examples": [
-      "tag",
-      "theme",
-      "ad-lib section",
+      "call and response",
+      "drop",
       "chorus",
-      "verse",
-      "interlude"
+      "pre-chorus",
+      "fade-out",
+      "variation"
     ]
   },
   "music.vocalStyle": {
@@ -3267,12 +3267,12 @@
     "description": "Specific vocal techniques, styles, and singing methods",
     "total": 187,
     "examples": [
-      "subharmonic singing",
-      "buccal speech",
-      "gorgheggio",
-      "diphonic singing",
-      "distorted vocals",
-      "gregorian chant"
+      "egressive singing",
+      "overtone singing",
+      "a cappella",
+      "choral singing",
+      "grunt",
+      "guttural"
     ]
   },
   "music.vocal": {
@@ -3281,12 +3281,12 @@
     "description": "Descriptive styles and textures of vocal performances",
     "total": 119,
     "examples": [
+      "belting vocals",
+      "screamed vocals",
+      "a cappella vocals",
+      "call-and-response vocals",
       "distorted shouts",
-      "soaring vocals",
-      "staccato vocals",
-      "harmonized whispers",
-      "rhythmic chant-singing",
-      "spoken word vocals"
+      "husky vocals"
     ]
   },
   "mythical.artifact": {
@@ -3295,12 +3295,12 @@
     "description": "Mythological, religious, and fictional magical items and artifacts",
     "total": 215,
     "examples": [
-      "pashupatastra",
-      "fragarach",
-      "djed pillar",
-      "cornucopia",
-      "brahmastra",
-      "ankh of life"
+      "seven-league boots",
+      "staff of hermes",
+      "sword of damocles",
+      "tyrfing",
+      "shears of atropos",
+      "shield of achilles"
     ]
   },
   "mythical.chinese": {
@@ -3309,12 +3309,12 @@
     "description": "Deities, creatures, and figures from Chinese mythology",
     "total": 83,
     "examples": [
-      "chang'e's rabbit (玉兔)",
-      "hou yi (后羿)",
-      "nine sons of the dragon (龍生九子)",
-      "di ku (帝嚳)",
-      "tu di gong (土地公)",
-      "he xiangu (何仙姑)"
+      "chang'e (嫦娥)",
+      "yinglong (應龍)",
+      "sun wukong (孫悟空)",
+      "chiyou's brothers (蚩尤兄弟)",
+      "taotie (饕餮)",
+      "kui xing (魁星)"
     ]
   },
   "mythical.dndRace": {
@@ -3323,12 +3323,12 @@
     "description": "Playable character races from Dungeons and Dragons",
     "total": 66,
     "examples": [
-      "gnoll",
-      "human",
-      "aven",
-      "changeling",
-      "firbolg",
-      "warforged"
+      "half-elf",
+      "aarakocra",
+      "bariaur",
+      "duergar",
+      "kobold",
+      "reborn"
     ]
   },
   "mythical.dragon": {
@@ -3337,12 +3337,12 @@
     "description": "Specific named dragons and dragon types from global mythologies",
     "total": 86,
     "examples": [
-      "macedonian lamja dragon",
-      "japanese ryujin dragon",
-      "irish ollipheist dragon",
-      "indonesian naga taksaka dragon",
-      "french guivre dragon",
-      "mapuche kai-kai filu dragon"
+      "chinese long dragon",
+      "russian zmei gorynych dragon",
+      "hungarian sárkány dragon",
+      "hebrew leviathan dragon",
+      "french gargouille dragon",
+      "french peluda dragon"
     ]
   },
   "mythical.magicTheGathering": {
@@ -3351,12 +3351,12 @@
     "description": "Specific card names from the game Magic: The Gathering",
     "total": 32340,
     "examples": [
-      "compost",
-      "make your own luck",
-      "channeled force",
-      "gala greeters",
-      "headstrong brute",
-      "lightwielder paladin"
+      "diregraf escort",
+      "katilda and lier",
+      "mind unbound",
+      "do or die",
+      "death-rattle oni",
+      "davvol's birthdaymobile"
     ]
   },
   "mythical.magicType": {
@@ -3365,12 +3365,12 @@
     "description": "Various schools, disciplines, and types of magical arts",
     "total": 53,
     "examples": [
-      "shadow magic",
-      "abjuration",
-      "enchantment",
-      "banishment",
-      "druidism",
-      "angelology"
+      "light magic",
+      "geomancy",
+      "sorcery",
+      "angelology",
+      "biomancy",
+      "cosmic magic"
     ]
   },
   "mythical.mythicalCreature": {
@@ -3379,12 +3379,12 @@
     "description": "Famous monsters and creatures from global mythology and folklore",
     "total": 61,
     "examples": [
-      "jinn",
-      "faun",
-      "troll",
-      "goblin",
-      "gargoyle",
-      "imp"
+      "banshee",
+      "sasquatch",
+      "nessie",
+      "fenrir",
+      "unicorn",
+      "pegasus"
     ]
   },
   "nature.areaOfNaturalBeauty": {
@@ -3393,12 +3393,12 @@
     "description": "Specific national parks, landmarks, and natural wonders worldwide",
     "total": 625,
     "examples": [
-      "bromo tengger semeru national park",
-      "deadvlei",
-      "chittorgarh fort",
-      "the jesuit missions of la santisima trinidad de parana",
-      "borobudur temple",
-      "bwindi impenetrable forest"
+      "the mont blanc",
+      "loma mountains national park",
+      "antelope canyon",
+      "monte fitz roy",
+      "mekong river delta",
+      "kerið crater lake"
     ]
   },
   "nature.biome": {
@@ -3407,12 +3407,12 @@
     "description": "Diverse ecological biomes and natural environmental zones",
     "total": 62,
     "examples": [
-      "benthic zone",
-      "bog",
-      "mediterranean forest",
-      "temperate coniferous forest",
-      "wetland",
-      "montane shrubland"
+      "hydrothermal vent",
+      "flooded grasslands",
+      "moorland",
+      "badlands",
+      "abyssal zone",
+      "savanna"
     ]
   },
   "nature.cloudType": {
@@ -3421,12 +3421,12 @@
     "description": "Specific meteorological cloud formations and types",
     "total": 40,
     "examples": [
-      "cumulonimbus",
-      "pileus",
-      "altocumulus",
-      "castellanus",
-      "radiatus",
-      "pyrocumulus"
+      "pileus cloud",
+      "contrail",
+      "nacreous cloud",
+      "fallstreak cloud",
+      "funnel cloud",
+      "arcus"
     ]
   },
   "nature.flower": {
@@ -3435,12 +3435,12 @@
     "description": "Various flowering plants, herbs, and ornamental garden blooms",
     "total": 547,
     "examples": [
-      "mimosa (mimosa pudica)",
-      "frost flower (helianthemum)",
-      "cuckoo flower (cardamine pratensis)",
-      "daylily (hemerocallis)",
-      "cosmos bipinnatus (cosmos bipinnatus)",
-      "bromeliad (bromeliaceae)"
+      "flying duck orchid",
+      "butterfly pea (clitoria ternatea)",
+      "chinese lantern (physalis alkekengi)",
+      "black bat flower (tacca chantrieri)",
+      "bee orchid",
+      "alkanet (anchusa)"
     ]
   },
   "nature.fungus": {
@@ -3449,12 +3449,12 @@
     "description": "Assorted species of wild mushrooms and fungi",
     "total": 214,
     "examples": [
-      "magpie inkcap mushroom",
-      "earth star fungus",
-      "brown roll-rim mushroom",
-      "common stump brittlestem mushroom",
-      "lion shield mushroom",
-      "honey fungus"
+      "shaggy scalycap mushroom",
+      "enoki mushroom",
+      "butter cap mushroom",
+      "chanterelle mushroom",
+      "chaga mushroom",
+      "bleeding fairy helmet mushroom"
     ]
   },
   "nature.gemstone": {
@@ -3463,12 +3463,12 @@
     "description": "Various precious gemstones, crystals, and mineral specimens",
     "total": 375,
     "examples": [
-      "tahitian pearl",
-      "apache tear",
-      "goethite",
-      "alabaster",
-      "bixbyite",
-      "black opal"
+      "grandidierite",
+      "black spinel",
+      "arsenopyrite",
+      "augelite",
+      "apophyllite",
+      "hambergite"
     ]
   },
   "nature.landscape": {
@@ -3477,12 +3477,12 @@
     "description": "Geological formations and large-scale geographical landscape features",
     "total": 51,
     "examples": [
+      "butte",
+      "arch",
+      "plateau",
+      "cove",
       "atoll",
-      "cave",
-      "geyser",
-      "beach",
-      "floodplain",
-      "butte"
+      "sinkhole"
     ]
   },
   "nature.mineral": {
@@ -3491,12 +3491,12 @@
     "description": "Specific mineral specimens, crystals, and semi-precious stones",
     "total": 275,
     "examples": [
+      "anorthite",
       "labradorite",
-      "opal",
-      "realgar",
-      "magnesite",
-      "beryl",
-      "phenakite"
+      "turquoise",
+      "pyrophyllite",
+      "jadeite",
+      "microcline"
     ]
   },
   "nature.moonPhase": {
@@ -3505,12 +3505,12 @@
     "description": "Traditional, seasonal, and descriptive names for lunar phases",
     "total": 117,
     "examples": [
-      "storm moon",
-      "fruit moon",
-      "dyad moon",
-      "grass moon",
-      "crow moon",
-      "dyer moon"
+      "ivy moon",
+      "waxing crescent",
+      "bright moon",
+      "egg moon",
+      "chaste moon",
+      "first quarter"
     ]
   },
   "nature.naturalPhenomenon": {
@@ -3519,12 +3519,12 @@
     "description": "Rare atmospheric, meteorological, and natural optical phenomena",
     "total": 45,
     "examples": [
-      "solar eclipse",
+      "murmuration",
+      "fata morgana",
+      "aurora australis",
+      "blue jets",
       "afterglow",
-      "catatumbo lightning",
-      "fog bow",
-      "frost flowers",
-      "whirlpool"
+      "solar eclipse"
     ]
   },
   "nature.plant": {
@@ -3533,12 +3533,12 @@
     "description": "Common indoor houseplants and decorative potted foliage",
     "total": 55,
     "examples": [
-      "swiss cheese plant",
-      "umbrella tree",
-      "monstera",
-      "sempervivum",
-      "begonia",
-      "air plant"
+      "zz plant",
+      "air plant",
+      "dieffenbachia",
+      "succulent",
+      "maranta",
+      "bonsai"
     ]
   },
   "nature.sceneModifier": {
@@ -3547,12 +3547,12 @@
     "description": "Atmospheric conditions, weather, and mood modifiers for scenes",
     "total": 49,
     "examples": [
-      "eerie",
-      "peaceful",
-      "frost-covered",
-      "drizzle",
-      "moss-draped",
-      "windswept"
+      "hurricane",
+      "foggy",
+      "glistening",
+      "aurora",
+      "apocalyptic",
+      "peaceful"
     ]
   },
   "nature.scene": {
@@ -3561,12 +3561,12 @@
     "description": "Diverse natural environments, biomes, and landscape settings",
     "total": 84,
     "examples": [
+      "cliffs",
       "beach",
-      "river",
-      "plains",
-      "castle",
-      "sinkhole",
-      "rocky outcrop"
+      "long grass",
+      "fjord",
+      "lake",
+      "estuary"
     ]
   },
   "nature.sky": {
@@ -3575,12 +3575,12 @@
     "description": "Specific sky conditions, times of day, and cloud formations",
     "total": 198,
     "examples": [
-      "metallic sky",
+      "typhoon sky",
+      "asperity cloud sky",
+      "gloaming sky",
       "copper dawn sky",
       "fogbow sky",
-      "full moon sky",
-      "golden sunset sky",
-      "amber sky"
+      "iridescent cloud sky"
     ]
   },
   "nature.texture": {
@@ -3589,12 +3589,12 @@
     "description": "Assorted natural and artificial surface textures and patterns",
     "total": 167,
     "examples": [
-      "lichen-covered rock",
-      "mottled fabric",
-      "fossilized limestone",
-      "fabric folds",
-      "velvet",
-      "paisley fabric"
+      "iridescent beetle wing",
+      "stained glass",
+      "weathered sandstone",
+      "shattered glass",
+      "porous volcanic rock",
+      "wasp nest paper"
     ]
   },
   "nature.treeType": {
@@ -3603,12 +3603,12 @@
     "description": "Various species of deciduous, coniferous, and tropical trees",
     "total": 71,
     "examples": [
-      "sugar maple",
-      "alder",
-      "western red cedar",
-      "spruce",
-      "silver birch",
-      "poplar"
+      "quaking aspen",
+      "coast redwood",
+      "aspen",
+      "eucalyptus",
+      "date palm",
+      "ebony"
     ]
   },
   "nature.tree": {
@@ -3617,12 +3617,12 @@
     "description": "Assorted tree species, fruiting trees, and woody plants",
     "total": 158,
     "examples": [
-      "fraser fir",
-      "monkey puzzle tree",
-      "white ash",
-      "virginia creeper",
-      "southern redcedar",
-      "scarlet oak"
+      "chestnut",
+      "arizona cypress",
+      "tamarack",
+      "plum",
+      "magnolia",
+      "persimmon"
     ]
   },
   "nature.tropicalHouseplant": {
@@ -3631,12 +3631,12 @@
     "description": "Tropical flowering plants, orchids, and decorative botanicals",
     "total": 104,
     "examples": [
-      "gomphrena",
-      "odontoglossum",
-      "sinningia",
-      "amaranthus",
       "codiaeum",
-      "schefflera"
+      "euphorbia",
+      "abutilon",
+      "dieffenbachia",
+      "amaranthus",
+      "chamaedorea"
     ]
   },
   "nature.waterBody": {
@@ -3645,12 +3645,12 @@
     "description": "Various types of natural and artificial water formations",
     "total": 109,
     "examples": [
+      "hot spring",
       "anabranch",
-      "bight",
-      "bourne",
-      "lake",
-      "cenote",
-      "lagoon"
+      "gulf",
+      "loch",
+      "headwaters",
+      "liman"
     ]
   },
   "nature.weather": {
@@ -3659,12 +3659,12 @@
     "description": "Meteorological events, cloud types, and severe weather conditions",
     "total": 156,
     "examples": [
-      "snowy",
-      "black ice",
-      "drizzle",
-      "drought",
-      "glaze",
-      "cumulus clouds"
+      "altostratus clouds",
+      "overcast",
+      "heat lightning",
+      "virga",
+      "snowdrift",
+      "snow squall"
     ]
   },
   "nature.wood": {
@@ -3673,11 +3673,11 @@
     "description": "Specific types of hardwood and softwood timber materials",
     "total": 66,
     "examples": [
-      "snakewood",
-      "cedar",
-      "bamboo",
-      "santos mahogany",
-      "macassar ebony",
+      "ironwood",
+      "iroko",
+      "jatoba",
+      "hemlock",
+      "ipe",
       "alder"
     ]
   },
@@ -3687,12 +3687,12 @@
     "description": "Various global and regional spoken accents and dialects",
     "total": 126,
     "examples": [
-      "persian",
-      "ukrainian",
+      "yiddish",
       "irish",
-      "multicultural london english",
-      "belfast",
-      "australian"
+      "estuary",
+      "bengali",
+      "punjabi",
+      "swiss"
     ]
   },
   "people.beautifulFeminine": {
@@ -3701,12 +3701,12 @@
     "description": "Adjectives describing feminine beauty, grace, and physical attractiveness",
     "total": 48,
     "examples": [
-      "curvaceous",
-      "stunning",
-      "fashionable",
-      "gorgeous",
+      "pretty",
+      "stylish",
       "attractive",
-      "splendid"
+      "fashionable",
+      "graceful",
+      "resplendent"
     ]
   },
   "people.beautifulMasculine": {
@@ -3715,12 +3715,12 @@
     "description": "Personality traits and physical characteristics associated with masculine appeal",
     "total": 106,
     "examples": [
-      "soft skin",
-      "rugged",
+      "dark skin",
+      "in the moment",
+      "at ease",
       "thick, dark hair",
-      "polished",
-      "firm skin",
-      "intense"
+      "toned",
+      "considerate"
     ]
   },
   "people.bodyType": {
@@ -3729,12 +3729,12 @@
     "description": "Detailed descriptions of various human body shapes, builds, and proportions",
     "total": 115,
     "examples": [
-      "smaller upper body, wider hips and thighs",
+      "petite frame with curves",
+      "very fat with a robust physique",
+      "slender frame with delicate bone structure",
+      "tall, thin build",
       "pear-shaped lower body with toned upper body",
-      "narrow shoulders, wider hips and thighs",
-      "straight up and down, similar to rectangular shape",
-      "shoulders wider than hips, tapers down",
-      "athletic and toned with defined abs"
+      "triangle shape with muscular legs"
     ]
   },
   "people.celebrity": {
@@ -3743,12 +3743,12 @@
     "description": "Famous actors, singers, influencers, and members of British royalty",
     "total": 646,
     "examples": [
-      "marion cotillard",
-      "jojo",
-      "chris pine",
-      "clint eastwood",
-      "christina aguilera",
-      "charli xcx"
+      "benedict cumberbatch",
+      "sara underwood",
+      "bryce dallas howard",
+      "julia garner",
+      "emily bett rickards",
+      "christina hendricks"
     ]
   },
   "people.common": {
@@ -3757,12 +3757,12 @@
     "description": "Broad age groups, life stages, and general demographic categories",
     "total": 34,
     "examples": [
-      "young woman",
       "schoolboy",
-      "teenager",
-      "millennial",
-      "schoolgirl",
-      "gen-zer"
+      "adolescent",
+      "adult",
+      "person",
+      "baby",
+      "baby boomer"
     ]
   },
   "people.couple": {
@@ -3771,12 +3771,12 @@
     "description": "Various romantic, platonic, and professional two-person relationship dynamics",
     "total": 36,
     "examples": [
-      "double date",
-      "colleagues",
-      "study partners",
-      "partners",
-      "roommates",
-      "pair"
+      "dating partners",
+      "friends",
+      "dance partners",
+      "newlyweds",
+      "husband and wife",
+      "acquaintances"
     ]
   },
   "people.dance": {
@@ -3785,12 +3785,12 @@
     "description": "Traditional, cultural, and modern dance styles from around the world",
     "total": 119,
     "examples": [
-      "maypole dance",
-      "robot dance",
-      "sidi goma dance",
-      "odissi dance",
+      "merengue",
       "ballroom dance",
-      "sattriya dance"
+      "cumbia",
+      "jazz dance",
+      "finnish tango",
+      "butoh dance"
     ]
   },
   "people.expression": {
@@ -3799,12 +3799,12 @@
     "description": "Highly detailed descriptions of facial expressions and emotional body language",
     "total": 471,
     "examples": [
-      "weeping openly with streams of tears",
-      "sardonic laugh with head tilted and eyes narrowed",
-      "sideways head tilt with a slight smile",
-      "slight frown with one eyebrow raised questioningly",
-      "scowl with furrowed brow and slightly bared teeth",
-      "restrained, emotionless expression with alert eyes"
+      "tittering behind a raised hand with eyes darting around",
+      "nervous giggle with blushing cheeks and eyes looking away",
+      "open-mouthed laugh with thrown-back head and closed eyes",
+      "blank stare with slightly parted lips and a relaxed brow",
+      "goofy smile with crossed eyes and stuck-out tongue",
+      "lip trembling, on the verge of tears"
     ]
   },
   "people.eyeColor": {
@@ -3813,12 +3813,12 @@
     "description": "Natural and fantasy eye colors including gem-like and vivid shades",
     "total": 46,
     "examples": [
-      "mint green eyes",
-      "deep brown eyes",
-      "sapphire eyes",
-      "golden-brown eyes",
-      "light blue eyes",
-      "amber eyes"
+      "royal blue eyes",
+      "aquamarine eyes",
+      "chocolate brown eyes",
+      "dark brown eyes",
+      "charcoal eyes",
+      "blue eyes"
     ]
   },
   "people.festival": {
@@ -3827,12 +3827,12 @@
     "description": "Major international cultural, religious, and seasonal festivals and holidays",
     "total": 59,
     "examples": [
-      "albuquerque international balloon fiesta",
-      "holi",
-      "st. patrick's day",
-      "valentine's day",
-      "dussehra",
-      "hanukkah"
+      "calgary stampede",
+      "baisakhi",
+      "festival of colors",
+      "cherry blossom festival",
+      "diwali",
+      "carnival"
     ]
   },
   "people.group": {
@@ -3841,12 +3841,12 @@
     "description": "Collective nouns and terms for various groups or gatherings of people",
     "total": 71,
     "examples": [
-      "company",
-      "congregation",
-      "brigade",
-      "crew",
-      "guild",
-      "community"
+      "unit",
+      "fans",
+      "clique",
+      "assembly",
+      "ensemble",
+      "caravan"
     ]
   },
   "people.hairstyle": {
@@ -3855,12 +3855,12 @@
     "description": "Diverse haircuts, styling techniques, and hair textures for men and women",
     "total": 58,
     "examples": [
-      "bob cut",
+      "undercut",
+      "cornrows",
       "perm",
-      "beehive",
-      "messy bun",
-      "pageboy",
-      "beach waves"
+      "quiff",
+      "bantu knots",
+      "french braid"
     ]
   },
   "people.hobby": {
@@ -3869,12 +3869,12 @@
     "description": "Wide range of creative, physical, and intellectual hobbies and interests",
     "total": 291,
     "examples": [
-      "listening to music",
-      "urban farming",
-      "stand-up comedy",
-      "videography",
-      "conservation",
-      "animation"
+      "painting",
+      "hunting",
+      "herbalism",
+      "kite flying",
+      "ice skating",
+      "engraving"
     ]
   },
   "people.job": {
@@ -3883,12 +3883,12 @@
     "description": "Various professional occupations, roles, and employment titles",
     "total": 612,
     "examples": [
-      "mechanic",
-      "parts clerk",
-      "landscape architect",
-      "department manager",
+      "waiter/waitress",
+      "able-bodied seaman",
+      "fire inspector",
+      "computer programmer",
       "broadcaster",
-      "receptionist assistant"
+      "manufacturing engineer"
     ]
   },
   "people.makeupStyle": {
@@ -3897,11 +3897,11 @@
     "description": "Historical, trendy, and artistic makeup styles and cosmetic techniques",
     "total": 73,
     "examples": [
-      "feline flick",
-      "strobing",
-      "body painting",
-      "cat eye makeup",
-      "clown makeup",
+      "metallic makeup",
+      "flawless matte",
+      "drag makeup",
+      "foxy eye makeup",
+      "gothic makeup",
       "avant-garde makeup"
     ]
   },
@@ -3911,12 +3911,12 @@
     "description": "Specific camera angles, body positioning, and framing for portrait photography",
     "total": 45,
     "examples": [
-      "lying down",
-      "close-up",
-      "sitting on stairs",
-      "over-the-shoulder glance",
-      "chin resting on hand",
-      "propped up on one hand (sitting or standing)"
+      "against a wall",
+      "leaning back against a railing",
+      "sitting",
+      "crouched portrait",
+      "hand on hip",
+      "lying on their back"
     ]
   },
   "people.pose": {
@@ -3925,12 +3925,12 @@
     "description": "Dynamic body postures, gestures, and physical actions for characters",
     "total": 201,
     "examples": [
-      "standing on one leg with other leg bent at the knee",
-      "bowing",
-      "crouching down with hands on ground in front of body",
-      "leaning backward with one leg crossed in front of the other",
-      "kneeling on both knees",
-      "curled up"
+      "perched",
+      "curled up",
+      "leaning against a wall",
+      "kneeling with both knees on ground and hands clasped in front of body",
+      "leaning against a railing or fence",
+      "holding hands in prayer position"
     ]
   },
   "people.profession": {
@@ -3939,12 +3939,12 @@
     "description": "Specific historical, scientific, and specialized professions and trades",
     "total": 60,
     "examples": [
-      "beekeeper",
-      "shipwright",
-      "curator",
-      "geologist",
-      "watchmaker",
-      "lepidopterist"
+      "baker",
+      "archivist",
+      "judge",
+      "lepidopterist",
+      "lighthouse keeper",
+      "tanner"
     ]
   },
   "photography.apertureLook": {
@@ -3953,12 +3953,12 @@
     "description": "Photographic effects related to bokeh, depth of field, focus, and lens flares",
     "total": 52,
     "examples": [
-      "glow effect",
-      "anamorphic bokeh",
-      "f/16 look",
+      "infinite focus",
+      "out of focus",
+      "hyperfocal focus",
+      "shallow depth of field",
       "f/1.4 creamy background",
-      "f/1.2 look",
-      "razor-sharp focus"
+      "rack focus"
     ]
   },
   "photography.cameraMovement": {
@@ -3967,12 +3967,12 @@
     "description": "Cinematography terms for dynamic camera movements, rigs, and tracking shots",
     "total": 50,
     "examples": [
+      "hyperlapse",
+      "shaky cam",
+      "tracking shot",
+      "slow zoom",
       "dutch tilt movement",
-      "panning shot",
-      "tilting shot",
-      "pull out",
-      "crash zoom",
-      "timelapse"
+      "whip tilt"
     ]
   },
   "photography.camera": {
@@ -3981,12 +3981,12 @@
     "description": "Specific models of professional cinema cameras, DSLRs, and digital cameras",
     "total": 187,
     "examples": [
-      "imax hd camera",
-      "lomography diana f+",
-      "canon 6d",
-      "leica q2",
-      "canon 5d",
-      "samsung galaxy nx"
+      "samsung nx100",
+      "sony pdw-f800 xdcam",
+      "sony alpha nex-7 body only compact system camera",
+      "sony",
+      "xiaomi mi sphere 360 camera",
+      "ricoh gr digital iv compact digital camera"
     ]
   },
   "photography.composition": {
@@ -3995,12 +3995,12 @@
     "description": "Visual composition techniques, framing styles, and spatial balance methods",
     "total": 117,
     "examples": [
-      "dynamic composition",
-      "bisection",
-      "golden ratio",
-      "nose room",
-      "steelyard composition",
-      "organic composition"
+      "juxtaposition",
+      "frame within a frame",
+      "l-shape composition",
+      "concentric circles",
+      "layered composition",
+      "compositional anchor"
     ]
   },
   "photography.filmStock": {
@@ -4009,12 +4009,12 @@
     "description": "Specific brands, models, and ISO speeds of analog photographic film stocks",
     "total": 52,
     "examples": [
-      "instax mini film",
-      "fujifilm superia 400",
-      "cinestill 400d",
-      "ilford sfx 200",
-      "cinestill 50d",
-      "ilford delta 400"
+      "ilford xp2",
+      "foma fapan 100",
+      "fujichrome provia 100f",
+      "kodak ektachrome e100",
+      "rollei retro 80s",
+      "kodak gold 200"
     ]
   },
   "photography.film": {
@@ -4023,12 +4023,12 @@
     "description": "Specific analog photography film types, brands, and ISO speeds",
     "total": 102,
     "examples": [
-      "kodak elite 400s film",
-      "kodak portra 800 film",
-      "agfa vista 100 film",
-      "fuji neopan 400 film",
-      "agfa precisa ctd 100 film",
-      "foma fomapan 400 film"
+      "ultrafine xtreme film",
+      "kodak aps film",
+      "fuji superia xtra 400 film",
+      "ilford xp2 super 400 film",
+      "fuji provia 400f film",
+      "fuji velvia 100 film"
     ]
   },
   "photography.landscapeKeyword": {
@@ -4037,12 +4037,12 @@
     "description": "Broad photography concepts, subjects, and techniques related to outdoor photography",
     "total": 81,
     "examples": [
-      "forms",
-      "moon",
-      "textures",
-      "churches",
-      "rivers",
-      "color"
+      "forests",
+      "balance",
+      "color",
+      "exposure",
+      "composition",
+      "flowers"
     ]
   },
   "photography.landscapeSubjectDetailed": {
@@ -4051,12 +4051,12 @@
     "description": "Highly descriptive, full-sentence prompts of vivid nature and landscape scenes",
     "total": 158,
     "examples": [
-      "a series of terraced rice paddies reflecting the warm colors of a sunset",
-      "a peaceful fjord with calm waters and steep cliffs",
-      "a dramatic coastline with towering cliffs and crashing waves",
-      "a colorful canyon with towering walls of rock",
-      "a frozen tundra with snow-covered hills and valleys",
-      "a colorful hot spring with steam rising from the water"
+      "a peaceful river delta with a variety of bird species",
+      "a serene lake surrounded by dense forests and snow-capped peaks",
+      "a picturesque meadow filled with wildflowers",
+      "a picturesque highland lake with snow-capped peaks in the background",
+      "a quiet birch forest in winter with a fresh blanket of powdery snow",
+      "a massive sandstone arch carved by the wind and water"
     ]
   },
   "photography.landscapeSubject": {
@@ -4065,12 +4065,12 @@
     "description": "Various natural and man-made outdoor locations, structures, and landscape features",
     "total": 132,
     "examples": [
-      "sandstone formation",
-      "harbor",
-      "airport",
-      "wildflower",
-      "satellite dish",
-      "arboretum"
+      "vineyard",
+      "fountain",
+      "footpath",
+      "marsh",
+      "forest",
+      "covered bridge"
     ]
   },
   "photography.lensType": {
@@ -4079,12 +4079,12 @@
     "description": "General categories, optical designs, and specialized styles of photographic lenses",
     "total": 52,
     "examples": [
-      "cine lens",
-      "standard lens",
-      "pinhole",
+      "bellows",
+      "macro",
+      "speed-booster",
       "apochromatic",
-      "soft focus lens",
-      "helios 44-2 lens"
+      "cine lens",
+      "perspective control lens"
     ]
   },
   "photography.lens": {
@@ -4093,12 +4093,12 @@
     "description": "Specific focal lengths and exact branded camera lens models",
     "total": 87,
     "examples": [
-      "sony fe 24-70mm",
-      "18mm",
-      "200mm",
-      "fujifilm xf 8-16mm",
-      "50mm",
-      "fujifilm xf 35mm"
+      "300mm",
+      "sigma 50mm",
+      "nikon z 24-70mm",
+      "sigma 10-20mm",
+      "sony fe 16-35mm",
+      "sony fe 50mm"
     ]
   },
   "photography.lightSource": {
@@ -4107,12 +4107,12 @@
     "description": "Natural, artificial, and specialized light sources and lighting equipment",
     "total": 64,
     "examples": [
-      "matchstick",
-      "halogen lamp",
-      "chemiluminescence",
-      "firefly glow",
-      "fiber optics",
-      "spotlight"
+      "bioluminescence",
+      "photoflood lamp",
+      "window light",
+      "neon light",
+      "flashlight",
+      "umbrella light"
     ]
   },
   "photography.light": {
@@ -4121,12 +4121,12 @@
     "description": "Descriptive lighting styles, natural light conditions, and illumination techniques",
     "total": 136,
     "examples": [
-      "rembrandt lighting",
-      "low pressure sodium lamps",
-      "3 spots lighting",
-      "lit by umbrella light",
-      "blinding light",
-      "dekatron light"
+      "soft lighting",
+      "lit by butterfly light",
+      "blacklight",
+      "evening",
+      "dim dark light",
+      "lit by aurora borealis"
     ]
   },
   "photography.lightingSetup": {
@@ -4135,12 +4135,12 @@
     "description": "Studio lighting techniques, setups, and directional illumination styles",
     "total": 52,
     "examples": [
-      "short lighting",
-      "front lighting",
-      "key lighting",
-      "top lighting",
-      "beauty dish lighting",
-      "loop lighting"
+      "fill lighting",
+      "hat lighting",
+      "window lighting",
+      "low-key lighting",
+      "high-key lighting",
+      "available lighting"
     ]
   },
   "photography.perspective": {
@@ -4149,12 +4149,12 @@
     "description": "Camera angles, viewpoints, and geometric perspective techniques for visual framing",
     "total": 129,
     "examples": [
+      "exaggerated perspective",
+      "horizontal perspective",
+      "low-level view",
       "dutch angle",
-      "dolly-zoom perspective",
-      "exploded view",
-      "dimetric perspective",
-      "cabinet perspective",
-      "distorted perspective"
+      "bird's-eye perspective",
+      "extreme close-up perspective"
     ]
   },
   "photography.photographer": {
@@ -4163,12 +4163,12 @@
     "description": "Names of famous photographers paired with their specific genres or styles",
     "total": 960,
     "examples": [
-      "dmitry markov (portrait photographer)",
-      "boushra almutawakel (conceptual and portrait photographer)",
-      "philip-lorca dicorcia (documentary and fine art photographer)",
-      "david lachapelle (fashion and fine art photographer)",
-      "faisal abdu'allah (conceptual and portrait photographer)",
-      "dougie wallace (documentary photographer)"
+      "henri cartier-bresson (street photographer)",
+      "rania matar (portrait photographer)",
+      "zack arias (portrait and editorial photographer)",
+      "eduardo muñoz ordoqui (documentary photographer)",
+      "zwelethu mthethwa (documentary and portrait photographer)",
+      "bahman jalali (documentary photographer)"
     ]
   },
   "photography.portraitPhotographer": {
@@ -4177,12 +4177,12 @@
     "description": "Names of renowned portrait, fine art, and fashion photographers",
     "total": 79,
     "examples": [
-      "julia margaret cameron",
-      "man ray",
-      "jeff wall",
       "rania matar",
-      "nan goldin",
-      "lee jeffries"
+      "walker evans",
+      "william eggleston",
+      "sally mann",
+      "martin parr",
+      "man ray"
     ]
   },
   "photography.shotType": {
@@ -4191,12 +4191,12 @@
     "description": "Various camera angles and framing techniques for photography and film",
     "total": 43,
     "examples": [
-      "reaction shot",
-      "medium wide shot",
-      "candid shot",
-      "hip level shot",
-      "three shot",
-      "three-quarter shot"
+      "group shot",
+      "panoramic shot",
+      "over-the-shoulder",
+      "ground level shot",
+      "worm's-eye view",
+      "medium shot"
     ]
   },
   "photography.summerScene": {
@@ -4205,12 +4205,12 @@
     "description": "Idyllic, warm-weather outdoor scenes, landscapes, and summer activities",
     "total": 47,
     "examples": [
-      "a city park with lush green trees and flowers in full bloom",
-      "a country road winding through fields and forests",
-      "a boat ride on a river or lake",
-      "a vibrant farmers market stall with stacks of ripe red watermelons",
-      "a lush field of sunflowers glowing in the golden hour light",
-      "a thunderstorm rolling in over a prairie landscape"
+      "a winding boardwalk leading through coastal sand dunes to the ocean",
+      "a pathway lined with blooming hydrangeas leading to a seaside cottage",
+      "a sunrise over a wheat field",
+      "a rolling green hill dotted with grazing sheep",
+      "a beachside boardwalk lined with palm trees",
+      "a vineyard with rows of grapevines stretching towards the horizon"
     ]
   },
   "photography.summerTropicalBeach": {
@@ -4219,12 +4219,12 @@
     "description": "Sensory details and vibrant scenes of a tropical beach vacation",
     "total": 67,
     "examples": [
-      "a friendly game of beach volleyball in progress",
-      "a collection of colorful beach umbrellas providing welcome shade",
+      "the feel of warm sand between your toes as you walk along the shore",
       "a sun-kissed beach populated by happy vacationers and locals alike",
-      "a flock of pelicans soaring gracefully overhead",
-      "a dazzling display of stars overhead on a clear night",
-      "a family building a towering sandcastle with a moat at the water's edge"
+      "a collection of brightly colored fishing boats bobbing in the water",
+      "a school of playful dolphins jumping and diving in the distance",
+      "a collection of colorful beach towels draped over chairs and umbrellas",
+      "crystal clear turquoise waters lapping gently against the shore"
     ]
   },
   "photojournalism.newsExtreme": {
@@ -4233,12 +4233,12 @@
     "description": "Catastrophic, world-altering, and extreme global news events and disasters",
     "total": 68,
     "examples": [
-      "a major tech company's headquarters is destroyed in a terrorist attack",
-      "a new designer drug takes the world by storm, causing a major public health crisis",
-      "a new type of energy storage technology is discovered, making renewable energy even more feasible",
-      "a massive data leak exposes the private information of millions",
-      "a new type of terrorist attack that targets major sporting events is carried out",
-      "a massive tornado tears through a major city"
+      "a global agricultural blight rapidly destroys half of the world's wheat and corn crops",
+      "a team of astronauts discovers a new habitable planet",
+      "a military coup overthrows the government of a nuclear-armed nation in a sudden overnight raid",
+      "a major economic recession hits the global economy",
+      "the first human brain-computer interface is successfully implanted, allowing telepathic communication",
+      "a massive earthquake strikes a major metropolitan area"
     ]
   },
   "photojournalism.newsNormal": {
@@ -4247,12 +4247,12 @@
     "description": "Standard major news headlines covering science, politics, business, and society",
     "total": 57,
     "examples": [
-      "a major climate disaster, such as a tornado or a record-breaking heatwave",
-      "a historic museum heist occurs, with thieves stealing priceless masterpieces overnight",
-      "a high-profile court trial of a corrupt politician begins, attracting massive media crowds",
-      "a prominent social media influencer is banned from major platforms, sparking intense debate on free speech",
-      "a major breakthrough in space exploration, such as the discovery of a new planet or the launch of a new mission to the moon",
-      "a major cultural festival, celebrating the traditions and customs of a particular group or region"
+      "a major environmental crisis, such as deforestation or coral reef destruction",
+      "a breakthrough in agricultural technology allows crops to be grown in arid, desert conditions",
+      "a high-stakes corporate merger between two tech giants sparks anti-trust protests",
+      "a major cultural festival, celebrating the traditions and customs of a particular group or region",
+      "a major sporting event, such as the olympics or world cup, that brings together athletes from around the world",
+      "a major natural disaster, such as a hurricane or earthquake, that leaves thousands of people displaced"
     ]
   },
   "photojournalism.newsSpecific": {
@@ -4261,12 +4261,12 @@
     "description": "Highly detailed, specific descriptions of major global news events and crises",
     "total": 38,
     "examples": [
-      "a landmark supreme court ruling: justices hand down a historic decision on privacy rights in the digital age, limiting government surveillance",
-      "a massive refugee migration: thousands of families flee gang violence in central america, forming a massive caravan traveling toward the border",
-      "a high-profile corporate corruption trial: the chief executive of an energy giant goes on trial for multi-billion-dollar fraud and embezzlement",
-      "a devastating building collapse: a multi-story residential building in mumbai collapses overnight, triggering a frantic search for survivors",
-      "a major civil rights movement: the black lives matter movement gains widespread support and leads to major policy changes, including police reform and the removal of confederate statues",
-      "a groundbreaking archaeological discovery: researchers in egypt unearth a pristine, undisturbed royal tomb dating back three thousand years"
+      "a critical space rescue: an international crew of astronauts executes a daring spacewalk to repair a damaged life-support system",
+      "a historic election: a record number of women are elected to congress, marking a major milestone in the fight for gender equality in politics",
+      "a major climate change summit: leaders from around the world gather in paris to discuss a new global agreement on reducing carbon emissions and slowing the effects of climate change",
+      "a mass protest against police brutality and systemic racism: thousands march through the streets of new york city, demanding justice for victims of police violence and systemic racism in the criminal justice system",
+      "a mass shooting or act of domestic terrorism: a gunman opens fire at a crowded concert in las vegas, killing dozens and injuring hundreds more",
+      "a devastating building collapse: a multi-story residential building in mumbai collapses overnight, triggering a frantic search for survivors"
     ]
   },
   "photojournalism.styleProtest": {
@@ -4275,12 +4275,12 @@
     "description": "Various photographic styles and techniques used in photojournalism and documentary photography",
     "total": 38,
     "examples": [
-      "extreme wide-angle photography: using wide lenses to include both the protesters in the foreground and the grand architectural context in the background",
-      "close-up portraiture: focusing tightly on the expressive faces of individual protesters to highlight intense human emotion and determination",
+      "analog film photography: using traditional 35mm or medium format film to create a raw, grain-textured aesthetic with natural color tones",
+      "double exposure photography: combining two distinct images, such as a protester's face and a crowded street, to create a layered, symbolic narrative",
+      "telephoto lens photography: using long focal lengths to compress the perspective, making the crowd appear denser and bringing distant action closer",
+      "macro photography: focusing on the small details of protests and individual participants",
       "monochrome photojournalism: stripping away color to emphasize form, texture, shadow, and the pure raw emotion of the moment",
-      "selective focus photography: using a shallow depth of field to isolate a single protester, sign, or detail while blurring the surrounding crowd",
-      "snapshots: capturing the small, intimate moments of protests that might be overlooked by other forms of photojournalism",
-      "photojournalistic essay: using a series of photographs to tell a story about the protests and the issues they are addressing"
+      "intentional camera movement: deliberately moving the camera during a longer exposure to create a dynamic, abstract representation of chaos and action"
     ]
   },
   "photojournalism.types": {
@@ -4289,12 +4289,12 @@
     "description": "Diverse subjects and thematic beats covered in photojournalism and documentary reporting",
     "total": 87,
     "examples": [
-      "investigative reporting on the impact of big tech on society and privacy concerns",
-      "architectural and urban preservation, documenting historic landmarks threatened by development",
-      "art and culture events",
-      "extreme sports and adventure photojournalism",
-      "conflict resolution and peacekeeping missions, focusing on diplomatic efforts and peacekeepers in the field",
-      "cultural heritage and indigenous rights, documenting the preservation of ancient traditions and land claims"
+      "community and neighborhood storytelling, highlighting the everyday lives and challenges of local residents",
+      "energy and resource extraction",
+      "family and relationships",
+      "marine conservation and ocean plastic pollution",
+      "immigration and refugees",
+      "wildlife and conservation"
     ]
   },
   "places.home": {
@@ -4303,12 +4303,12 @@
     "description": "Various types of residential dwellings and architectural housing styles",
     "total": 103,
     "examples": [
-      "cabin",
-      "villa",
-      "duplex",
-      "hut",
-      "chateau",
-      "earth sheltered home"
+      "motorhome",
+      "quonset hut",
+      "midcentury modern",
+      "tower",
+      "underwater home",
+      "thatched roof home"
     ]
   },
   "places.interiorSpace": {
@@ -4317,12 +4317,12 @@
     "description": "Diverse indoor environments ranging from mundane rooms to specialized workspaces",
     "total": 481,
     "examples": [
-      "office cubicle",
-      "tasting room",
-      "sewing room",
-      "spare room",
-      "tailor shop",
-      "school cafeteria"
+      "radio broadcast booth",
+      "ship bridge",
+      "monastery library",
+      "loft bedroom",
+      "jewelry store",
+      "mihrab alcove"
     ]
   },
   "places.public": {
@@ -4331,12 +4331,12 @@
     "description": "Common public venues, recreational areas, and civic facilities",
     "total": 94,
     "examples": [
-      "movie theater",
-      "cathedral",
-      "college campus",
-      "driving range",
-      "fountain",
-      "aquarium"
+      "train station",
+      "auditorium",
+      "seafront promenade",
+      "art museum",
+      "subway station",
+      "boulevard"
     ]
   },
   "places.roomType": {
@@ -4345,12 +4345,12 @@
     "description": "Specific, often historical or grand interior rooms and specialized chambers",
     "total": 71,
     "examples": [
-      "cellar",
+      "den",
       "antechamber",
-      "darkroom",
-      "music room",
-      "anteroom",
-      "banquet hall"
+      "refectory",
+      "barroom",
+      "card room",
+      "billiard room"
     ]
   },
   "places.room": {
@@ -4359,12 +4359,12 @@
     "description": "Standard functional rooms and spaces found in typical modern homes",
     "total": 51,
     "examples": [
-      "mail room",
-      "balcony",
-      "scullery",
-      "pantry",
-      "bathroom",
-      "attic"
+      "laundry room",
+      "pool house",
+      "corridor",
+      "bedroom",
+      "meeting room",
+      "boardroom"
     ]
   },
   "places.urbanFeature": {
@@ -4373,12 +4373,12 @@
     "description": "Structural elements, fixtures, and infrastructure found in city environments",
     "total": 196,
     "examples": [
-      "green roof",
-      "marquee",
-      "elevated railway",
-      "dog park",
-      "highway ramp",
-      "canopy"
+      "pocket park",
+      "wrought iron fence",
+      "arcade",
+      "fire escape",
+      "market stall",
+      "staircase"
     ]
   },
   "plot.action": {
@@ -4387,12 +4387,12 @@
     "description": "High-stakes, thrilling scenarios involving combat, heists, rescues, and survival",
     "total": 66,
     "examples": [
-      "infiltrating a secret society or cult",
       "preventing a dangerous weapon from falling into the wrong hands",
-      "defending against a cyber attack or hacking attempt",
-      "rescuing survivors of a natural disaster",
-      "stopping a nuclear missile launch from a remote silo",
-      "escaping from a helicopter crash or other airborne disaster"
+      "rescuing a captive from a jungle or wilderness",
+      "participating in a high-speed car chase",
+      "rescuing a loved one from danger",
+      "escaping from a high-speed train under enemy control",
+      "rescuing a stranded or lost team or crew"
     ]
   },
   "plot.arthouse": {
@@ -4401,12 +4401,12 @@
     "description": "Introspective narratives focusing on emotional struggles, relationships, and personal crises",
     "total": 66,
     "examples": [
-      "challenging the status quo",
-      "being haunted by a ghost",
-      "dealing with a moral dilemma",
-      "investigating a mysterious disappearance",
+      "being held captive",
+      "coping with the sudden silence of a solitary rural existence",
+      "going on a journey of self-discovery",
+      "exploring their sexuality",
       "engaging in acts of rebellion",
-      "struggling with identity issues"
+      "challenging the status quo"
     ]
   },
   "plot.fantasy": {
@@ -4415,12 +4415,12 @@
     "description": "Magical and supernatural adventures involving mythical creatures, curses, and epic quests",
     "total": 66,
     "examples": [
-      "recovering a forgotten language of power",
-      "overcoming obstacles in a world filled with magic",
-      "restoring light to a dying sacred world-tree",
-      "navigating the shifting rules of a court of fae nobility",
-      "overcoming personal demons or fears",
-      "surviving in a world with limited resources"
+      "dealing with the consequences of using dark magic",
+      "navigating through a magical jungle or swamp",
+      "seeking audience with a reclusive mountain giant",
+      "bargaining with an ancient primordial deity",
+      "escaping from a spell-induced sleep",
+      "saving a magical creature from harm"
     ]
   },
   "plot.general": {
@@ -4430,11 +4430,11 @@
     "total": 109,
     "examples": [
       "attempting to break a world record",
-      "attending a high school reunion",
-      "saving a local landmark from corporate developers",
-      "planning a heist",
-      "solving a mystery or crime",
-      "performing a musical"
+      "participating in a sporting event",
+      "participating in a protest",
+      "dealing with a family crisis",
+      "participating in a karaoke competition",
+      "helping to rebuild after a natural disaster"
     ]
   },
   "plot.horror": {
@@ -4443,12 +4443,12 @@
     "description": "Horror and survival scenarios involving supernatural entities, monsters, and deadly environments",
     "total": 65,
     "examples": [
-      "staying alive in a world overrun by genetically modified creatures",
-      "investigating a series of bizarre deaths",
+      "escaping a house that rearranges its rooms overnight",
+      "investigating a mysterious ghost town",
+      "investigating a mysterious disappearance",
       "escaping from a mad scientist's laboratory",
-      "investigating a cursed radio signal that causes hallucinations",
-      "escaping from a haunted forest",
-      "investigating a mysterious ghost town"
+      "fighting against an evil spirit",
+      "facing a parasitic entity infecting a small rural community"
     ]
   },
   "plot.musical": {
@@ -4457,12 +4457,12 @@
     "description": "Storylines focused on musical competitions, bands, solo artists, and creative collaborations",
     "total": 66,
     "examples": [
-      "reuniting an old high school garage band for one last gig",
-      "dealing with the impact of age on a musical career",
-      "discovering a hidden singing talent in an unassuming street busker",
-      "learning to work together as a musical team",
-      "navigating the rivalry between two competing music academies",
-      "saving a beloved historic theater from demolition through a benefit concert"
+      "finding the courage to pursue their musical dreams",
+      "staging an unauthorized underground musical",
+      "balancing a secret identity as a rising pop star and a normal student",
+      "competing for a prestigious scholarship at a music conservatory",
+      "navigating the backstage drama and romance of a broadway show",
+      "dealing with the realities of the music business"
     ]
   },
   "plot.romance": {
@@ -4471,12 +4471,12 @@
     "description": "Romantic storylines about overcoming personal, social, and communication obstacles to find love",
     "total": 65,
     "examples": [
-      "coping with the end of a relationship",
-      "surviving a test of love",
-      "dealing with the complexities of a polyamorous relationship",
-      "overcoming communication issues or misunderstandings",
-      "navigating a romance between a member of royalty and a commoner",
-      "navigating a romance that blooms during a scenic culinary tour"
+      "building a relationship while balancing career or other commitments",
+      "navigating the awkward transition from best friends to lovers",
+      "overcoming societal or cultural expectations",
+      "finding love while pursuing personal goals",
+      "navigating the challenges of marriage or long-term commitment",
+      "surviving a long-distance relationship"
     ]
   },
   "plot.scifiCyberpunk": {
@@ -4485,12 +4485,12 @@
     "description": "Cyberpunk scenarios involving hacking, rogue AI, cyborgs, and dystopian corporate espionage",
     "total": 66,
     "examples": [
-      "defending against a powerful ai or rogue program",
-      "navigating through a cyber-controlled wasteland",
-      "investigating a technological cover-up",
       "overcoming personal limitations through technology",
-      "infiltrating an orbital space penthouse owned by the elite",
-      "navigating through a virtual maze or labyrinth"
+      "overcoming a technological apocalypse",
+      "rescuing a captive or hostage",
+      "investigating a cult that worships a rogue artificial intelligence",
+      "infiltrating a corporation or government facility",
+      "participating in a cyberwar or virtual battle"
     ]
   },
   "plot.scifi": {
@@ -4499,12 +4499,12 @@
     "description": "Science fiction scenarios featuring space exploration, alien encounters, and planetary disasters",
     "total": 185,
     "examples": [
-      "searching for a way to communicate with a mysterious alien race",
-      "establishing first contact with a non-carbon-based lifeform",
-      "exploring a lost moon",
-      "a team of rebels try to stop a massive asteroid from hitting earth",
-      "a group of astronauts try to save earth from an alien attack by using a mysterious device",
-      "infiltrating a space-based research facility or laboratory"
+      "collecting valuable resources",
+      "investigating a space-based conspiracy or murder",
+      "stopping a rogue planet from destroying earth",
+      "navigating through an asteroid field or space anomaly",
+      "navigating a sentient nebula that responds to the crew's emotions",
+      "dealing with the power struggles between intergalactic nations"
     ]
   },
   "plot.war": {
@@ -4513,12 +4513,12 @@
     "description": "Military and tactical operations including covert missions, sieges, and defensive stands",
     "total": 66,
     "examples": [
-      "infiltrating enemy territory",
-      "stopping enemy propaganda or psychological operations",
-      "stopping enemy sabotage or guerrilla operations",
-      "destroying enemy supplies or logistics",
-      "recovering a downed pilot from deep within enemy territory",
-      "conducting a sabotage mission"
+      "defending against a chemical or biological attack",
+      "conducting a covert operation",
+      "carrying out a dangerous mission",
+      "conducting a deep penetration mission",
+      "infiltrating a coastal artillery battery to disable its guns",
+      "defending against a surprise attack"
     ]
   },
   "science.astronomy": {
@@ -4527,12 +4527,12 @@
     "description": "Astronomical concepts, phenomena, and celestial structures like black holes and dark matter",
     "total": 54,
     "examples": [
-      "solar wind",
-      "eclipse",
-      "cosmic ray",
-      "binary star",
-      "pluto",
-      "neptune"
+      "comet trail",
+      "neutron star",
+      "star cluster",
+      "andromeda",
+      "kuiper belt",
+      "red giant"
     ]
   },
   "science.chemicalElement": {
@@ -4541,12 +4541,12 @@
     "description": "Various chemical elements from the periodic table",
     "total": 118,
     "examples": [
-      "dysprosium",
-      "seaborgium",
-      "terbium",
-      "thallium",
-      "actinium",
-      "gadolinium"
+      "astatine",
+      "mendelevium",
+      "cadmium",
+      "ytterbium",
+      "hafnium",
+      "helium"
     ]
   },
   "science.constellation": {
@@ -4555,12 +4555,12 @@
     "description": "Names of recognized star constellations in the night sky",
     "total": 88,
     "examples": [
-      "lynx",
-      "leo",
-      "volans",
-      "sagittarius",
+      "lyra",
+      "canes venatici",
+      "aquarius",
+      "gemini",
       "lepus",
-      "scutum"
+      "orion"
     ]
   },
   "science.geometry": {
@@ -4569,12 +4569,12 @@
     "description": "Advanced mathematical shapes, fractals, attractors, and geometric concepts",
     "total": 117,
     "examples": [
-      "julia 3d fractal",
-      "clifford attractor",
-      "kite hexecontahedron",
-      "fractal",
-      "archimedean solids",
-      "ellipsoid"
+      "annulus",
+      "sacred geometry",
+      "apollonian gasket",
+      "bucky ball",
+      "barnsley fern",
+      "cellular automaton"
     ]
   },
   "science.isotope": {
@@ -4583,12 +4583,12 @@
     "description": "Specific radioactive and stable isotopes of various chemical elements",
     "total": 56,
     "examples": [
-      "curium-244",
-      "aluminium-26",
-      "carbon-12",
-      "argon-40",
-      "phosphorus-32",
-      "technetium-99m"
+      "barium-133",
+      "caesium-137",
+      "uranium-234",
+      "iridium-192",
+      "iodine-123",
+      "phosphorus-32"
     ]
   },
   "science.medicalImages": {
@@ -4597,12 +4597,12 @@
     "description": "Medical imaging techniques and diagnostic scanning procedures",
     "total": 45,
     "examples": [
-      "ct scan",
-      "bone scan",
-      "fmri",
-      "pet scan",
-      "ultrasound",
-      "optical coherence tomography"
+      "cta",
+      "4d ultrasound",
+      "phase-contrast x-ray imaging",
+      "cone beam ct",
+      "oct scan",
+      "spect scan"
     ]
   },
   "science.planetBody": {
@@ -4611,12 +4611,12 @@
     "description": "Specific planets, moons, asteroids, and other named celestial bodies",
     "total": 224,
     "examples": [
-      "lysithea",
-      "adrastea",
-      "eunomia",
-      "2002 ms4",
-      "desdemona",
-      "churyumov-gerasimenko"
+      "altjira",
+      "geographos",
+      "hd 189733 b",
+      "enceladus",
+      "chaos",
+      "dimorphos"
     ]
   },
   "science.robotType": {
@@ -4625,12 +4625,12 @@
     "description": "Various types of industrial, agricultural, and specialized autonomous robots and drones",
     "total": 328,
     "examples": [
-      "sample-preparation robot",
-      "hybrid drone",
-      "atmospheric satellite",
-      "modular robot",
-      "internal pipe robot",
-      "humanoid robot"
+      "tiltwing drone",
+      "tactical entry robot",
+      "space exploration robot",
+      "spot-welding robot",
+      "robotic turret",
+      "robotic submarine"
     ]
   },
   "science.scifiTech": {
@@ -4639,12 +4639,12 @@
     "description": "Fictional science fiction technology, gadgets, and futuristic devices",
     "total": 63,
     "examples": [
-      "bacta tank",
-      "genetic sequencer",
-      "cloning vat",
-      "artificial gravity generator",
-      "teleporter",
-      "matter replicator"
+      "android",
+      "bionic eye",
+      "nanobot swarm",
+      "neural lace",
+      "jetpack",
+      "brain-computer interface"
     ]
   },
   "set.describeStyle": {
@@ -4653,12 +4653,12 @@
     "description": "Eclectic art styles, hashtags, and artist names used in AI image generation",
     "total": 17756,
     "examples": [
-      "dark yellow and dark gold",
-      "light gray and dark cyan",
-      "highly detailed illustrations",
-      "delicately rendered landscapes",
-      "installation creator",
-      "baroque still life"
+      "light magenta and light cyan",
+      "light green and dark blue",
+      "watercolor landscapes",
+      "light emerald and pink",
+      "light white and light green",
+      "light pink and dark orange"
     ]
   },
   "set.describeSubject": {
@@ -4667,12 +4667,12 @@
     "description": "Highly specific, random AI-generated image prompts and surreal subject descriptions",
     "total": 139614,
     "examples": [
-      "a cartoon cat in an icon on a white background",
+      "2001 nissan versa sxt gdi manual 4",
       "anime character pictures",
-      "3d rendered frog with raft",
-      "a black and white photo of a bird on the Antarctic island of st john do",
-      "a gun pistol with two hands",
-      "a black and white logo for quiksilver"
+      "a close up shot of cloth with white netting",
+      "a light in a glass aquarium with purple lights",
+      "'the knight and the shield' artbook cover",
+      "a credit card in an image on a pink background"
     ]
   },
   "set.memeDescription": {

--- a/list-metadata.json
+++ b/list-metadata.json
@@ -1837,14 +1837,14 @@
     "title": "Amber names",
     "category": "fiction",
     "description": "Places, powers, factions, and concepts from Roger Zelazny's Chronicles of Amber",
-    "total": 65,
+    "total": 91,
     "examples": [
-      "ganelon",
-      "keep of the four worlds",
-      "the courts of chaos",
-      "cabal",
-      "shadow",
-      "the jewel of judgment"
+      "kashfa",
+      "luke",
+      "delwin and sand",
+      "black road",
+      "delwin",
+      "arden"
     ]
   },
   "fiction.asoiaf": {
@@ -1853,54 +1853,54 @@
     "description": "Places, houses, peoples, and creatures from A Song of Ice and Fire",
     "total": 449,
     "examples": [
-      "deep den",
-      "house tarbeck",
-      "grumkin",
-      "house borrell",
-      "dorne",
-      "barrowton"
+      "storm's end",
+      "house serrett",
+      "dyre den",
+      "house cray",
+      "house crakehall",
+      "house grafton"
     ]
   },
   "fiction.avatar": {
     "title": "Avatar: The Last Airbender names",
     "category": "fiction",
     "description": "Places, peoples, spirits, bending arts, and factions from Avatar: The Last Airbender and The Legend of Korra",
-    "total": 87,
+    "total": 131,
     "examples": [
-      "the fire lord",
-      "ba sing se upper ring",
-      "air nomads",
-      "hei bai",
-      "chi blocking",
-      "mechanist"
+      "airbending",
+      "southern air temple",
+      "mai",
+      "piandao",
+      "spirit oasis",
+      "naga"
     ]
   },
   "fiction.barsoom": {
     "title": "Barsoom names",
     "category": "fiction",
     "description": "Places, peoples, creatures, titles, and artifacts from Edgar Rice Burroughs' Barsoom",
-    "total": 69,
+    "total": 95,
     "examples": [
-      "plant men",
-      "tharkian hordes",
-      "warhoon",
-      "masena",
-      "xavarian",
-      "river iss"
+      "black martians",
+      "panthan",
+      "barsoom",
+      "synthetic men",
+      "zodanga",
+      "therns"
     ]
   },
   "fiction.basLag": {
     "title": "Bas-Lag names",
     "category": "fiction",
     "description": "Places, peoples, creatures, factions, and concepts from China Mieville's Bas-Lag fiction",
-    "total": 61,
+    "total": 80,
     "examples": [
-      "lin",
-      "parliament",
-      "south badlands",
-      "khepri",
-      "malachite",
-      "jabber"
+      "grindylow",
+      "torque",
+      "yagharek",
+      "bohemie",
+      "oriel",
+      "wyrmen"
     ]
   },
   "fiction.bookOfTheNewSun": {
@@ -1909,12 +1909,12 @@
     "description": "Unique names from The Book of the New Sun (Gene Wolfe) — places, peoples, creatures, factions, and ships combined.",
     "total": 227,
     "examples": [
-      "triskele",
-      "chalicothere",
-      "scylla",
-      "father inire",
-      "miles",
-      "the client's room"
+      "the bellkeep",
+      "apheta",
+      "the water garden",
+      "blood bat",
+      "the village of the sorcerers",
+      "the septs"
     ]
   },
   "fiction.brokenEarth": {
@@ -1923,26 +1923,26 @@
     "description": "Unique names from The Broken Earth (N.K. Jemisin) — places, peoples, creatures, factions, and ships combined.",
     "total": 184,
     "examples": [
-      "the doctors",
-      "tasi",
-      "the tourmaline",
-      "the inner core",
-      "castrima-under",
-      "the dead moon"
+      "the arctics",
+      "kilen",
+      "cuur",
+      "the flint node",
+      "the roggas",
+      "the coastles"
     ]
   },
   "fiction.conan": {
     "title": "Hyborian Age names",
     "category": "fiction",
     "description": "Places, peoples, creatures, gods, and factions from Robert E. Howard's Conan and Hyborian Age",
-    "total": 71,
+    "total": 107,
     "examples": [
-      "kosala",
-      "amazon",
-      "atali",
-      "kordava",
-      "black circle",
-      "jemsha"
+      "scarlet citadel",
+      "red brotherhood",
+      "vilayet sea",
+      "thoth-amon",
+      "ophir",
+      "the tree of death"
     ]
   },
   "fiction.cthulhuMythos": {
@@ -1951,54 +1951,54 @@
     "description": "Unique names from Cthulhu Mythos — places, peoples, creatures, factions, and ships combined.",
     "total": 758,
     "examples": [
-      "great race of yith",
-      "ngyr-korath",
-      "deep one",
-      "hicksville",
-      "gloucester",
-      "hingham"
+      "smithtown",
+      "wells",
+      "the cult of the thousand young",
+      "stony brook",
+      "the chthonic society",
+      "the cult of yig"
     ]
   },
   "fiction.culture": {
     "title": "Culture series",
     "category": "fiction",
     "description": "Starship names, orbitals, planets, systems, species, and factions from Iain M. Banks' Culture series",
-    "total": 61,
+    "total": 198,
     "examples": [
-      "ahforgetit tendency",
-      "cheradenine zakalwe",
-      "ablation",
-      "contact",
-      "chiark orbital",
-      "casualty of cause"
+      "size isn't everything",
+      "compromised integrity",
+      "flere-imsaho",
+      "demi-mind",
+      "falling outside the normal moral constraints",
+      "empiricist"
     ]
   },
   "fiction.darkTower": {
     "title": "Dark Tower names",
     "category": "fiction",
     "description": "Places, peoples, creatures, factions, and powers from Stephen King's Dark Tower fiction",
-    "total": 74,
+    "total": 143,
     "examples": [
-      "the speaking demon",
-      "mohaine desert",
-      "ka-tet",
-      "arthur eld",
-      "calla bryn sturgis",
-      "tull"
+      "aaron deepneau",
+      "outer-world",
+      "blue heaven",
+      "shardik",
+      "lud",
+      "alain johns"
     ]
   },
   "fiction.dc": {
     "title": "DC Universe names",
     "category": "fiction",
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from DC fiction",
-    "total": 85,
+    "total": 95,
     "examples": [
-      "hawkman",
-      "arkham knight",
-      "amanda waller",
+      "blue beetle scarab",
       "crime alley",
       "intergang",
-      "the multiverse"
+      "bat-signal",
+      "batcave",
+      "green arrow"
     ]
   },
   "fiction.discworld": {
@@ -2007,12 +2007,12 @@
     "description": "Places, peoples, creatures, and groups from Terry Pratchett's Discworld",
     "total": 143,
     "examples": [
-      "igors",
-      "curse-of-the-mummy scarab",
-      "bes pelargic",
-      "great a'tuin",
-      "hunchbroad",
-      "gnomes"
+      "naiads",
+      "the rim",
+      "trolls",
+      "unseen university",
+      "sapient pearwood",
+      "the auditors"
     ]
   },
   "fiction.dragonBall": {
@@ -2021,12 +2021,12 @@
     "description": "Places, species, transformations, artifacts, and powers from Dragon Ball",
     "total": 77,
     "examples": [
-      "android 16",
-      "planet vegeta",
-      "other world",
+      "trunks",
+      "capsule corporation",
+      "bulma",
       "gohan",
-      "super saiyan blue",
-      "galactic patrol"
+      "ginyu force",
+      "majin buu"
     ]
   },
   "fiction.dragonlance": {
@@ -2035,12 +2035,12 @@
     "description": "Places, peoples, factions, creatures, deities, and artifacts from Dragonlance",
     "total": 128,
     "examples": [
-      "palanthas",
-      "balifor",
-      "tasslehoff burrfoot",
-      "ariakas",
-      "zakhal",
-      "tower of high sorcery at palanthas"
+      "gasshan",
+      "magius",
+      "abanasinia",
+      "the gods of darkness",
+      "kapak draconian",
+      "dragon highlords"
     ]
   },
   "fiction.dune": {
@@ -2049,26 +2049,26 @@
     "description": "Planets, cities, factions, houses, and political groups from Frank Herbert's Dune universe",
     "total": 157,
     "examples": [
-      "arrakeen",
-      "mohiam",
-      "duncan idaho",
-      "butlerian jihad",
-      "farad'n corrino",
-      "atrides"
+      "alia atreides",
+      "golden path",
+      "chaumas",
+      "ix",
+      "burseg",
+      "coom"
     ]
   },
   "fiction.elderScrolls": {
     "title": "Elder Scrolls names",
     "category": "fiction",
     "description": "Places, peoples, factions, creatures, artifacts, and deities from The Elder Scrolls",
-    "total": 82,
+    "total": 98,
     "examples": [
-      "jarl",
-      "thalmor",
-      "blackreach",
-      "knights of the nine",
-      "winterhold",
-      "red mountain"
+      "namira",
+      "oblivion",
+      "aldmer",
+      "alduin",
+      "bruma",
+      "solstheim"
     ]
   },
   "fiction.expanse": {
@@ -2077,40 +2077,40 @@
     "description": "Places, factions, ships, peoples, and technologies from The Expanse",
     "total": 126,
     "examples": [
-      "new terra",
-      "sol gate",
-      "auberon",
-      "inazami",
-      "cotyar ghazi",
-      "phoebe station"
+      "fred johnson",
+      "behemoth",
+      "leonidas",
+      "phoebe",
+      "luna",
+      "iapetus"
     ]
   },
   "fiction.forgottenRealms": {
     "title": "Forgotten Realms names",
     "category": "fiction",
     "description": "Places, peoples, factions, creatures, deities, and artifacts from the Forgotten Realms",
-    "total": 65,
+    "total": 85,
     "examples": [
-      "nine hells",
-      "red wizards",
-      "the order of the gauntlet",
-      "shadowdale",
-      "blackstaff tower",
-      "selune"
+      "red wizards of thay",
+      "baldur's gate",
+      "kezef",
+      "auril",
+      "abeir-toril",
+      "drizzt"
     ]
   },
   "fiction.foundation": {
     "title": "Foundation names",
     "category": "fiction",
     "description": "Places, planets, factions, and groups from Isaac Asimov's Foundation universe",
-    "total": 74,
+    "total": 92,
     "examples": [
-      "lingane",
-      "nexon",
-      "florina",
-      "smitheus",
-      "orsha ii",
-      "comporellon"
+      "61 cygni",
+      "arcturus",
+      "rhodia",
+      "independents",
+      "echegaray",
+      "tithonus"
     ]
   },
   "fiction.gethen": {
@@ -2119,12 +2119,12 @@
     "description": "Planets, countries, towns, cultures, and organizations from Ursula K. Le Guin's Hainish Cycle and Earthsea",
     "total": 155,
     "examples": [
-      "haka",
-      "fastness",
-      "stabilizer",
-      "anarres",
-      "ged",
-      "esker faxe"
+      "taka",
+      "hare",
+      "atuan",
+      "handdara",
+      "eorviny",
+      "mesk"
     ]
   },
   "fiction.gormenghast": {
@@ -2133,12 +2133,12 @@
     "description": "Unique names from Gormenghast (Mervyn Peake) — places, peoples, creatures, factions, and ships combined.",
     "total": 237,
     "examples": [
-      "the grooms",
-      "the professors",
-      "the scullions",
-      "the mud village",
-      "the owls",
-      "the magistrates"
+      "the little kitchen",
+      "the lords of groan",
+      "the salt mines",
+      "the subjects",
+      "the nobles",
+      "the south wing"
     ]
   },
   "fiction.halo": {
@@ -2147,12 +2147,12 @@
     "description": "Places, factions, species, artifacts, ships, and installations from Halo",
     "total": 143,
     "examples": [
+      "spartan-ii",
+      "offensive bias",
       "master chief",
-      "atriox",
-      "edward buck",
-      "genesis",
-      "energy sword",
-      "doisac"
+      "mauler",
+      "retriever sentinel",
+      "mjolnir armor"
     ]
   },
   "fiction.harryPotter": {
@@ -2161,12 +2161,12 @@
     "description": "Places, schools, houses, creatures, objects, and groups from the Harry Potter and Wizarding World fiction",
     "total": 93,
     "examples": [
-      "chamber of secrets",
-      "azkaban",
+      "beedle the bard",
       "hogsmeade",
-      "knight bus",
-      "the burrow",
-      "spellotape"
+      "death eaters",
+      "scabbers",
+      "wizengamot",
+      "flobberworm"
     ]
   },
   "fiction.hisDarkMaterials": {
@@ -2175,12 +2175,12 @@
     "description": "Places, peoples, creatures, and concepts from Philip Pullman's His Dark Materials",
     "total": 109,
     "examples": [
-      "dust",
-      "torre degli angeli",
-      "kirjava",
-      "geneva",
-      "billy costa",
-      "dark matter"
+      "subtle knife rift",
+      "lyra belacqua",
+      "john fane",
+      "cazimi",
+      "lord asriel",
+      "brytain"
     ]
   },
   "fiction.hitchhikers": {
@@ -2189,12 +2189,12 @@
     "description": "Places, species, spacecraft, and groups from The Hitchhiker's Guide to the Galaxy",
     "total": 72,
     "examples": [
-      "golgafrinchans",
-      "prehistoric earth",
-      "alpha centauri",
-      "haggunenons",
-      "blagulon kappa",
-      "han wavel"
+      "arkintoofle minor",
+      "argabuthon",
+      "lintillas",
+      "golgafrinchan ark fleet ship b",
+      "mice",
+      "milliways"
     ]
   },
   "fiction.hyperion": {
@@ -2203,12 +2203,12 @@
     "description": "Unique names from Hyperion Cantos — places, peoples, creatures, factions, and ships combined.",
     "total": 321,
     "examples": [
-      "kite-fox",
-      "angel",
-      "briareus construct",
-      "clone",
-      "deer park",
-      "cybrid-human hybrid"
+      "centauri b",
+      "sol draconi septem",
+      "the ouster swarm",
+      "nevermore",
+      "the brotherhood of the muir",
+      "dolphin"
     ]
   },
   "fiction.lotr": {
@@ -2217,12 +2217,12 @@
     "description": "Places, races, creatures, and unique names from J.R.R. Tolkien's Middle-earth",
     "total": 464,
     "examples": [
-      "rhûn",
-      "thranduil",
-      "lune",
-      "orcs",
-      "ori",
-      "war of wrath"
+      "westfold",
+      "varda",
+      "menegroth",
+      "radbug",
+      "isen river",
+      "turin turambar"
     ]
   },
   "fiction.magicMultiverse": {
@@ -2231,12 +2231,12 @@
     "description": "Planes, peoples, factions, creatures, and artifacts from Magic: The Gathering fiction",
     "total": 136,
     "examples": [
-      "dragonlord dromoka",
-      "temur",
-      "sarkhan vol",
-      "golgari swarm",
-      "elspeth tirel",
-      "abzan"
+      "liliana vess",
+      "multani",
+      "vedalken",
+      "eldrazi",
+      "dragonlord atarka",
+      "grixis"
     ]
   },
   "fiction.malazan": {
@@ -2245,12 +2245,12 @@
     "description": "Places, peoples, creatures, and groups from the Malazan Book of the Fallen",
     "total": 98,
     "examples": [
+      "aren",
       "barghast",
-      "korel",
-      "maurik",
-      "eleint",
-      "coral",
-      "eres'al"
+      "tiste liosan",
+      "quon tali",
+      "tiste edur",
+      "the wastelands"
     ]
   },
   "fiction.marvel": {
@@ -2259,12 +2259,12 @@
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction",
     "total": 97,
     "examples": [
-      "the defenders",
-      "a-force",
-      "spider-man",
-      "midnight sons",
-      "annihilus",
-      "new mutants"
+      "avengers mansion",
+      "infinity stones",
+      "aim",
+      "avengers",
+      "mind stone",
+      "annihilus"
     ]
   },
   "fiction.massEffect": {
@@ -2273,12 +2273,12 @@
     "description": "Places, species, factions, ships, artifacts, and powers from Mass Effect",
     "total": 79,
     "examples": [
-      "reaper",
-      "batarians",
       "hanar",
-      "edi",
-      "aria t'loak",
-      "joker"
+      "mass effect field",
+      "crucible",
+      "mako",
+      "cerberus",
+      "samara"
     ]
   },
   "fiction.narnia": {
@@ -2287,12 +2287,12 @@
     "description": "Places, peoples, creatures, and magical beings from C.S. Lewis's Chronicles of Narnia",
     "total": 80,
     "examples": [
-      "eastern ocean",
-      "merpeople",
-      "calormenes",
-      "telmarines",
-      "marsh-wiggles",
-      "wood between the worlds"
+      "castle of miraz",
+      "world's end",
+      "dryads",
+      "fauns",
+      "salamanders",
+      "fords of beruna"
     ]
   },
   "fiction.onePiece": {
@@ -2301,12 +2301,12 @@
     "description": "Places, factions, peoples, creatures, ships, powers, and treasures from One Piece",
     "total": 80,
     "examples": [
-      "ohara",
-      "red line",
-      "shanks",
-      "seven warlords",
-      "one piece",
-      "mirror world"
+      "enies lobby",
+      "jinbe",
+      "mariejois",
+      "alabasta",
+      "devil fruit",
+      "drum island"
     ]
   },
   "fiction.pokemon": {
@@ -2315,12 +2315,12 @@
     "description": "Regions, species, legendary Pokemon, teams, and artifacts from Pokemon",
     "total": 1137,
     "examples": [
-      "swellow",
-      "minior",
-      "purrloin",
-      "sceptile",
-      "heracross",
-      "excadrill"
+      "spoink",
+      "charmander",
+      "lumineon",
+      "flaaffy",
+      "love ball",
+      "cobalion"
     ]
   },
   "fiction.starTrek": {
@@ -2329,12 +2329,12 @@
     "description": "Unique names from Star Trek — places, peoples, creatures, factions, and ships combined.",
     "total": 721,
     "examples": [
-      "peltian",
-      "deep space 9",
-      "ss santa maria",
-      "mari",
-      "oberth-class",
-      "brikar"
+      "j'naii",
+      "ss robert fox",
+      "karigan",
+      "bzzit khaht",
+      "bolian",
+      "nausicaa"
     ]
   },
   "fiction.starWars": {
@@ -2343,12 +2343,12 @@
     "description": "Unique names from Star Wars — places, peoples, creatures, factions, and ships combined.",
     "total": 784,
     "examples": [
-      "utoppan",
-      "tactician",
-      "porg",
-      "ruusan",
-      "the death troopers",
-      "the hidden path"
+      "lambda-class t-4a shuttle",
+      "marian",
+      "kel dor",
+      "negotiator",
+      "mos pelgo",
+      "neimoidian"
     ]
   },
   "fiction.transformers": {
@@ -2357,12 +2357,12 @@
     "description": "Places, factions, species, artifacts, and groups from Transformers",
     "total": 59,
     "examples": [
+      "minicons",
+      "ratchet",
+      "autobots",
+      "megatron",
       "quintessons",
-      "ironhide",
-      "devastator",
-      "aerialbots",
-      "metroplex",
-      "starscream"
+      "the allspark"
     ]
   },
   "fiction.warcraft": {
@@ -2371,12 +2371,12 @@
     "description": "Places, peoples, factions, creatures, artifacts, and powers from the Warcraft universe",
     "total": 91,
     "examples": [
-      "azshara",
-      "pandaria",
-      "darnassus",
-      "kalimdor",
-      "gul'dan",
-      "durotar"
+      "the bronze dragonflight",
+      "alleria",
+      "lordaeron",
+      "alterac",
+      "illidan",
+      "kul tiras"
     ]
   },
   "fiction.warhammer40k": {
@@ -2385,12 +2385,12 @@
     "description": "Unique names from Warhammer 40,000 — places, peoples, creatures, factions, and ships combined.",
     "total": 653,
     "examples": [
-      "plague planet",
-      "space wolves",
-      "novokh dynasty",
-      "order of the ebon chalice",
-      "pax imperialis",
-      "roboute guilliman"
+      "the great rift",
+      "lucius",
+      "nicassar",
+      "perturabo",
+      "masque of the veiled path",
+      "hive fleet behemoth"
     ]
   },
   "fiction.wheelOfTime": {
@@ -2399,12 +2399,12 @@
     "description": "Places, peoples, creatures, and groups from The Wheel of Time",
     "total": 109,
     "examples": [
-      "kinslayer's dagger",
-      "salidar",
-      "jumara",
-      "s'redit",
-      "far madding",
-      "aelfinn"
+      "gholam",
+      "toman head",
+      "baerlon",
+      "to'raken",
+      "mayene",
+      "aridhol"
     ]
   },
   "fiction.witcher": {
@@ -2413,12 +2413,12 @@
     "description": "Places, kingdoms, schools, peoples, creatures, and objects from The Witcher",
     "total": 81,
     "examples": [
-      "the continent",
-      "aedirn",
-      "dryads",
-      "caer a'muirehen",
-      "francesca findabair",
-      "golden dragon"
+      "harpy",
+      "aretuza",
+      "angren",
+      "gors velen",
+      "ciri",
+      "feline school"
     ]
   },
   "fiction.zelda": {
@@ -2427,12 +2427,12 @@
     "description": "Places, peoples, creatures, artifacts, and powers from The Legend of Zelda",
     "total": 84,
     "examples": [
-      "lanayru",
-      "great plateau",
-      "beedle",
-      "hyrule castle",
-      "blight ganon",
-      "gerudo"
+      "great fairy",
+      "divine beast vah rudania",
+      "dark world",
+      "hyrule field",
+      "farore",
+      "din"
     ]
   },
   "food.bakery": {
@@ -2441,12 +2441,12 @@
     "description": "Assorted baked goods including cakes, pies, pastries, and sweet breads",
     "total": 176,
     "examples": [
-      "swiss roll",
-      "cinnamon rolls",
-      "challah",
+      "pain au chocolat",
+      "eclairs",
+      "cassata",
       "apple pie",
-      "soda bread",
-      "chocolate fondue"
+      "æbleskive (apple slice)",
+      "chiffon cake"
     ]
   },
   "food.bbq": {
@@ -2455,12 +2455,12 @@
     "description": "Grilled meats, seafood, vegetables, and fruits typical of barbecue cooking",
     "total": 41,
     "examples": [
-      "grilled halloumi",
-      "burgers",
-      "corn on the cob",
-      "chicken wings",
-      "chicken skewers",
-      "elote"
+      "grilled oysters",
+      "grilled romaine",
+      "steak",
+      "grilled zucchini",
+      "grilled shrimp skewers",
+      "smoked turkey leg"
     ]
   },
   "food.beverage": {
@@ -2469,12 +2469,12 @@
     "description": "Various alcoholic and non-alcoholic drinks including cocktails, coffees, and teas",
     "total": 224,
     "examples": [
-      "hojicha",
-      "ginger tea",
-      "ayran",
-      "grape juice",
-      "café au lait",
-      "grog"
+      "atole",
+      "shandy",
+      "affogato",
+      "sazerac",
+      "cola",
+      "cherry cola"
     ]
   },
   "food.bread": {
@@ -2483,12 +2483,12 @@
     "description": "A diverse global selection of traditional breads, biscuits, and baked rolls",
     "total": 269,
     "examples": [
-      "michetta",
-      "bath bun",
-      "buttermilk biscuit",
-      "arepa de huevo",
-      "angel biscuit",
-      "kisra"
+      "kulcha",
+      "pan de deificación",
+      "spelt bread",
+      "lompe",
+      "steamed bread",
+      "julekake"
     ]
   },
   "food.breakfast": {
@@ -2497,12 +2497,12 @@
     "description": "Sweet and savory breakfast dishes including eggs, waffles, and avocado toast",
     "total": 86,
     "examples": [
-      "gourmet cheeses",
-      "congee",
-      "french toast",
-      "bagel with cream cheese",
-      "avocado toast",
-      "breakfast sausage"
+      "quiche",
+      "veggie florentine",
+      "blintzes",
+      "quiche lorraine",
+      "frittata",
+      "boiled eggs"
     ]
   },
   "food.cheese": {
@@ -2511,12 +2511,12 @@
     "description": "A wide variety of international cheeses from different regions and styles",
     "total": 515,
     "examples": [
-      "nanclares",
-      "brossa",
-      "chhena",
-      "cabrales",
-      "imeruli",
-      "gervais"
+      "livarot",
+      "leyden",
+      "azeitão",
+      "coquetdale",
+      "olivet cendré",
+      "lyme bay"
     ]
   },
   "food.cocktail": {
@@ -2525,11 +2525,11 @@
     "description": "Classic and modern mixed alcoholic drinks and cocktails",
     "total": 153,
     "examples": [
-      "casino",
-      "harvey wallbanger",
-      "cosmopolitan",
-      "gin and tonic",
-      "irish coffee",
+      "vesper",
+      "amaretto sour",
+      "pimm's cup",
+      "espresso martini",
+      "last word",
       "air mail"
     ]
   },
@@ -2539,12 +2539,12 @@
     "description": "Culinary techniques for preparing food, ranging from baking to dry aging",
     "total": 97,
     "examples": [
-      "rendering",
-      "coal roasting",
-      "blowtorching",
-      "butter poaching",
-      "dry curing",
-      "flash freezing"
+      "canning",
+      "tempering",
+      "pasteurizing",
+      "oil roasting",
+      "torching",
+      "parching"
     ]
   },
   "food.cuisine": {
@@ -2553,12 +2553,12 @@
     "description": "Specific regional and national culinary traditions from around the world",
     "total": 340,
     "examples": [
-      "betawi cuisine",
-      "kenyan cuisine",
-      "amish cuisine",
-      "kerala cuisine",
-      "badener cuisine",
-      "senegalese cuisine"
+      "maritime cuisine",
+      "nepalese cuisine",
+      "palestinian cuisine",
+      "oaxacan cuisine",
+      "maharashtrian cuisine",
+      "sarawakian cuisine"
     ]
   },
   "food.dessert": {
@@ -2567,12 +2567,12 @@
     "description": "Global sweet treats including cakes, puddings, pastries, and confections",
     "total": 174,
     "examples": [
-      "turkish delight",
-      "rugelach",
-      "panforte",
-      "loukoumades",
-      "taiyaki",
-      "oatmeal raisin cookie"
+      "cranachan",
+      "affogato",
+      "carrot cake",
+      "mince pie",
+      "parfait",
+      "coconut macaroon"
     ]
   },
   "food.drink": {
@@ -2581,12 +2581,12 @@
     "description": "Assorted beverages including sodas, juices, teas, milks, and alcoholic drinks",
     "total": 289,
     "examples": [
-      "distilled water",
-      "highball cocktail",
-      "white tea",
-      "ginger shot",
-      "cola",
-      "cashew milk"
+      "whiskey",
+      "ouzo",
+      "mead",
+      "mai tai",
+      "margarita",
+      "merlot"
     ]
   },
   "food.fast": {
@@ -2595,12 +2595,12 @@
     "description": "Global fast food and street food items including burgers, fries, and rolls",
     "total": 164,
     "examples": [
-      "spicy chicken burger",
-      "donburi",
-      "bufalina pizza",
-      "orange chicken",
-      "banana milkshake",
-      "katsu"
+      "crinkle cut fries",
+      "egg rolls",
+      "gyoza",
+      "garlic fries",
+      "currywurst",
+      "siciliana pizza"
     ]
   },
   "food.fruit": {
@@ -2609,12 +2609,12 @@
     "description": "Common and exotic fruits, berries, and melons from around the world",
     "total": 142,
     "examples": [
-      "feijoa",
-      "cherimoya",
-      "acai",
+      "ugli fruit",
+      "acerola",
+      "currant",
       "blackcurrant",
-      "blueberry",
-      "crenshaw melon"
+      "blackberry",
+      "cherry guava"
     ]
   },
   "food.herbSpice": {
@@ -2623,12 +2623,12 @@
     "description": "Various culinary herbs, spices, and seeds used for flavoring food",
     "total": 50,
     "examples": [
-      "mint",
-      "cilantro",
-      "cumin",
       "paprika",
-      "sage",
-      "cardamom"
+      "sumac",
+      "green pepper",
+      "sichuan pepper",
+      "basil",
+      "parsley"
     ]
   },
   "food.pastaShape": {
@@ -2637,12 +2637,12 @@
     "description": "Various types of traditional and novelty pasta shapes",
     "total": 145,
     "examples": [
-      "mafaldine",
-      "ditalini",
-      "corallini",
-      "acini di pepe",
-      "croxetti",
-      "agnolini"
+      "gramigna",
+      "spaghettini",
+      "marille",
+      "mostaccioli",
+      "passatelli",
+      "pici"
     ]
   },
   "food.platingStyle": {
@@ -2651,12 +2651,12 @@
     "description": "Artistic and structural techniques for arranging and presenting food on a plate",
     "total": 104,
     "examples": [
-      "freeform",
-      "architectural",
-      "banquet",
-      "skillet style",
-      "canape style",
-      "casual"
+      "kaiseki",
+      "family style",
+      "modern",
+      "cast-iron style",
+      "plated dessert",
+      "mediterranean style"
     ]
   },
   "food.tea": {
@@ -2665,12 +2665,12 @@
     "description": "Specific varieties of traditional, herbal, and regional teas",
     "total": 193,
     "examples": [
-      "junshan yinzhen",
-      "sarsaparilla tea",
-      "biluochun",
-      "jin xuan",
+      "nilgiri",
+      "feverfew tea",
+      "blue tea",
+      "high mountain oolong",
       "chun mee",
-      "elderflower tea"
+      "jujube tea"
     ]
   },
   "food.vegetable": {
@@ -2679,12 +2679,12 @@
     "description": "Various vegetables, legumes, squashes, and edible plant sprouts",
     "total": 266,
     "examples": [
-      "grape tomato",
-      "yam",
-      "butternut squash",
-      "spinach",
-      "black salsify",
-      "celery"
+      "shallot",
+      "burdock root",
+      "hubbard squash",
+      "carrot",
+      "brussels sprouts",
+      "alfalfa sprouts"
     ]
   },
   "geography.city": {
@@ -2693,12 +2693,12 @@
     "description": "Specific global cities listed with their respective regions and countries",
     "total": 22953,
     "examples": [
-      "Parras de la Fuente, Coahuila, Mexico",
-      "Richmond, Victoria, Australia",
-      "Kasterlee, Flanders, Belgium",
-      "Char Bhadrāsan, Dhaka, Bangladesh",
-      "Hājīganj, Chittagong, Bangladesh",
-      "Quixadá, Ceará, Brazil"
+      "Goražde, Federation of Bosnia and Herzegovina, Bosnia and Herzegovina",
+      "Chachapoyas, Amazonas, Peru",
+      "Jaunpur, Uttar Pradesh, India",
+      "João Câmara, Rio Grande do Norte, Brazil",
+      "Itamarandiba, Minas Gerais, Brazil",
+      "Villa Gesell, Buenos Aires, Argentina"
     ]
   },
   "geography.country": {
@@ -2707,12 +2707,12 @@
     "description": "A diverse list of sovereign nations and countries around the world",
     "total": 199,
     "examples": [
-      "Lesotho",
-      "Sudan",
-      "Afghanistan",
-      "Angola",
-      "Burundi",
-      "Uzbekistan"
+      "Kuwait",
+      "Croatia",
+      "Brunei",
+      "Czechoslovakia",
+      "Honduras",
+      "Indonesia"
     ]
   },
   "geography.ethnicGroup": {
@@ -2721,12 +2721,12 @@
     "description": "The following groups are commonly identified as \"ethnic groups\", as opposed to ethno-linguistic phyla, national groups, racial groups or similar.\n",
     "total": 1055,
     "examples": [
-      "tagish",
-      "germans",
-      "gibraltarians",
-      "guajajara",
-      "erzyas",
-      "ghorbati"
+      "kalmyks",
+      "banjara",
+      "chuanqing",
+      "newars",
+      "aragonese",
+      "buryats"
     ]
   },
   "geography.language": {
@@ -2735,12 +2735,12 @@
     "description": "A list of language names (glossonyms)",
     "total": 609,
     "examples": [
-      "kumyk",
-      "erzya",
-      "cocos islands malay",
-      "hawaiian",
-      "igbo",
-      "inuktitut"
+      "gilbertese",
+      "kurdish (southern)",
+      "dolgan",
+      "haida",
+      "assamese",
+      "aari"
     ]
   },
   "geography.nationality": {
@@ -2749,12 +2749,12 @@
     "description": "Adjectives describing nationalities and citizenships from various countries",
     "total": 206,
     "examples": [
-      "salvadoran",
-      "samoan",
-      "tobagonian",
-      "bissau-guinean",
-      "mosotho",
-      "argentine"
+      "honduran",
+      "singaporean",
+      "estonian",
+      "german",
+      "antiguan",
+      "beninese"
     ]
   },
   "geography.territory": {
@@ -2763,12 +2763,12 @@
     "description": "Global territories, dependencies, emirates, and non-sovereign geographic regions",
     "total": 79,
     "examples": [
-      "American Samoa",
-      "Faroe Islands",
-      "British Virgin Islands",
-      "Jersey",
-      "Dhekelia",
-      "French Southern Territories"
+      "Réunion",
+      "Cocos (Keeling) Islands",
+      "Guam",
+      "Aruba",
+      "Antarctica",
+      "Johnston Atoll"
     ]
   },
   "interaction.coupleNegative": {
@@ -2777,12 +2777,12 @@
     "description": "Toxic, emotional, and negative behavioral interactions between romantic partners",
     "total": 70,
     "examples": [
-      "feeling weak with each other",
-      "feeling defeated with each other",
       "accusing each other",
-      "experiencing rejection from each other",
-      "feeling annoyed with each other",
-      "experiencing self-doubt with each other"
+      "snapping over a minor detail",
+      "criticizing each other's family",
+      "feeling guilty with each other",
+      "speaking with a sharp tongue",
+      "feeling abandoned by each other"
     ]
   },
   "interaction.couple": {
@@ -2791,12 +2791,12 @@
     "description": "Positive and negative relational dynamics and activities between couples",
     "total": 69,
     "examples": [
+      "holding hands across a table",
       "showing compassion",
       "mentorship",
-      "having tension",
-      "offering support",
-      "negotiating a deal",
-      "watching the sunrise together"
+      "holding a grudge",
+      "reconciliation",
+      "romance"
     ]
   },
   "interaction.crowd": {
@@ -2805,12 +2805,12 @@
     "description": "Collective actions, events, and emotional responses experienced by large crowds",
     "total": 64,
     "examples": [
-      "gathering for a festival",
-      "attending a sporting event",
+      "attending a religious ceremony",
+      "protesting against injustice",
+      "clapping to a rhythm",
       "celebrating a birthday",
-      "holding a protest",
-      "attending a parade",
-      "holding a peaceful assembly"
+      "holding a concert",
+      "watching a play"
     ]
   },
   "interaction.danceStyle": {
@@ -2819,12 +2819,12 @@
     "description": "Diverse global dance genres, traditional styles, and modern rhythmic movements",
     "total": 266,
     "examples": [
-      "ballet",
-      "nihon buyo",
-      "apache dance",
-      "boogie-woogie",
-      "burlesque",
-      "charleston"
+      "isicathamiya",
+      "tarraxinha",
+      "ballroom",
+      "horon",
+      "bachata",
+      "house dance"
     ]
   },
   "interaction.group": {
@@ -2833,12 +2833,12 @@
     "description": "Collaborative group activities ranging from mundane events to dramatic fictional scenarios",
     "total": 70,
     "examples": [
-      "running for public office",
-      "rescuing a hostage",
-      "trying to clear someone's name",
-      "training for a marathon together",
-      "taking a journey of self-discovery",
-      "studying for a final exam"
+      "rehearsing a theater play",
+      "taking part in a paranormal investigation",
+      "finding inner peace",
+      "becoming a superhero",
+      "competing in a trivia night",
+      "training for a marathon together"
     ]
   },
   "interaction.individualDetailed": {
@@ -2847,12 +2847,12 @@
     "description": "Highly specific, multi-step physical actions and behavioral sequences performed by individuals",
     "total": 214,
     "examples": [
-      "licks a finger, turns the page of a heavy book, and continues reading intently",
-      "sighs deeply, rubs forehead, and then looks up with a forced smile",
-      "knits brow, rubs chin thoughtfully, and then offers a suggestion",
-      "adjusts a watch on wrist, checks the time, and quickens their pace",
-      "flips through a book, finds the desired page, and begins reading",
-      "places a bookmark in a book, closes it, and then sets it aside"
+      "adjusts glasses, squints at something in the distance, then nods in understanding",
+      "leans against a wall, folds arms, and then tilts head to the side to listen",
+      "furrows brow, rubs chin thoughtfully, and then nods in agreement",
+      "balances on one foot, hops a few times, and then switches to the other foot",
+      "clicks tongue, shakes head, and then tries again",
+      "checks wrist watch, sighs in frustration, and peers down the street"
     ]
   },
   "interaction.individual": {
@@ -2861,12 +2861,12 @@
     "description": "Simple, everyday physical gestures, adjustments, and actions performed by a single person",
     "total": 424,
     "examples": [
-      "drops to the ground and does push-ups",
-      "slurps spaghetti noisily",
-      "taps fingers on a surface nervously",
-      "crawls under a table",
-      "sits cross-legged on the floor",
-      "squishes play dough"
+      "sneaks up behind someone",
+      "crumples a piece of paper in frustration",
+      "combs beard with fingers",
+      "counts on fingers",
+      "gives a thumbs up",
+      "creeps down a hallway"
     ]
   },
   "interaction.martialArt": {
@@ -2875,12 +2875,12 @@
     "description": "Traditional and modern martial arts and combat systems from around the world",
     "total": 110,
     "examples": [
-      "yoseikan budo",
-      "kickboxing",
+      "ssireum",
       "baguazhang",
-      "bando",
-      "bajiquan",
-      "kenpo"
+      "kali",
+      "canne de combat",
+      "hung gar",
+      "iaido"
     ]
   },
   "keyword.detailed": {
@@ -2889,12 +2889,12 @@
     "description": "Descriptive adjectives used to prompt high-resolution, intricate, and textured artwork",
     "total": 58,
     "examples": [
-      "well-defined",
-      "crisp",
-      "exquisitely-detailed",
-      "realistic",
+      "carefully-detailed",
+      "multifaceted",
+      "ultra-fine-detail",
+      "lifelike",
       "ultra-realistic",
-      "ultra-fine-detail"
+      "beautifully-rendered"
     ]
   },
   "keyword.epic": {
@@ -2903,12 +2903,12 @@
     "description": "Evocative adjectives for generating dramatic, majestic, and awe-inspiring visual atmospheres",
     "total": 129,
     "examples": [
-      "noble",
-      "marvelous",
-      "regal",
-      "virtuous",
-      "monumental",
-      "sensational"
+      "majestic",
+      "unforgettable",
+      "awe-inspiring",
+      "gorgeous",
+      "intricate",
+      "exquisite"
     ]
   },
   "keyword.genre": {
@@ -2917,12 +2917,12 @@
     "description": "Sci-fi, historical, and punk-themed aesthetic art genres and styles",
     "total": 65,
     "examples": [
-      "hopepunk",
-      "cybergrunge",
-      "ancient",
-      "dieselpunk",
-      "futurism",
-      "art deco"
+      "mid-century",
+      "victorian",
+      "neo-victorian",
+      "weird fiction",
+      "post-apocalyptic",
+      "retro-futurism"
     ]
   },
   "keyword.glitch": {
@@ -2931,12 +2931,12 @@
     "description": "Digital and analog visual artifacts, distortions, and glitch effects",
     "total": 56,
     "examples": [
-      "rgb split",
-      "warping",
-      "artifact",
-      "glitch-art",
-      "analog artifact",
-      "distortion"
+      "stutter",
+      "bug",
+      "scrambled signal",
+      "datamosh",
+      "interlacing",
+      "refraction"
     ]
   },
   "keyword.modifier": {
@@ -2945,12 +2945,12 @@
     "description": "Keywords that modify the style of an image (Noodle Soup prompts)",
     "total": 88,
     "examples": [
-      "gothic",
-      "60s kitsch and psychedelia",
-      "afrofuturism",
-      "anime",
-      "anaglyph filter",
-      "folk art"
+      "stippling",
+      "dutch golden age",
+      "graffiti",
+      "double exposure effect",
+      "calotype",
+      "fractalism"
     ]
   },
   "keyword.negative": {
@@ -2959,12 +2959,12 @@
     "description": "Negative prompt keywords for avoiding bad anatomy, artifacts, and low quality",
     "total": 90,
     "examples": [
-      "jpeg artifact",
-      "3d",
-      "noisy",
-      "mutated hands",
-      "cloned face",
-      "low resolution"
+      "low-res",
+      "asymmetry",
+      "double face",
+      "extra fingers",
+      "signature",
+      "surreal"
     ]
   },
   "keyword.prayer": {
@@ -2973,12 +2973,12 @@
     "description": "Quality-enhancing prompt modifiers for high resolution and masterpiece renders",
     "total": 67,
     "examples": [
-      "breathtaking detail",
-      "impeccable",
-      "superb rendering",
-      "8k",
-      "gorgeous lighting",
-      "unreal engine 5 render"
+      "unreal engine 5 render",
+      "advanced",
+      "cutting-edge",
+      "ultra-high definition",
+      "masterpiece",
+      "premium-quality"
     ]
   },
   "keyword.trending": {
@@ -2987,12 +2987,12 @@
     "description": "Keywords referencing trending or featured artwork on popular portfolio websites",
     "total": 35,
     "examples": [
-      "featured on deviantart",
-      "featured on getty images",
-      "trending on midjourney",
-      "featured on zbrushcentral",
-      "trending on pinterest",
-      "trending on artstation hd"
+      "trending on pixiv",
+      "trending on dribbble",
+      "featured on behance",
+      "trending on getty images",
+      "trending on unsplash",
+      "zbrush central"
     ]
   },
   "keyword.unusual": {
@@ -3001,12 +3001,12 @@
     "description": "Adjectives describing weird, unique, unusual, or abnormal subjects",
     "total": 62,
     "examples": [
-      "curious",
-      "unusual",
-      "peculiar",
-      "bewildering",
-      "unorthodox",
-      "confusing"
+      "eccentric",
+      "baffling",
+      "unique",
+      "wild",
+      "rare",
+      "atypical"
     ]
   },
   "music.artist": {
@@ -3015,12 +3015,12 @@
     "description": "Diverse musical artists and bands with distinct musical styles",
     "total": 114,
     "examples": [
-      "the smiths",
-      "kate bush",
-      "tame impala",
-      "fka twigs",
-      "leonard cohen",
-      "erykah badu"
+      "outkast",
+      "joanna newsom",
+      "erykah badu",
+      "billie holiday",
+      "alan stivell",
+      "grimes"
     ]
   },
   "music.bpm": {
@@ -3029,12 +3029,12 @@
     "description": "Various musical tempos measured in beats per minute",
     "total": 42,
     "examples": [
-      "145 bpm",
-      "300 bpm",
-      "210 bpm",
-      "135 bpm",
-      "200 bpm",
-      "130 bpm"
+      "50 bpm",
+      "280 bpm",
+      "80 bpm",
+      "150 bpm",
+      "85 bpm",
+      "100 bpm"
     ]
   },
   "music.composer": {
@@ -3043,12 +3043,12 @@
     "description": "Famous classical and contemporary music composers",
     "total": 190,
     "examples": [
-      "carl friedrich abel",
-      "pierre boulez",
-      "jean sibelius",
+      "john dowland",
+      "jean-baptiste lully",
       "joan tower",
-      "john harbison",
-      "richard wagner"
+      "zhou long",
+      "johann stamitz",
+      "john cage"
     ]
   },
   "music.drop": {
@@ -3057,12 +3057,12 @@
     "description": "Specific electronic dance music subgenre drops and rhythmic transitions",
     "total": 39,
     "examples": [
-      "electro house bass drop",
-      "big room drop",
-      "hardstyle reverse bass drop",
-      "progressive house melodic drop",
+      "uk garage speed garage bassline drop",
+      "deep house groove drop",
       "hardstyle kick drop",
-      "moombahton beat drop"
+      "trance uplifting drop",
+      "darkpsy intense hypnotic drop",
+      "drumstep fast drum drop"
     ]
   },
   "music.dynamic": {
@@ -3071,12 +3071,12 @@
     "description": "Musical tempo, dynamic, and articulation terms with their definitions",
     "total": 89,
     "examples": [
-      "staccato (short and detached)",
-      "morendo (dying away, gradually softer and slower)",
-      "lento (slowly, at a slow tempo)",
-      "portamento (sliding smoothly from one note to another)",
-      "pianissimo (very soft)",
-      "niente (gradually fade out to nothing)"
+      "senza sordino (without mute)",
+      "con sordino (with mute)",
+      "glissando (sliding smoothly from one pitch to another)",
+      "crescendo poco a poco (gradually getting louder little by little)",
+      "brillante ma non troppo (brilliant but not too much)",
+      "brillante (brilliantly, with dazzling and sparkling quality)"
     ]
   },
   "music.feature": {
@@ -3085,12 +3085,12 @@
     "description": "Specific instrumental, vocal, and atmospheric musical elements and techniques",
     "total": 206,
     "examples": [
-      "catchy melodies",
-      "groovy bassline",
-      "driving rhythm section",
+      "floating electronic arpeggiators",
+      "distorted synth bass drops",
+      "energetic percussion",
       "acoustic guitars",
-      "cascading harpsichord arpeggios",
-      "searing guitar leads"
+      "fretless bass melodies",
+      "ethereal vocal falsettos"
     ]
   },
   "music.genre": {
@@ -3099,12 +3099,12 @@
     "description": "Diverse music genres ranging from electronic and rock to folk",
     "total": 305,
     "examples": [
-      "breakcore",
-      "surf rock",
-      "space ambient",
-      "ska jazz",
-      "ska core",
-      "samba"
+      "experimental rock",
+      "gothic metal",
+      "noise rock",
+      "klezmer",
+      "jersey club",
+      "reggae"
     ]
   },
   "music.harmony": {
@@ -3113,12 +3113,12 @@
     "description": "Various types of musical harmonies and chordal structures",
     "total": 38,
     "examples": [
-      "modal interchange harmony",
-      "parallel harmony",
+      "minor harmony",
+      "tonal harmony",
+      "microtonal harmony",
+      "vocal harmony",
       "subdominant harmony",
-      "jazz harmony",
-      "spectral harmony",
-      "consonant harmony"
+      "polyphonic harmony"
     ]
   },
   "music.instrument": {
@@ -3127,12 +3127,12 @@
     "description": "Traditional, classical, and world music instruments",
     "total": 216,
     "examples": [
-      "zurna",
-      "ney",
-      "nyckelharpa",
-      "piccolo",
-      "taonga pūoro",
-      "washboard"
+      "toubeleki",
+      "cello",
+      "guitar",
+      "didgeridoo",
+      "hurdy-gurdy",
+      "french horn"
     ]
   },
   "music.key": {
@@ -3142,11 +3142,11 @@
     "total": 35,
     "examples": [
       "a# minor",
-      "d# minor",
-      "f minor",
-      "gb minor",
-      "f major",
-      "eb minor"
+      "bb minor",
+      "eb major",
+      "e minor",
+      "a minor",
+      "g# minor"
     ]
   },
   "music.melody": {
@@ -3155,12 +3155,12 @@
     "description": "Descriptive types of musical melodies with their definitions",
     "total": 94,
     "examples": [
-      "antiphonal melody (alternating phrases between different groups)",
-      "cascading melody (falling notes in a cascading fashion)",
-      "sequential melody (with repeated patterns at different pitch levels)",
-      "homophonic melody (melody accompanied by chords)",
-      "riff melody (repeated melodic pattern)",
-      "modal melody (based on a specific mode or scale)"
+      "sighing melody (expressing a sense of longing or sadness)",
+      "brooding melody (dark, low-pitched, and contemplative)",
+      "harmonized melody (melody supported by accompanying harmonies)",
+      "descending melody (falling motion)",
+      "choral melody (sung by a choir or vocal ensemble)",
+      "ethereal melody (airy and otherworldly)"
     ]
   },
   "music.mode": {
@@ -3169,12 +3169,12 @@
     "description": "Various musical scales, modes, and traditional tonal systems",
     "total": 55,
     "examples": [
-      "blues scale mode",
-      "half-whole diminished mode",
+      "pelog scale mode",
       "pentatonic major mode",
-      "maqam saba mode",
-      "lydian augmented mode",
-      "acoustic scale mode"
+      "double harmonic scale mode",
+      "maqam bayati mode",
+      "half-whole diminished mode",
+      "lydian mode"
     ]
   },
   "music.mood": {
@@ -3183,12 +3183,12 @@
     "description": "Emotional and atmospheric musical moods or vibes",
     "total": 117,
     "examples": [
-      "hopeful",
-      "gloomy",
-      "catchy",
-      "abrasive",
-      "comforting",
-      "euphoric"
+      "savage",
+      "exciting",
+      "dreamy",
+      "epic",
+      "atmospheric",
+      "agitated"
     ]
   },
   "music.musicGenre": {
@@ -3197,12 +3197,12 @@
     "description": "Diverse global music genres and subgenres",
     "total": 63,
     "examples": [
-      "rockabilly",
-      "death metal",
-      "calypso",
-      "dubstep",
+      "acid jazz",
       "kwaito",
-      "gothic rock"
+      "death metal",
+      "doom metal",
+      "chillwave",
+      "grime"
     ]
   },
   "music.percussive": {
@@ -3211,12 +3211,12 @@
     "description": "Specific percussion instruments and percussive sound makers",
     "total": 145,
     "examples": [
-      "crotales",
-      "hand clap",
+      "handpan",
+      "log drum mallet",
+      "surdo beater",
       "cricket clicker",
-      "djembe",
-      "jawbone",
-      "bata drum"
+      "ride cymbal",
+      "bell tree"
     ]
   },
   "music.recording": {
@@ -3225,12 +3225,12 @@
     "description": "Various formats and styles of audio recordings",
     "total": 72,
     "examples": [
-      "binaural recording",
-      "acoustic session recording",
+      "spoken word recording",
+      "rehearsal recording",
+      "stereo recording",
       "livestream concert recording",
-      "analog recording",
-      "single recording",
-      "acoustic recording"
+      "cassette recording",
+      "binaural recording"
     ]
   },
   "music.rhythm": {
@@ -3239,12 +3239,12 @@
     "description": "Specific rhythmic patterns and timing structures in music",
     "total": 27,
     "examples": [
-      "cross rhythm",
       "broken rhythm",
-      "shuffle rhythm",
-      "swing rhythm",
-      "additive rhythm",
-      "motorik rhythm"
+      "backbeat rhythm",
+      "polyrhythmic rhythm",
+      "straight rhythm",
+      "cross rhythm",
+      "tresillo rhythm"
     ]
   },
   "music.songSection": {
@@ -3253,11 +3253,11 @@
     "description": "Structural components and sections of a musical composition",
     "total": 37,
     "examples": [
-      "refrain",
-      "spoken word section",
       "tag",
-      "cadenza",
-      "breakdown",
+      "theme",
+      "ad-lib section",
+      "chorus",
+      "verse",
       "interlude"
     ]
   },
@@ -3267,12 +3267,12 @@
     "description": "Specific vocal techniques, styles, and singing methods",
     "total": 187,
     "examples": [
-      "growl",
-      "choral",
-      "ezenggileer",
-      "mixed voice",
-      "parlato",
-      "joik"
+      "subharmonic singing",
+      "buccal speech",
+      "gorgheggio",
+      "diphonic singing",
+      "distorted vocals",
+      "gregorian chant"
     ]
   },
   "music.vocal": {
@@ -3281,12 +3281,12 @@
     "description": "Descriptive styles and textures of vocal performances",
     "total": 119,
     "examples": [
-      "ethereal vocals",
-      "adrenaline-fueled vocals",
-      "choral falsetto",
-      "dynamic vocals",
-      "rasp vocals",
-      "grunge vocals"
+      "distorted shouts",
+      "soaring vocals",
+      "staccato vocals",
+      "harmonized whispers",
+      "rhythmic chant-singing",
+      "spoken word vocals"
     ]
   },
   "mythical.artifact": {
@@ -3295,12 +3295,12 @@
     "description": "Mythological, religious, and fictional magical items and artifacts",
     "total": 215,
     "examples": [
-      "deck of many things",
-      "seven-league boots",
-      "iron crown of lombardy",
-      "key of solomon",
-      "scabbard of excalibur",
-      "dowsing rod"
+      "pashupatastra",
+      "fragarach",
+      "djed pillar",
+      "cornucopia",
+      "brahmastra",
+      "ankh of life"
     ]
   },
   "mythical.chinese": {
@@ -3309,12 +3309,12 @@
     "description": "Deities, creatures, and figures from Chinese mythology",
     "total": 83,
     "examples": [
-      "taotie (饕餮)",
+      "chang'e's rabbit (玉兔)",
+      "hou yi (后羿)",
       "nine sons of the dragon (龍生九子)",
-      "kui (夔)",
-      "bi fang (畢方)",
-      "ba (巴)",
-      "xi wangmu's tigers (金虎)"
+      "di ku (帝嚳)",
+      "tu di gong (土地公)",
+      "he xiangu (何仙姑)"
     ]
   },
   "mythical.dndRace": {
@@ -3323,12 +3323,12 @@
     "description": "Playable character races from Dungeons and Dragons",
     "total": 66,
     "examples": [
-      "dragonborn",
-      "bariaur",
+      "gnoll",
+      "human",
       "aven",
-      "svirfneblin",
-      "astral elf",
-      "bugbear"
+      "changeling",
+      "firbolg",
+      "warforged"
     ]
   },
   "mythical.dragon": {
@@ -3337,12 +3337,12 @@
     "description": "Specific named dragons and dragon types from global mythologies",
     "total": 86,
     "examples": [
-      "babylonian tiamat dragon",
-      "norse nidhogg dragon",
-      "australian rainbow serpent dragon",
-      "chinese fucanglong dragon",
-      "french gargouille dragon",
-      "filipino bakunawa dragon"
+      "macedonian lamja dragon",
+      "japanese ryujin dragon",
+      "irish ollipheist dragon",
+      "indonesian naga taksaka dragon",
+      "french guivre dragon",
+      "mapuche kai-kai filu dragon"
     ]
   },
   "mythical.magicTheGathering": {
@@ -3351,12 +3351,12 @@
     "description": "Specific card names from the game Magic: The Gathering",
     "total": 32340,
     "examples": [
-      "leyline of lightning",
-      "tax taker",
-      "chrome companion",
-      "fireshrieker",
-      "herald of slaanesh",
-      "fuel tank feaster"
+      "compost",
+      "make your own luck",
+      "channeled force",
+      "gala greeters",
+      "headstrong brute",
+      "lightwielder paladin"
     ]
   },
   "mythical.magicType": {
@@ -3365,12 +3365,12 @@
     "description": "Various schools, disciplines, and types of magical arts",
     "total": 53,
     "examples": [
-      "divination",
-      "light magic",
-      "elemental magic",
-      "nature magic",
-      "conjuration",
-      "druidry"
+      "shadow magic",
+      "abjuration",
+      "enchantment",
+      "banishment",
+      "druidism",
+      "angelology"
     ]
   },
   "mythical.mythicalCreature": {
@@ -3379,12 +3379,12 @@
     "description": "Famous monsters and creatures from global mythology and folklore",
     "total": 61,
     "examples": [
-      "sphinx",
-      "cockatrice",
-      "yeti",
+      "jinn",
+      "faun",
+      "troll",
       "goblin",
-      "gorgon",
-      "ghoul"
+      "gargoyle",
+      "imp"
     ]
   },
   "nature.areaOfNaturalBeauty": {
@@ -3393,12 +3393,12 @@
     "description": "Specific national parks, landmarks, and natural wonders worldwide",
     "total": 625,
     "examples": [
-      "stone forest",
-      "kailash mountain",
-      "great barrier reef",
-      "jiayuguan pass",
-      "fiordland national park",
-      "kamchatka peninsula"
+      "bromo tengger semeru national park",
+      "deadvlei",
+      "chittorgarh fort",
+      "the jesuit missions of la santisima trinidad de parana",
+      "borobudur temple",
+      "bwindi impenetrable forest"
     ]
   },
   "nature.biome": {
@@ -3407,12 +3407,12 @@
     "description": "Diverse ecological biomes and natural environmental zones",
     "total": 62,
     "examples": [
-      "karst",
-      "peatland",
-      "tropical dry forest",
-      "rainforest",
       "benthic zone",
-      "ice sheet"
+      "bog",
+      "mediterranean forest",
+      "temperate coniferous forest",
+      "wetland",
+      "montane shrubland"
     ]
   },
   "nature.cloudType": {
@@ -3421,12 +3421,12 @@
     "description": "Specific meteorological cloud formations and types",
     "total": 40,
     "examples": [
-      "lacunosus",
-      "nimbostratus",
-      "roll cloud",
+      "cumulonimbus",
       "pileus",
-      "arcus cloud",
-      "kelvin-helmholtz"
+      "altocumulus",
+      "castellanus",
+      "radiatus",
+      "pyrocumulus"
     ]
   },
   "nature.flower": {
@@ -3435,12 +3435,12 @@
     "description": "Various flowering plants, herbs, and ornamental garden blooms",
     "total": 547,
     "examples": [
-      "yellow bell (tecoma stans)",
-      "iberis (iberis)",
-      "encyclia orchid (encyclia)",
-      "false sunflower (heliopsis helianthoides)",
-      "fleur de lis (iris pseudacorus)",
-      "aconite (aconitum)"
+      "mimosa (mimosa pudica)",
+      "frost flower (helianthemum)",
+      "cuckoo flower (cardamine pratensis)",
+      "daylily (hemerocallis)",
+      "cosmos bipinnatus (cosmos bipinnatus)",
+      "bromeliad (bromeliaceae)"
     ]
   },
   "nature.fungus": {
@@ -3449,12 +3449,12 @@
     "description": "Assorted species of wild mushrooms and fungi",
     "total": 214,
     "examples": [
-      "bicolored deceiver mushroom",
-      "black trumpet mushroom",
-      "jelly babies fungus",
-      "devil's cigar",
-      "jelly antler fungus",
-      "glistening inkcap mushroom"
+      "magpie inkcap mushroom",
+      "earth star fungus",
+      "brown roll-rim mushroom",
+      "common stump brittlestem mushroom",
+      "lion shield mushroom",
+      "honey fungus"
     ]
   },
   "nature.gemstone": {
@@ -3463,12 +3463,12 @@
     "description": "Various precious gemstones, crystals, and mineral specimens",
     "total": 375,
     "examples": [
-      "arsenopyrite",
-      "cavansite",
-      "septarian",
-      "amblygonite",
-      "creedite",
-      "hessonite garnet"
+      "tahitian pearl",
+      "apache tear",
+      "goethite",
+      "alabaster",
+      "bixbyite",
+      "black opal"
     ]
   },
   "nature.landscape": {
@@ -3477,12 +3477,12 @@
     "description": "Geological formations and large-scale geographical landscape features",
     "total": 51,
     "examples": [
-      "delta",
-      "alluvial fan",
-      "precipice",
-      "plateau",
-      "caldera",
-      "bay"
+      "atoll",
+      "cave",
+      "geyser",
+      "beach",
+      "floodplain",
+      "butte"
     ]
   },
   "nature.mineral": {
@@ -3491,12 +3491,12 @@
     "description": "Specific mineral specimens, crystals, and semi-precious stones",
     "total": 275,
     "examples": [
-      "wolframite",
-      "bornite",
-      "chrysocolla",
-      "erythrite",
-      "anatase",
-      "cristobalite"
+      "labradorite",
+      "opal",
+      "realgar",
+      "magnesite",
+      "beryl",
+      "phenakite"
     ]
   },
   "nature.moonPhase": {
@@ -3505,12 +3505,12 @@
     "description": "Traditional, seasonal, and descriptive names for lunar phases",
     "total": 117,
     "examples": [
-      "hunter's moon",
-      "mothers' moon",
-      "alder moon",
-      "fish moon",
-      "claiming moon",
-      "hot moon"
+      "storm moon",
+      "fruit moon",
+      "dyad moon",
+      "grass moon",
+      "crow moon",
+      "dyer moon"
     ]
   },
   "nature.naturalPhenomenon": {
@@ -3519,12 +3519,12 @@
     "description": "Rare atmospheric, meteorological, and natural optical phenomena",
     "total": 45,
     "examples": [
-      "catatumbo lightning",
-      "penitentes",
-      "rainbow",
+      "solar eclipse",
       "afterglow",
-      "fire rainbow",
-      "geyser"
+      "catatumbo lightning",
+      "fog bow",
+      "frost flowers",
+      "whirlpool"
     ]
   },
   "nature.plant": {
@@ -3533,12 +3533,12 @@
     "description": "Common indoor houseplants and decorative potted foliage",
     "total": 55,
     "examples": [
-      "philodendron",
-      "anthurium",
-      "dumb cane",
-      "staghorn fern",
-      "nerve plant",
-      "sensitive plant"
+      "swiss cheese plant",
+      "umbrella tree",
+      "monstera",
+      "sempervivum",
+      "begonia",
+      "air plant"
     ]
   },
   "nature.sceneModifier": {
@@ -3547,12 +3547,12 @@
     "description": "Atmospheric conditions, weather, and mood modifiers for scenes",
     "total": 49,
     "examples": [
-      "sun-dappled",
-      "foreboding",
-      "cumulonimbus",
-      "dark skies",
-      "apocalyptic",
-      "cloudy"
+      "eerie",
+      "peaceful",
+      "frost-covered",
+      "drizzle",
+      "moss-draped",
+      "windswept"
     ]
   },
   "nature.scene": {
@@ -3561,12 +3561,12 @@
     "description": "Diverse natural environments, biomes, and landscape settings",
     "total": 84,
     "examples": [
-      "folly",
-      "crater",
-      "glacier",
-      "island",
-      "archipelago",
-      "gorge"
+      "beach",
+      "river",
+      "plains",
+      "castle",
+      "sinkhole",
+      "rocky outcrop"
     ]
   },
   "nature.sky": {
@@ -3575,12 +3575,12 @@
     "description": "Specific sky conditions, times of day, and cloud formations",
     "total": 198,
     "examples": [
-      "zenith sky",
-      "brooding sky",
-      "dramatic storm clouds",
+      "metallic sky",
+      "copper dawn sky",
+      "fogbow sky",
+      "full moon sky",
       "golden sunset sky",
-      "dreamlike sky",
-      "dusk sky"
+      "amber sky"
     ]
   },
   "nature.texture": {
@@ -3589,12 +3589,12 @@
     "description": "Assorted natural and artificial surface textures and patterns",
     "total": 167,
     "examples": [
-      "rust",
-      "shag carpet",
-      "plastic",
-      "porous volcanic rock",
-      "rustic wood",
-      "ice"
+      "lichen-covered rock",
+      "mottled fabric",
+      "fossilized limestone",
+      "fabric folds",
+      "velvet",
+      "paisley fabric"
     ]
   },
   "nature.treeType": {
@@ -3603,12 +3603,12 @@
     "description": "Various species of deciduous, coniferous, and tropical trees",
     "total": 71,
     "examples": [
-      "larch",
+      "sugar maple",
       "alder",
-      "hickory",
-      "linden",
-      "ash",
-      "bristlecone pine"
+      "western red cedar",
+      "spruce",
+      "silver birch",
+      "poplar"
     ]
   },
   "nature.tree": {
@@ -3617,12 +3617,12 @@
     "description": "Assorted tree species, fruiting trees, and woody plants",
     "total": 158,
     "examples": [
-      "douglas fir",
-      "longleaf pine",
-      "birch",
-      "arizona cypress",
-      "honeylocust",
-      "black walnut"
+      "fraser fir",
+      "monkey puzzle tree",
+      "white ash",
+      "virginia creeper",
+      "southern redcedar",
+      "scarlet oak"
     ]
   },
   "nature.tropicalHouseplant": {
@@ -3631,12 +3631,12 @@
     "description": "Tropical flowering plants, orchids, and decorative botanicals",
     "total": 104,
     "examples": [
-      "pentas",
-      "nemesia",
-      "maranta",
-      "pelargonium",
-      "spathiphyllum",
-      "verbena canadensis"
+      "gomphrena",
+      "odontoglossum",
+      "sinningia",
+      "amaranthus",
+      "codiaeum",
+      "schefflera"
     ]
   },
   "nature.waterBody": {
@@ -3645,12 +3645,12 @@
     "description": "Various types of natural and artificial water formations",
     "total": 109,
     "examples": [
-      "ocean",
-      "thermal spring",
-      "tributary",
-      "creeklet",
-      "source",
-      "waterhole"
+      "anabranch",
+      "bight",
+      "bourne",
+      "lake",
+      "cenote",
+      "lagoon"
     ]
   },
   "nature.weather": {
@@ -3659,12 +3659,12 @@
     "description": "Meteorological events, cloud types, and severe weather conditions",
     "total": 156,
     "examples": [
-      "sprinkle",
-      "mist",
-      "landspout",
-      "damp",
-      "kelvin-helmholtz clouds",
-      "rainy"
+      "snowy",
+      "black ice",
+      "drizzle",
+      "drought",
+      "glaze",
+      "cumulus clouds"
     ]
   },
   "nature.wood": {
@@ -3673,12 +3673,12 @@
     "description": "Specific types of hardwood and softwood timber materials",
     "total": 66,
     "examples": [
-      "koa",
-      "figured bubinga",
-      "butternut",
-      "hickory",
-      "jatoba",
-      "cedar"
+      "snakewood",
+      "cedar",
+      "bamboo",
+      "santos mahogany",
+      "macassar ebony",
+      "alder"
     ]
   },
   "people.accent": {
@@ -3687,12 +3687,12 @@
     "description": "Various global and regional spoken accents and dialects",
     "total": 126,
     "examples": [
-      "cornish",
-      "castilian",
-      "french",
-      "geordie",
-      "hebrew",
-      "estonian"
+      "persian",
+      "ukrainian",
+      "irish",
+      "multicultural london english",
+      "belfast",
+      "australian"
     ]
   },
   "people.beautifulFeminine": {
@@ -3701,12 +3701,12 @@
     "description": "Adjectives describing feminine beauty, grace, and physical attractiveness",
     "total": 48,
     "examples": [
-      "lovely",
-      "angelic",
-      "alluring",
-      "delicate",
-      "splendid",
-      "classy"
+      "curvaceous",
+      "stunning",
+      "fashionable",
+      "gorgeous",
+      "attractive",
+      "splendid"
     ]
   },
   "people.beautifulMasculine": {
@@ -3715,12 +3715,12 @@
     "description": "Personality traits and physical characteristics associated with masculine appeal",
     "total": 106,
     "examples": [
-      "loyal",
-      "muscular",
-      "peaceful",
-      "hard-working",
-      "dark skin",
-      "smooth skin"
+      "soft skin",
+      "rugged",
+      "thick, dark hair",
+      "polished",
+      "firm skin",
+      "intense"
     ]
   },
   "people.bodyType": {
@@ -3729,12 +3729,12 @@
     "description": "Detailed descriptions of various human body shapes, builds, and proportions",
     "total": 115,
     "examples": [
-      "thin all over, little body fat",
-      "curvy shape with larger hips",
-      "hourglass figure with long legs",
-      "broad shoulders, narrow hips",
-      "banana-shaped with straight hips and shoulders",
-      "hourglass figure with short legs"
+      "smaller upper body, wider hips and thighs",
+      "pear-shaped lower body with toned upper body",
+      "narrow shoulders, wider hips and thighs",
+      "straight up and down, similar to rectangular shape",
+      "shoulders wider than hips, tapers down",
+      "athletic and toned with defined abs"
     ]
   },
   "people.celebrity": {
@@ -3743,12 +3743,12 @@
     "description": "Famous actors, singers, influencers, and members of British royalty",
     "total": 646,
     "examples": [
-      "adriana lima",
-      "whitney cummings",
-      "jenna coleman",
-      "jamie chung",
-      "judy greer",
-      "elizabeth debicki"
+      "marion cotillard",
+      "jojo",
+      "chris pine",
+      "clint eastwood",
+      "christina aguilera",
+      "charli xcx"
     ]
   },
   "people.common": {
@@ -3757,12 +3757,12 @@
     "description": "Broad age groups, life stages, and general demographic categories",
     "total": 34,
     "examples": [
-      "middle-aged man",
-      "toddler",
-      "middle-aged woman",
-      "senior",
-      "adolescent",
-      "young man"
+      "young woman",
+      "schoolboy",
+      "teenager",
+      "millennial",
+      "schoolgirl",
+      "gen-zer"
     ]
   },
   "people.couple": {
@@ -3771,12 +3771,12 @@
     "description": "Various romantic, platonic, and professional two-person relationship dynamics",
     "total": 36,
     "examples": [
-      "married couple",
-      "same-sex couple",
-      "soulmates",
-      "lovers",
-      "teammates",
-      "duo"
+      "double date",
+      "colleagues",
+      "study partners",
+      "partners",
+      "roommates",
+      "pair"
     ]
   },
   "people.dance": {
@@ -3785,12 +3785,12 @@
     "description": "Traditional, cultural, and modern dance styles from around the world",
     "total": 119,
     "examples": [
-      "jitterbug dance",
-      "japanese butoh-fu dance",
-      "jive",
-      "charleston dance",
-      "chhau dance",
-      "lambada dance"
+      "maypole dance",
+      "robot dance",
+      "sidi goma dance",
+      "odissi dance",
+      "ballroom dance",
+      "sattriya dance"
     ]
   },
   "people.expression": {
@@ -3799,12 +3799,12 @@
     "description": "Highly detailed descriptions of facial expressions and emotional body language",
     "total": 471,
     "examples": [
-      "quivering upper lip with tear-filled eyes and a red face",
-      "soft, dreamy expression with a faraway look in the eyes",
-      "slight pout with puppy-dog eyes and raised inner eyebrows",
-      "scowl with furrowed brow and slightly protruding lower lip",
-      "slight pout with puppy-dog eyes and hunched shoulders",
-      "tight-lipped smile with one eyebrow raised inquisitively"
+      "weeping openly with streams of tears",
+      "sardonic laugh with head tilted and eyes narrowed",
+      "sideways head tilt with a slight smile",
+      "slight frown with one eyebrow raised questioningly",
+      "scowl with furrowed brow and slightly bared teeth",
+      "restrained, emotionless expression with alert eyes"
     ]
   },
   "people.eyeColor": {
@@ -3813,12 +3813,12 @@
     "description": "Natural and fantasy eye colors including gem-like and vivid shades",
     "total": 46,
     "examples": [
-      "grey eyes",
-      "ruby eyes",
-      "silver eyes",
-      "purple eyes",
+      "mint green eyes",
+      "deep brown eyes",
+      "sapphire eyes",
       "golden-brown eyes",
-      "honey brown eyes"
+      "light blue eyes",
+      "amber eyes"
     ]
   },
   "people.festival": {
@@ -3827,12 +3827,12 @@
     "description": "Major international cultural, religious, and seasonal festivals and holidays",
     "total": 59,
     "examples": [
-      "calgary stampede",
-      "carnival",
-      "sapporo snow festival",
-      "san fermin",
-      "pride month",
-      "semana santa"
+      "albuquerque international balloon fiesta",
+      "holi",
+      "st. patrick's day",
+      "valentine's day",
+      "dussehra",
+      "hanukkah"
     ]
   },
   "people.group": {
@@ -3841,12 +3841,12 @@
     "description": "Collective nouns and terms for various groups or gatherings of people",
     "total": 71,
     "examples": [
-      "coalition",
-      "spectators",
-      "people",
-      "fans",
-      "flock",
-      "customers"
+      "company",
+      "congregation",
+      "brigade",
+      "crew",
+      "guild",
+      "community"
     ]
   },
   "people.hairstyle": {
@@ -3855,12 +3855,12 @@
     "description": "Diverse haircuts, styling techniques, and hair textures for men and women",
     "total": 58,
     "examples": [
-      "beach waves",
-      "flat top",
-      "shag cut",
-      "bowl cut",
-      "high and tight",
-      "bob cut"
+      "bob cut",
+      "perm",
+      "beehive",
+      "messy bun",
+      "pageboy",
+      "beach waves"
     ]
   },
   "people.hobby": {
@@ -3869,12 +3869,12 @@
     "description": "Wide range of creative, physical, and intellectual hobbies and interests",
     "total": 291,
     "examples": [
-      "card making",
-      "poetry",
-      "collecting coins",
-      "photography",
-      "roller skating",
-      "paper folding"
+      "listening to music",
+      "urban farming",
+      "stand-up comedy",
+      "videography",
+      "conservation",
+      "animation"
     ]
   },
   "people.job": {
@@ -3883,12 +3883,12 @@
     "description": "Various professional occupations, roles, and employment titles",
     "total": 612,
     "examples": [
-      "retail clerk",
-      "librarian assistant",
-      "dentist",
-      "cryptographer",
-      "activist",
-      "aircraft maintenance technicians"
+      "mechanic",
+      "parts clerk",
+      "landscape architect",
+      "department manager",
+      "broadcaster",
+      "receptionist assistant"
     ]
   },
   "people.makeupStyle": {
@@ -3897,12 +3897,12 @@
     "description": "Historical, trendy, and artistic makeup styles and cosmetic techniques",
     "total": 73,
     "examples": [
+      "feline flick",
+      "strobing",
+      "body painting",
       "cat eye makeup",
       "clown makeup",
-      "fantasy makeup",
-      "festival makeup",
-      "goth makeup",
-      "editorial makeup"
+      "avant-garde makeup"
     ]
   },
   "people.posePortrait": {
@@ -3911,12 +3911,12 @@
     "description": "Specific camera angles, body positioning, and framing for portrait photography",
     "total": 45,
     "examples": [
-      "arms crossed",
-      "against a wall",
+      "lying down",
+      "close-up",
       "sitting on stairs",
-      "leaning back against a railing",
-      "dramatic close-up",
-      "sitting down with legs crossed"
+      "over-the-shoulder glance",
+      "chin resting on hand",
+      "propped up on one hand (sitting or standing)"
     ]
   },
   "people.pose": {
@@ -3925,12 +3925,12 @@
     "description": "Dynamic body postures, gestures, and physical actions for characters",
     "total": 201,
     "examples": [
-      "winking with one eye",
-      "leaning back",
-      "holding an object in one hand, such as a flower or book",
-      "dancing or jumping in mid-air with a joyful expression",
-      "crouching",
-      "lying on back with arms outstretched"
+      "standing on one leg with other leg bent at the knee",
+      "bowing",
+      "crouching down with hands on ground in front of body",
+      "leaning backward with one leg crossed in front of the other",
+      "kneeling on both knees",
+      "curled up"
     ]
   },
   "people.profession": {
@@ -3939,12 +3939,12 @@
     "description": "Specific historical, scientific, and specialized professions and trades",
     "total": 60,
     "examples": [
-      "carpenter",
-      "barrister",
-      "stonemason",
-      "silversmith",
-      "lepidopterist",
-      "librarian"
+      "beekeeper",
+      "shipwright",
+      "curator",
+      "geologist",
+      "watchmaker",
+      "lepidopterist"
     ]
   },
   "photography.apertureLook": {
@@ -3953,12 +3953,12 @@
     "description": "Photographic effects related to bokeh, depth of field, focus, and lens flares",
     "total": 52,
     "examples": [
-      "f/2.8 look",
-      "hyperfocal focus",
-      "deep focus",
-      "shallow depth of field",
-      "f/1.8 look",
-      "anamorphic bokeh"
+      "glow effect",
+      "anamorphic bokeh",
+      "f/16 look",
+      "f/1.4 creamy background",
+      "f/1.2 look",
+      "razor-sharp focus"
     ]
   },
   "photography.cameraMovement": {
@@ -3967,12 +3967,12 @@
     "description": "Cinematography terms for dynamic camera movements, rigs, and tracking shots",
     "total": 50,
     "examples": [
-      "push in",
+      "dutch tilt movement",
       "panning shot",
-      "shaky cam",
-      "arc shot",
-      "arc",
-      "time-lapse camera movement"
+      "tilting shot",
+      "pull out",
+      "crash zoom",
+      "timelapse"
     ]
   },
   "photography.camera": {
@@ -3981,12 +3981,12 @@
     "description": "Specific models of professional cinema cameras, DSLRs, and digital cameras",
     "total": 187,
     "examples": [
-      "ricoh gr ii",
-      "blackmagic design pocket cinema camera 4k",
-      "fujifilm gfx 100s",
-      "canon ae-1",
-      "samsung nx200 smart camera",
-      "blackmagic cinema camera 2.5k"
+      "imax hd camera",
+      "lomography diana f+",
+      "canon 6d",
+      "leica q2",
+      "canon 5d",
+      "samsung galaxy nx"
     ]
   },
   "photography.composition": {
@@ -3995,12 +3995,12 @@
     "description": "Visual composition techniques, framing styles, and spatial balance methods",
     "total": 117,
     "examples": [
-      "diagonal composition",
-      "u-shape composition",
-      "allover composition",
-      "z-shape composition",
-      "negative space",
-      "left-to-right rule"
+      "dynamic composition",
+      "bisection",
+      "golden ratio",
+      "nose room",
+      "steelyard composition",
+      "organic composition"
     ]
   },
   "photography.filmStock": {
@@ -4009,12 +4009,12 @@
     "description": "Specific brands, models, and ISO speeds of analog photographic film stocks",
     "total": 52,
     "examples": [
-      "agfa vista 400",
+      "instax mini film",
+      "fujifilm superia 400",
+      "cinestill 400d",
+      "ilford sfx 200",
       "cinestill 50d",
-      "fujifilm provia 100f",
-      "kodak ektar 100",
-      "ilford delta 3200",
-      "lomography purple"
+      "ilford delta 400"
     ]
   },
   "photography.film": {
@@ -4023,12 +4023,12 @@
     "description": "Specific analog photography film types, brands, and ISO speeds",
     "total": 102,
     "examples": [
-      "lomography color negative 400 film",
-      "fujifilm 120 film",
-      "fuji provia 400x rdpiii film",
-      "kodak 126 film",
-      "ilford pan 100 film",
-      "foma fomapan 200 film"
+      "kodak elite 400s film",
+      "kodak portra 800 film",
+      "agfa vista 100 film",
+      "fuji neopan 400 film",
+      "agfa precisa ctd 100 film",
+      "foma fomapan 400 film"
     ]
   },
   "photography.landscapeKeyword": {
@@ -4037,12 +4037,12 @@
     "description": "Broad photography concepts, subjects, and techniques related to outdoor photography",
     "total": 81,
     "examples": [
+      "forms",
+      "moon",
       "textures",
-      "exposure",
-      "dunes",
-      "horizons",
       "churches",
-      "angles"
+      "rivers",
+      "color"
     ]
   },
   "photography.landscapeSubjectDetailed": {
@@ -4051,12 +4051,12 @@
     "description": "Highly descriptive, full-sentence prompts of vivid nature and landscape scenes",
     "total": 158,
     "examples": [
-      "a lush, tropical island with palm-fringed beaches",
-      "a rolling hillside covered in vineyards",
-      "a picturesque river gorge with towering cliffs",
-      "a quiet birch forest in winter with a fresh blanket of powdery snow",
-      "a peaceful zen garden with meticulously raked sand around large mossy stones",
-      "a remote wilderness area with snow-covered peaks and alpine meadows"
+      "a series of terraced rice paddies reflecting the warm colors of a sunset",
+      "a peaceful fjord with calm waters and steep cliffs",
+      "a dramatic coastline with towering cliffs and crashing waves",
+      "a colorful canyon with towering walls of rock",
+      "a frozen tundra with snow-covered hills and valleys",
+      "a colorful hot spring with steam rising from the water"
     ]
   },
   "photography.landscapeSubject": {
@@ -4065,12 +4065,12 @@
     "description": "Various natural and man-made outdoor locations, structures, and landscape features",
     "total": 132,
     "examples": [
-      "forest",
-      "savannah",
-      "badlands",
-      "water tower",
-      "cave",
-      "alpine meadow"
+      "sandstone formation",
+      "harbor",
+      "airport",
+      "wildflower",
+      "satellite dish",
+      "arboretum"
     ]
   },
   "photography.lensType": {
@@ -4079,12 +4079,12 @@
     "description": "General categories, optical designs, and specialized styles of photographic lenses",
     "total": 52,
     "examples": [
-      "apochromatic lens",
-      "fresnel lens",
+      "cine lens",
+      "standard lens",
+      "pinhole",
       "apochromatic",
-      "cine",
-      "ultra-wide-angle",
-      "fisheye"
+      "soft focus lens",
+      "helios 44-2 lens"
     ]
   },
   "photography.lens": {
@@ -4093,12 +4093,12 @@
     "description": "Specific focal lengths and exact branded camera lens models",
     "total": 87,
     "examples": [
-      "canon ef 35mm",
-      "300mm",
-      "nikon z 100-400mm",
-      "sony fe 50mm",
-      "sony fe 16-35mm",
-      "nikon af-s 50mm"
+      "sony fe 24-70mm",
+      "18mm",
+      "200mm",
+      "fujifilm xf 8-16mm",
+      "50mm",
+      "fujifilm xf 35mm"
     ]
   },
   "photography.lightSource": {
@@ -4107,12 +4107,12 @@
     "description": "Natural, artificial, and specialized light sources and lighting equipment",
     "total": 64,
     "examples": [
-      "desk lamp",
-      "bioluminescence",
+      "matchstick",
       "halogen lamp",
-      "flashlight",
-      "fireplace",
-      "blacklight"
+      "chemiluminescence",
+      "firefly glow",
+      "fiber optics",
+      "spotlight"
     ]
   },
   "photography.light": {
@@ -4121,12 +4121,12 @@
     "description": "Descriptive lighting styles, natural light conditions, and illumination techniques",
     "total": 136,
     "examples": [
-      "flat lighting",
-      "dual red and green",
-      "afternoon lighting",
-      "lit by fluorescent tube",
-      "ethereal light",
-      "bright sunlight"
+      "rembrandt lighting",
+      "low pressure sodium lamps",
+      "3 spots lighting",
+      "lit by umbrella light",
+      "blinding light",
+      "dekatron light"
     ]
   },
   "photography.lightingSetup": {
@@ -4135,12 +4135,12 @@
     "description": "Studio lighting techniques, setups, and directional illumination styles",
     "total": 52,
     "examples": [
-      "dramatic lighting",
-      "available lighting",
+      "short lighting",
       "front lighting",
-      "broad lighting",
-      "checkerboard lighting",
-      "silhouette lighting"
+      "key lighting",
+      "top lighting",
+      "beauty dish lighting",
+      "loop lighting"
     ]
   },
   "photography.perspective": {
@@ -4150,11 +4150,11 @@
     "total": 129,
     "examples": [
       "dutch angle",
-      "anamorphic perspective",
-      "cross-section view",
-      "extreme close-up perspective",
-      "first-person view",
-      "horizon-level view"
+      "dolly-zoom perspective",
+      "exploded view",
+      "dimetric perspective",
+      "cabinet perspective",
+      "distorted perspective"
     ]
   },
   "photography.photographer": {
@@ -4163,12 +4163,12 @@
     "description": "Names of famous photographers paired with their specific genres or styles",
     "total": 960,
     "examples": [
-      "zaida ben-yusuf (portrait photographer)",
-      "mitch epstein (documentary photographer)",
-      "marc riboud (documentary photographer)",
-      "mariya kozhanova (documentary and portrait photographer)",
-      "max dupain (documentary and commercial photographer)",
-      "zack arias (portrait and editorial photographer)"
+      "dmitry markov (portrait photographer)",
+      "boushra almutawakel (conceptual and portrait photographer)",
+      "philip-lorca dicorcia (documentary and fine art photographer)",
+      "david lachapelle (fashion and fine art photographer)",
+      "faisal abdu'allah (conceptual and portrait photographer)",
+      "dougie wallace (documentary photographer)"
     ]
   },
   "photography.portraitPhotographer": {
@@ -4177,12 +4177,12 @@
     "description": "Names of renowned portrait, fine art, and fashion photographers",
     "total": 79,
     "examples": [
-      "martin schoeller",
-      "bill brandt",
-      "joel meyerowitz",
-      "august sander",
-      "jürgen teller",
-      "bruce gilden"
+      "julia margaret cameron",
+      "man ray",
+      "jeff wall",
+      "rania matar",
+      "nan goldin",
+      "lee jeffries"
     ]
   },
   "photography.shotType": {
@@ -4191,12 +4191,12 @@
     "description": "Various camera angles and framing techniques for photography and film",
     "total": 43,
     "examples": [
-      "aerial shot",
-      "american shot",
-      "drone shot",
-      "cowboy shot",
-      "bird's-eye view",
-      "close-up"
+      "reaction shot",
+      "medium wide shot",
+      "candid shot",
+      "hip level shot",
+      "three shot",
+      "three-quarter shot"
     ]
   },
   "photography.summerScene": {
@@ -4205,12 +4205,12 @@
     "description": "Idyllic, warm-weather outdoor scenes, landscapes, and summer activities",
     "total": 47,
     "examples": [
-      "a rustic beach shack surrounded by sand dunes and sea grass",
-      "a peaceful campsite under a canopy of stars next to a glowing campfire",
-      "a garden filled with butterflies and hummingbirds",
-      "a rolling green hill dotted with grazing sheep",
-      "a mountain lake surrounded by trees",
-      "a terrace overlooking coastal cliffs and the turquoise mediterranean sea"
+      "a city park with lush green trees and flowers in full bloom",
+      "a country road winding through fields and forests",
+      "a boat ride on a river or lake",
+      "a vibrant farmers market stall with stacks of ripe red watermelons",
+      "a lush field of sunflowers glowing in the golden hour light",
+      "a thunderstorm rolling in over a prairie landscape"
     ]
   },
   "photography.summerTropicalBeach": {
@@ -4219,12 +4219,12 @@
     "description": "Sensory details and vibrant scenes of a tropical beach vacation",
     "total": 67,
     "examples": [
-      "the gentle sound of water lapping at the shore, like a soothing balm",
-      "a collection of brightly colored fishing boats bobbing in the water",
+      "a friendly game of beach volleyball in progress",
+      "a collection of colorful beach umbrellas providing welcome shade",
+      "a sun-kissed beach populated by happy vacationers and locals alike",
+      "a flock of pelicans soaring gracefully overhead",
       "a dazzling display of stars overhead on a clear night",
-      "children splashing in the gentle, warm shallows of a protected lagoon",
-      "a vibrant, colorful reef visible just offshore",
-      "gentle waves rolling in and out, leaving a lacy pattern of foam on the sand"
+      "a family building a towering sandcastle with a moat at the water's edge"
     ]
   },
   "photojournalism.newsExtreme": {
@@ -4233,12 +4233,12 @@
     "description": "Catastrophic, world-altering, and extreme global news events and disasters",
     "total": 68,
     "examples": [
+      "a major tech company's headquarters is destroyed in a terrorist attack",
+      "a new designer drug takes the world by storm, causing a major public health crisis",
+      "a new type of energy storage technology is discovered, making renewable energy even more feasible",
       "a massive data leak exposes the private information of millions",
-      "a massive new environmental law is passed",
-      "a major historical artifact is discovered, rewriting history as we know it",
-      "a global agricultural blight rapidly destroys half of the world's wheat and corn crops",
-      "a new type of food additive is discovered to be causing cancer in humans",
-      "a major new discovery in the world of quantum physics"
+      "a new type of terrorist attack that targets major sporting events is carried out",
+      "a massive tornado tears through a major city"
     ]
   },
   "photojournalism.newsNormal": {
@@ -4247,12 +4247,12 @@
     "description": "Standard major news headlines covering science, politics, business, and society",
     "total": 57,
     "examples": [
-      "a major geopolitical event, such as a peace treaty or a declaration of war",
+      "a major climate disaster, such as a tornado or a record-breaking heatwave",
+      "a historic museum heist occurs, with thieves stealing priceless masterpieces overnight",
       "a high-profile court trial of a corrupt politician begins, attracting massive media crowds",
-      "a major natural disaster, such as a hurricane or earthquake, that leaves thousands of people displaced",
-      "a political protest, aimed at overturning a controversial law or policy",
-      "a new high-speed rail line is inaugurated, connecting major cities and reducing travel times",
-      "a major international airport suffers a system-wide it failure, grounding hundreds of commercial flights"
+      "a prominent social media influencer is banned from major platforms, sparking intense debate on free speech",
+      "a major breakthrough in space exploration, such as the discovery of a new planet or the launch of a new mission to the moon",
+      "a major cultural festival, celebrating the traditions and customs of a particular group or region"
     ]
   },
   "photojournalism.newsSpecific": {
@@ -4261,12 +4261,12 @@
     "description": "Highly detailed, specific descriptions of major global news events and crises",
     "total": 38,
     "examples": [
+      "a landmark supreme court ruling: justices hand down a historic decision on privacy rights in the digital age, limiting government surveillance",
+      "a massive refugee migration: thousands of families flee gang violence in central america, forming a massive caravan traveling toward the border",
+      "a high-profile corporate corruption trial: the chief executive of an energy giant goes on trial for multi-billion-dollar fraud and embezzlement",
+      "a devastating building collapse: a multi-story residential building in mumbai collapses overnight, triggering a frantic search for survivors",
       "a major civil rights movement: the black lives matter movement gains widespread support and leads to major policy changes, including police reform and the removal of confederate statues",
-      "a critical space rescue: an international crew of astronauts executes a daring spacewalk to repair a damaged life-support system",
-      "a mass protest against police brutality and systemic racism: thousands march through the streets of new york city, demanding justice for victims of police violence and systemic racism in the criminal justice system",
-      "a major sporting event: the world cup is held in qatar, bringing together teams from around the world and drawing massive crowds of enthusiastic fans",
-      "a breakthrough in the fight against cancer: researchers develop a new type of cancer treatment that uses the body's own immune system to target and destroy cancer cells",
-      "a stunning scientific achievement: fusion energy researchers achieve net energy gain for the first time, marking a major milestone for clean power"
+      "a groundbreaking archaeological discovery: researchers in egypt unearth a pristine, undisturbed royal tomb dating back three thousand years"
     ]
   },
   "photojournalism.styleProtest": {
@@ -4275,12 +4275,12 @@
     "description": "Various photographic styles and techniques used in photojournalism and documentary photography",
     "total": 38,
     "examples": [
-      "dramatic silhouette photography: framing protesters against a bright light source, like the setting sun or police headlights, to create powerful dark outlines",
-      "action photography: capturing the movement and energy of the protesters in action",
-      "intentional camera movement: deliberately moving the camera during a longer exposure to create a dynamic, abstract representation of chaos and action",
-      "street photography: capturing the atmosphere of the protests and the surrounding environment",
-      "documentary photography: providing a historical record of the protests and the people involved",
-      "close-up portraiture: focusing tightly on the expressive faces of individual protesters to highlight intense human emotion and determination"
+      "extreme wide-angle photography: using wide lenses to include both the protesters in the foreground and the grand architectural context in the background",
+      "close-up portraiture: focusing tightly on the expressive faces of individual protesters to highlight intense human emotion and determination",
+      "monochrome photojournalism: stripping away color to emphasize form, texture, shadow, and the pure raw emotion of the moment",
+      "selective focus photography: using a shallow depth of field to isolate a single protester, sign, or detail while blurring the surrounding crowd",
+      "snapshots: capturing the small, intimate moments of protests that might be overlooked by other forms of photojournalism",
+      "photojournalistic essay: using a series of photographs to tell a story about the protests and the issues they are addressing"
     ]
   },
   "photojournalism.types": {
@@ -4289,12 +4289,12 @@
     "description": "Diverse subjects and thematic beats covered in photojournalism and documentary reporting",
     "total": 87,
     "examples": [
-      "advocacy photojournalism, documenting specific causes to raise awareness and inspire social change",
-      "entertainment and celebrity culture",
-      "community and neighborhood storytelling, highlighting the everyday lives and challenges of local residents",
-      "religion and spirituality",
-      "transportation and infrastructure",
-      "photojournalistic coverage of the refugee crisis and displacement"
+      "investigative reporting on the impact of big tech on society and privacy concerns",
+      "architectural and urban preservation, documenting historic landmarks threatened by development",
+      "art and culture events",
+      "extreme sports and adventure photojournalism",
+      "conflict resolution and peacekeeping missions, focusing on diplomatic efforts and peacekeepers in the field",
+      "cultural heritage and indigenous rights, documenting the preservation of ancient traditions and land claims"
     ]
   },
   "places.home": {
@@ -4303,12 +4303,12 @@
     "description": "Various types of residential dwellings and architectural housing styles",
     "total": 103,
     "examples": [
-      "stilt house",
-      "thatched roof home",
-      "solar home",
-      "playhouse",
-      "prefab home",
-      "shipping container home"
+      "cabin",
+      "villa",
+      "duplex",
+      "hut",
+      "chateau",
+      "earth sheltered home"
     ]
   },
   "places.interiorSpace": {
@@ -4317,12 +4317,12 @@
     "description": "Diverse indoor environments ranging from mundane rooms to specialized workspaces",
     "total": 481,
     "examples": [
-      "indoor balcony",
-      "cloakroom",
-      "cowshed",
-      "abbey church nave",
-      "arcade hall",
-      "distillery"
+      "office cubicle",
+      "tasting room",
+      "sewing room",
+      "spare room",
+      "tailor shop",
+      "school cafeteria"
     ]
   },
   "places.public": {
@@ -4331,12 +4331,12 @@
     "description": "Common public venues, recreational areas, and civic facilities",
     "total": 94,
     "examples": [
-      "ice rink",
-      "seafront promenade",
-      "observatory",
-      "hiking trail",
-      "lighthouse",
-      "art gallery"
+      "movie theater",
+      "cathedral",
+      "college campus",
+      "driving range",
+      "fountain",
+      "aquarium"
     ]
   },
   "places.roomType": {
@@ -4345,12 +4345,12 @@
     "description": "Specific, often historical or grand interior rooms and specialized chambers",
     "total": 71,
     "examples": [
-      "great hall",
-      "vault",
-      "root cellar",
-      "wine cellar",
-      "scriptorium",
-      "wardrobe"
+      "cellar",
+      "antechamber",
+      "darkroom",
+      "music room",
+      "anteroom",
+      "banquet hall"
     ]
   },
   "places.room": {
@@ -4359,12 +4359,12 @@
     "description": "Standard functional rooms and spaces found in typical modern homes",
     "total": 51,
     "examples": [
+      "mail room",
       "balcony",
-      "conference room",
-      "waiting room",
-      "cellar",
-      "conservatory",
-      "server room"
+      "scullery",
+      "pantry",
+      "bathroom",
+      "attic"
     ]
   },
   "places.urbanFeature": {
@@ -4373,12 +4373,12 @@
     "description": "Structural elements, fixtures, and infrastructure found in city environments",
     "total": 196,
     "examples": [
-      "public restroom",
-      "alleyway",
-      "hanging basket",
-      "jersey barrier",
-      "market stall",
-      "lamppost"
+      "green roof",
+      "marquee",
+      "elevated railway",
+      "dog park",
+      "highway ramp",
+      "canopy"
     ]
   },
   "plot.action": {
@@ -4387,12 +4387,12 @@
     "description": "High-stakes, thrilling scenarios involving combat, heists, rescues, and survival",
     "total": 66,
     "examples": [
-      "infiltrating a high-stakes illegal casino to gather evidence",
-      "rescuing survivors of a natural disaster",
+      "infiltrating a secret society or cult",
       "preventing a dangerous weapon from falling into the wrong hands",
-      "stopping a political uprising or revolution",
-      "stopping a rogue government agency or corporation",
-      "stopping a criminal mastermind from enacting their plan"
+      "defending against a cyber attack or hacking attempt",
+      "rescuing survivors of a natural disaster",
+      "stopping a nuclear missile launch from a remote silo",
+      "escaping from a helicopter crash or other airborne disaster"
     ]
   },
   "plot.arthouse": {
@@ -4401,12 +4401,12 @@
     "description": "Introspective narratives focusing on emotional struggles, relationships, and personal crises",
     "total": 66,
     "examples": [
-      "dealing with an unwanted pregnancy",
-      "struggling with poverty",
-      "facing discrimination based on race, gender or sexuality",
-      "unraveling the subtle threads of a shared family myth",
-      "navigating the quiet decay of a suburban marriage",
-      "forming a secret society"
+      "challenging the status quo",
+      "being haunted by a ghost",
+      "dealing with a moral dilemma",
+      "investigating a mysterious disappearance",
+      "engaging in acts of rebellion",
+      "struggling with identity issues"
     ]
   },
   "plot.fantasy": {
@@ -4415,12 +4415,12 @@
     "description": "Magical and supernatural adventures involving mythical creatures, curses, and epic quests",
     "total": 66,
     "examples": [
-      "participating in a prophecy or destiny",
-      "closing a rift opening into the elemental plane of fire",
-      "retrieving a stolen treasure",
-      "fighting against an army of undead creatures",
+      "recovering a forgotten language of power",
+      "overcoming obstacles in a world filled with magic",
+      "restoring light to a dying sacred world-tree",
+      "navigating the shifting rules of a court of fae nobility",
       "overcoming personal demons or fears",
-      "dealing with the aftermath of a spell gone wrong"
+      "surviving in a world with limited resources"
     ]
   },
   "plot.general": {
@@ -4429,12 +4429,12 @@
     "description": "A mix of everyday life events, personal goals, and lighthearted adventures",
     "total": 109,
     "examples": [
-      "going on a holiday",
-      "participating in a scavenger hunt",
-      "renovating a historic but run-down house",
-      "seeking revenge",
-      "participating in a charity walk",
-      "attending a music festival"
+      "attempting to break a world record",
+      "attending a high school reunion",
+      "saving a local landmark from corporate developers",
+      "planning a heist",
+      "solving a mystery or crime",
+      "performing a musical"
     ]
   },
   "plot.horror": {
@@ -4443,12 +4443,12 @@
     "description": "Horror and survival scenarios involving supernatural entities, monsters, and deadly environments",
     "total": 65,
     "examples": [
-      "battling a supernatural entity",
-      "escaping from a haunted house",
-      "fighting against a cult",
-      "investigating a mysterious ghost town",
+      "staying alive in a world overrun by genetically modified creatures",
       "investigating a series of bizarre deaths",
-      "being pursued by an ancient woodland deity after trespassing"
+      "escaping from a mad scientist's laboratory",
+      "investigating a cursed radio signal that causes hallucinations",
+      "escaping from a haunted forest",
+      "investigating a mysterious ghost town"
     ]
   },
   "plot.musical": {
@@ -4457,12 +4457,12 @@
     "description": "Storylines focused on musical competitions, bands, solo artists, and creative collaborations",
     "total": 66,
     "examples": [
-      "balancing a secret identity as a rising pop star and a normal student",
-      "competing for a prestigious scholarship at a music conservatory",
-      "finding their own unique sound",
-      "finding inspiration for new music",
-      "finding the courage to perform in public after a personal loss",
-      "finding the courage to experiment with different musical styles"
+      "reuniting an old high school garage band for one last gig",
+      "dealing with the impact of age on a musical career",
+      "discovering a hidden singing talent in an unassuming street busker",
+      "learning to work together as a musical team",
+      "navigating the rivalry between two competing music academies",
+      "saving a beloved historic theater from demolition through a benefit concert"
     ]
   },
   "plot.romance": {
@@ -4471,12 +4471,12 @@
     "description": "Romantic storylines about overcoming personal, social, and communication obstacles to find love",
     "total": 65,
     "examples": [
-      "coping with infidelity or trust issues",
+      "coping with the end of a relationship",
+      "surviving a test of love",
+      "dealing with the complexities of a polyamorous relationship",
       "overcoming communication issues or misunderstandings",
-      "navigating a romance that blooms during a scenic culinary tour",
-      "rekindling love after a period of distance",
-      "finding love despite personal or financial difficulties",
-      "dealing with relationship challenges or obstacles"
+      "navigating a romance between a member of royalty and a commoner",
+      "navigating a romance that blooms during a scenic culinary tour"
     ]
   },
   "plot.scifiCyberpunk": {
@@ -4485,12 +4485,12 @@
     "description": "Cyberpunk scenarios involving hacking, rogue AI, cyborgs, and dystopian corporate espionage",
     "total": 66,
     "examples": [
-      "escaping from a virtual prison or detention center",
-      "discovering a ghost in the machine within a colossal city-wide mainframe",
-      "investigating a technological cover-up",
       "defending against a powerful ai or rogue program",
-      "overcoming addiction to virtual reality or technology",
-      "stealing advanced weapons or military technology"
+      "navigating through a cyber-controlled wasteland",
+      "investigating a technological cover-up",
+      "overcoming personal limitations through technology",
+      "infiltrating an orbital space penthouse owned by the elite",
+      "navigating through a virtual maze or labyrinth"
     ]
   },
   "plot.scifi": {
@@ -4499,12 +4499,12 @@
     "description": "Science fiction scenarios featuring space exploration, alien encounters, and planetary disasters",
     "total": 185,
     "examples": [
-      "stopping a rogue ai from destroying humanity",
-      "a group of rebels attempt to overthrow a powerful cyborg empire",
-      "battling against alien races or space monsters",
-      "dealing with the consequences of space travel or time-travel",
-      "a group of survivors try to rebuild society after a massive emp destroys all technology",
-      "dealing with the consequences of a space-based weapon"
+      "searching for a way to communicate with a mysterious alien race",
+      "establishing first contact with a non-carbon-based lifeform",
+      "exploring a lost moon",
+      "a team of rebels try to stop a massive asteroid from hitting earth",
+      "a group of astronauts try to save earth from an alien attack by using a mysterious device",
+      "infiltrating a space-based research facility or laboratory"
     ]
   },
   "plot.war": {
@@ -4513,12 +4513,12 @@
     "description": "Military and tactical operations including covert missions, sieges, and defensive stands",
     "total": 66,
     "examples": [
-      "infiltrating a coastal artillery battery to disable its guns",
-      "securing a remote radio tower to restore allied communications",
-      "overcoming physical challenges in extreme conditions",
-      "surviving behind enemy lines",
-      "participating in a rescue mission",
-      "fighting on the front lines of a battle"
+      "infiltrating enemy territory",
+      "stopping enemy propaganda or psychological operations",
+      "stopping enemy sabotage or guerrilla operations",
+      "destroying enemy supplies or logistics",
+      "recovering a downed pilot from deep within enemy territory",
+      "conducting a sabotage mission"
     ]
   },
   "science.astronomy": {
@@ -4527,12 +4527,12 @@
     "description": "Astronomical concepts, phenomena, and celestial structures like black holes and dark matter",
     "total": 54,
     "examples": [
-      "mars",
-      "mercury",
-      "white dwarf",
-      "event horizon",
-      "big bang",
-      "cosmic microwave background"
+      "solar wind",
+      "eclipse",
+      "cosmic ray",
+      "binary star",
+      "pluto",
+      "neptune"
     ]
   },
   "science.chemicalElement": {
@@ -4541,12 +4541,12 @@
     "description": "Various chemical elements from the periodic table",
     "total": 118,
     "examples": [
-      "radium",
-      "boron",
-      "holmium",
-      "dubnium",
-      "hassium",
-      "cobalt"
+      "dysprosium",
+      "seaborgium",
+      "terbium",
+      "thallium",
+      "actinium",
+      "gadolinium"
     ]
   },
   "science.constellation": {
@@ -4555,12 +4555,12 @@
     "description": "Names of recognized star constellations in the night sky",
     "total": 88,
     "examples": [
-      "lacerta",
-      "circinus",
-      "columba",
-      "caelum",
-      "auriga",
-      "canis minor"
+      "lynx",
+      "leo",
+      "volans",
+      "sagittarius",
+      "lepus",
+      "scutum"
     ]
   },
   "science.geometry": {
@@ -4569,12 +4569,12 @@
     "description": "Advanced mathematical shapes, fractals, attractors, and geometric concepts",
     "total": 117,
     "examples": [
-      "klein bottle",
-      "strange attractor",
-      "platonic solid",
-      "knot theory",
-      "superellipse",
-      "truncated octahedron"
+      "julia 3d fractal",
+      "clifford attractor",
+      "kite hexecontahedron",
+      "fractal",
+      "archimedean solids",
+      "ellipsoid"
     ]
   },
   "science.isotope": {
@@ -4583,12 +4583,12 @@
     "description": "Specific radioactive and stable isotopes of various chemical elements",
     "total": 56,
     "examples": [
-      "beryllium-10",
-      "sulfur-35",
-      "neptunium-237",
-      "promethium-147",
+      "curium-244",
       "aluminium-26",
-      "molybdenum-99"
+      "carbon-12",
+      "argon-40",
+      "phosphorus-32",
+      "technetium-99m"
     ]
   },
   "science.medicalImages": {
@@ -4597,12 +4597,12 @@
     "description": "Medical imaging techniques and diagnostic scanning procedures",
     "total": 45,
     "examples": [
-      "4d ultrasound",
-      "3d ultrasound",
-      "fmri",
-      "echocardiography",
       "ct scan",
-      "oct scan"
+      "bone scan",
+      "fmri",
+      "pet scan",
+      "ultrasound",
+      "optical coherence tomography"
     ]
   },
   "science.planetBody": {
@@ -4611,12 +4611,12 @@
     "description": "Specific planets, moons, asteroids, and other named celestial bodies",
     "total": 224,
     "examples": [
-      "ceres",
-      "carme",
-      "titania",
-      "rhea",
-      "trappist-1c",
-      "neat"
+      "lysithea",
+      "adrastea",
+      "eunomia",
+      "2002 ms4",
+      "desdemona",
+      "churyumov-gerasimenko"
     ]
   },
   "science.robotType": {
@@ -4625,12 +4625,12 @@
     "description": "Various types of industrial, agricultural, and specialized autonomous robots and drones",
     "total": 328,
     "examples": [
-      "telepresence robot",
-      "edible robot",
-      "gecko-inspired climber",
-      "assistive robot",
-      "autonomous surface vehicle",
-      "lunar rover"
+      "sample-preparation robot",
+      "hybrid drone",
+      "atmospheric satellite",
+      "modular robot",
+      "internal pipe robot",
+      "humanoid robot"
     ]
   },
   "science.scifiTech": {
@@ -4639,12 +4639,12 @@
     "description": "Fictional science fiction technology, gadgets, and futuristic devices",
     "total": 63,
     "examples": [
-      "carbonite chamber",
-      "replicator",
-      "disintegrator ray",
-      "gauss rifle",
-      "time machine",
-      "cryo-sleep chamber"
+      "bacta tank",
+      "genetic sequencer",
+      "cloning vat",
+      "artificial gravity generator",
+      "teleporter",
+      "matter replicator"
     ]
   },
   "set.describeStyle": {
@@ -4653,12 +4653,12 @@
     "description": "Eclectic art styles, hashtags, and artist names used in AI image generation",
     "total": 17756,
     "examples": [
-      "james nares",
-      "abstracted figurative forms",
-      "dark aquamarine and gray",
-      "bold spray-painted letters",
-      "dark yellow and black",
-      "dark green and orange"
+      "dark yellow and dark gold",
+      "light gray and dark cyan",
+      "highly detailed illustrations",
+      "delicately rendered landscapes",
+      "installation creator",
+      "baroque still life"
     ]
   },
   "set.describeSubject": {
@@ -4667,12 +4667,12 @@
     "description": "Highly specific, random AI-generated image prompts and surreal subject descriptions",
     "total": 139614,
     "examples": [
-      "a young muslim woman stands near a table wearing traditional dress",
-      "a painting showing a hand holding an arrow",
-      "a picture of a valley with mountains and the words ugrave",
-      "a painting shows a couple walking by the seaside together",
-      "a man in a suit with his arms crossed",
-      "a man in a suit and tie is talking"
+      "a cartoon cat in an icon on a white background",
+      "anime character pictures",
+      "3d rendered frog with raft",
+      "a black and white photo of a bird on the Antarctic island of st john do",
+      "a gun pistol with two hands",
+      "a black and white logo for quiksilver"
     ]
   },
   "set.memeDescription": {
@@ -4681,12 +4681,12 @@
     "description": "Popular internet memes paired with brief descriptions of their visual content",
     "total": 44,
     "examples": [
+      "ceiling cat meme - cat peering through hole in ceiling",
+      "expectation vs. reality meme - two images contrasting ideal and actual outcomes",
+      "dolan meme - poorly drawn donald duck with absurd captions",
       "american chopper argument meme - father and son yelling, throwing chair",
-      "bernie sanders \"i am once again asking\" meme - bernie asking for financial support",
-      "first world problems meme - woman crying over trivial issues",
-      "disaster girl meme - young girl smirking in front of burning house",
-      "gibby on icarly \"i don't care if you broke your elbow\" meme - gibby responding callously",
-      "galaxy brain meme - increasingly glowing brains with complex ideas"
+      "ancient aliens guy meme - man with wild hair gesturing \"aliens",
+      "coffin dance meme - same as dancing pallbearers"
     ]
   },
   "set.meme": {
@@ -4695,12 +4695,12 @@
     "description": "Popular internet memes and viral image macros",
     "total": 44,
     "examples": [
-      "area 51 raid meme",
-      "ermahgerd meme",
-      "first world problems meme",
-      "felt cute might delete later meme",
-      "blinking white guy meme",
-      "ceiling cat meme"
+      "chad vs. virgin meme",
+      "crying michael jordan meme",
+      "bad luck brian meme",
+      "doge meme",
+      "confused math lady meme",
+      "dab meme"
     ]
   },
   "set.moviegenBench": {
@@ -4709,12 +4709,12 @@
     "description": "MovieGen Video Bench contains 1003 diverse prompts testing various aspects including human activities (motion, emotions), animals, nature/scenery, physics (fluids, gravity, collisions), and unusual subjects/activities. The prompts provide comprehensive coverage across high, medium and low motion scenarios.\n",
     "total": 1003,
     "examples": [
-      "A woman is search her bag trying to find something.",
-      "A man talking animatedly on the phone, his mouth moving rapidly.",
-      "Close-up of a bright blue parrot's feathers glittering in the light, showing its unique plumage and vibrant colors",
-      "A woman applying bright red lipstick in front of a mirror.",
-      "A man is playing the drums under the water",
-      "Top view timelapse video of an artwork being drawn by hand with colored markers, the artwork shows a dragon flying over a castle"
+      "A person making pottery from clay that changes colors with each touch.",
+      "A low-angle shot of a towering skyscraper against a blue sky, giving a sense of its immense height.",
+      "An over-the-shoulder perspective of a chef meticulously plating a dish in a bustling kitchen.",
+      "The mesmerizing dance of boiling water in a pot, with bubbles rising, bursting, and sending ripples across the surface.",
+      "A magical forest with trees that have faces and whisper to each other.",
+      "an adorable kangaroo wearing blue jeans and a white t shirt taking a pleasant stroll in Mumbai India during a winter storm"
     ]
   },
   "set.parti": {
@@ -4723,12 +4723,12 @@
     "description": "PartiPrompts (P2) is a rich set of over 1600 prompts in English. P2 can be used to measure model capabilities across various categories and challenge aspects.\n",
     "total": 1632,
     "examples": [
-      "a robot cooking in the kitchen",
-      "the planet Jupiter",
-      "A cat that has black fur bats a red Christmas ornament that has silver sparkles.",
-      "a white pawn attacking a black bishop",
-      "air",
-      "A bare kitchen has wood cabinets and white appliances"
+      "A high resolution photo of a large bowl of ramen. There are several origami boats in the ramen of different colors.",
+      "a child eating a birthday cake near some palm trees",
+      "a roast turkey being taken out of the oven",
+      "a cow eating a green leafy plant",
+      "a bamboo ladder",
+      "a politician giving a speech at a podium"
     ]
   },
   "sport.all": {
@@ -4737,12 +4737,12 @@
     "description": "Various athletic sports, gymnastics, and competitive physical activities",
     "total": 470,
     "examples": [
-      "air hockey",
-      "bobsleigh",
-      "cross-country running",
-      "croquet",
-      "chess boxing",
-      "canyoning"
+      "roller hockey",
+      "deep-water soloing",
+      "field hockey",
+      "ice fishing",
+      "finswimming",
+      "basque pelota"
     ]
   },
   "thing.adjective": {
@@ -4751,12 +4751,12 @@
     "description": "Adjectives describing physical textures and material conditions",
     "total": 71,
     "examples": [
-      "elastic",
-      "distressed",
-      "gritty",
-      "rusty",
-      "folded",
-      "spongy"
+      "silky",
+      "crinkled",
+      "dull",
+      "fuzzy",
+      "hard",
+      "mushy"
     ]
   },
   "thing.armor": {
@@ -4765,12 +4765,12 @@
     "description": "Historical and modern protective armor, helmets, and tactical vests",
     "total": 171,
     "examples": [
-      "adrian helmet",
-      "sode",
-      "lorica hamata",
-      "pig-faced bascinet",
-      "linothorax",
-      "banded mail"
+      "cabasset helmet",
+      "scale barding",
+      "plate mail",
+      "tassets",
+      "ringmail barding",
+      "kabuto helmet"
     ]
   },
   "thing.city": {
@@ -4779,12 +4779,12 @@
     "description": "Urban infrastructure, commercial buildings, and city street elements",
     "total": 216,
     "examples": [
-      "greek restaurant",
-      "street vendor cart",
-      "statue",
-      "skyscraper",
-      "overpass",
-      "sidewalk"
+      "dentist",
+      "thrift store",
+      "bus",
+      "ambulance",
+      "alleyway",
+      "swimming pool"
     ]
   },
   "thing.everyday": {
@@ -4793,12 +4793,12 @@
     "description": "Common household objects, appliances, and everyday personal items",
     "total": 243,
     "examples": [
-      "drill",
-      "books",
+      "sink",
+      "frying pan",
       "desk lamp",
-      "tea towel",
-      "shoes",
-      "rags"
+      "oven",
+      "bottle opener",
+      "earrings"
     ]
   },
   "thing.fabric": {
@@ -4807,12 +4807,12 @@
     "description": "Various natural and synthetic textiles and fabric materials",
     "total": 56,
     "examples": [
-      "denim",
-      "duck cloth",
-      "houndstooth",
-      "mohair",
-      "rayon",
-      "silk"
+      "fleece",
+      "elastane",
+      "merino wool",
+      "bamboo fabric",
+      "angora",
+      "alpaca"
     ]
   },
   "thing.fantasy": {
@@ -4821,12 +4821,12 @@
     "description": "Fantasy characters, magical items, and mythical creatures",
     "total": 146,
     "examples": [
-      "mystic",
-      "defender",
-      "energy",
-      "explosion",
-      "breaking point",
-      "limit"
+      "countermeasure",
+      "armor",
+      "sword",
+      "castle",
+      "dwarf",
+      "archer"
     ]
   },
   "thing.furniture": {
@@ -4835,11 +4835,11 @@
     "description": "Various types of indoor and outdoor seating and storage furniture",
     "total": 58,
     "examples": [
-      "chesterfield sofa",
-      "canopy bed",
-      "adirondack chair",
-      "pew",
-      "sofa",
+      "display cabinet",
+      "dining table",
+      "loveseat",
+      "bench",
+      "headboard",
       "armchair"
     ]
   },
@@ -4849,12 +4849,12 @@
     "description": "Electronic devices, musical gadgets, and modern technological equipment",
     "total": 417,
     "examples": [
-      "hearing aid",
-      "bluetooth audio receiver",
-      "arcade game machine",
-      "external hard drive",
-      "digital egg incubator",
-      "electronic plant watering system"
+      "massage chair",
+      "electronic organizer",
+      "electronic drum pad",
+      "3d scanner",
+      "access control system",
+      "electronic keyboard (computer input device)"
     ]
   },
   "thing.gemstone": {
@@ -4863,12 +4863,12 @@
     "description": "Precious and semi-precious gemstones and mineral crystals",
     "total": 59,
     "examples": [
-      "beryl",
-      "sodalite",
       "hiddenite",
-      "onyx",
-      "garnet",
-      "spinel"
+      "aventurine",
+      "jasper",
+      "nephrite jade",
+      "kunzite",
+      "onyx"
     ]
   },
   "thing.icon": {
@@ -4877,12 +4877,12 @@
     "description": "Common digital interface icons and simple graphic symbols",
     "total": 132,
     "examples": [
-      "lightbulb",
-      "battery",
-      "envelope",
-      "shopping cart",
-      "phone",
-      "briefcase"
+      "tennis",
+      "calendar",
+      "telescope",
+      "star",
+      "book",
+      "document"
     ]
   },
   "thing.material": {
@@ -4891,12 +4891,12 @@
     "description": "Various raw materials, plastics, stones, and crafting substances",
     "total": 68,
     "examples": [
-      "acrylic",
-      "acrylic plastic",
-      "marble",
+      "bamboo",
       "brass",
-      "stucco",
-      "titanium"
+      "limestone",
+      "concrete",
+      "gold",
+      "acrylic"
     ]
   },
   "thing.metal": {
@@ -4905,12 +4905,12 @@
     "description": "Various metallic elements, alloys, and metal finishes",
     "total": 273,
     "examples": [
-      "iridescent metal",
-      "anodized aluminum",
-      "ruthenium",
-      "mischmetal",
-      "oxidized bronze",
-      "mirror-polished steel"
+      "shibuichi",
+      "aluminum",
+      "polished stainless steel",
+      "matte brass",
+      "chromium",
+      "brushed steel"
     ]
   },
   "thing.office": {
@@ -4919,11 +4919,11 @@
     "description": "Financial tools, office supplies, and business-related items",
     "total": 68,
     "examples": [
-      "clipboard",
-      "stock chart",
-      "magnifying glass",
-      "abacus",
-      "protective gloves",
+      "rubber stamp",
+      "computer mouse",
+      "folder",
+      "envelope",
+      "banknote",
       "adding machine"
     ]
   },
@@ -4933,12 +4933,12 @@
     "description": "Decorative geometric, textile, and camouflage visual patterns",
     "total": 115,
     "examples": [
-      "awning stripe",
-      "gingham",
-      "sashiko",
+      "botanical",
+      "kanoko",
+      "snake print",
+      "houndstooth",
       "jacquard",
-      "suzani",
-      "dogtooth"
+      "arabesque"
     ]
   },
   "thing.scary": {
@@ -4947,12 +4947,12 @@
     "description": "Creepy locations, paranormal entities, and horror-themed concepts",
     "total": 211,
     "examples": [
-      "possessed vehicles",
-      "boogeyman",
-      "flickering lights",
-      "ghostly apparitions in photographs",
-      "dark tunnels",
-      "grim reaper"
+      "wraiths",
+      "plague doctors",
+      "living nightmares",
+      "mists and fog",
+      "seances",
+      "phantom shadow"
     ]
   },
   "thing.sciFi": {
@@ -4961,12 +4961,12 @@
     "description": "Futuristic technology, AI systems, and science fiction transportation",
     "total": 204,
     "examples": [
-      "force field generator",
-      "space rescue pod",
+      "climate stabilization device",
+      "asteroid deflector device",
+      "gravity shield",
+      "mind mapping device",
       "ai construction machine",
-      "cybernetic implant",
-      "disaster response robot",
-      "human augmentation device"
+      "autonomous robots"
     ]
   },
   "thing.space": {
@@ -4975,12 +4975,12 @@
     "description": "Celestial bodies, nebulae, moons, stars, and cosmic phenomena",
     "total": 158,
     "examples": [
-      "millisecond pulsar",
-      "soft gamma repeater",
-      "chaldene",
-      "molecular cloud",
-      "orthosie",
-      "harpalyke"
+      "galactic halo",
+      "star",
+      "europa",
+      "large magellanic cloud",
+      "hoag's object",
+      "iocaste"
     ]
   },
   "thing.summer": {
@@ -4989,12 +4989,12 @@
     "description": "Summer recreation items, beach gear, and outdoor accessories",
     "total": 70,
     "examples": [
-      "shorts",
-      "tanning lotion",
-      "picnic blanket",
-      "paddleboard",
-      "sandals",
-      "s'mores"
+      "canoe",
+      "fishing pole",
+      "kite",
+      "seashell",
+      "baseball cap",
+      "sprinkler"
     ]
   },
   "thing.surfaceFinish": {
@@ -5003,12 +5003,12 @@
     "description": "Material surface treatments, textures, and manufacturing finishes",
     "total": 164,
     "examples": [
+      "zinc-plated",
+      "luster-glazed",
       "distressed",
-      "combed",
-      "aqueous-coated",
-      "board-marked",
-      "eggshell",
-      "honed"
+      "lustre",
+      "nappa",
+      "machined"
     ]
   },
   "thing.weapon": {
@@ -5017,12 +5017,12 @@
     "description": "Historical melee, ranged, and medieval combat weapons",
     "total": 55,
     "examples": [
-      "tomahawk",
-      "greataxe",
-      "mace weapon",
-      "quarterstaff",
-      "scimitar",
-      "halberd"
+      "composite bow",
+      "zweihander",
+      "poignard",
+      "warhammer",
+      "mace",
+      "glaive"
     ]
   },
   "thing.woodType": {
@@ -5031,12 +5031,12 @@
     "description": "Various tree species and types of woodworking lumber",
     "total": 150,
     "examples": [
-      "pearwood",
-      "butternut",
-      "lyptus",
-      "curly maple",
-      "greenheart",
-      "ziricote"
+      "lacewood",
+      "sandalwood",
+      "okoume",
+      "larch",
+      "lignum vitae",
+      "monkeypod"
     ]
   },
   "time.century": {
@@ -5045,12 +5045,12 @@
     "description": "Specific centuries spanning BC and AD historical timelines",
     "total": 37,
     "examples": [
-      "11th century",
-      "1st century",
-      "2nd century",
-      "4th century",
-      "19th century",
-      "3rd century"
+      "25th century",
+      "10th century",
+      "10th century bc",
+      "4th century bc",
+      "8th century",
+      "11th century"
     ]
   },
   "time.dayOfYear": {
@@ -5059,12 +5059,12 @@
     "description": "Specific calendar dates and notable days of the year",
     "total": 387,
     "examples": [
-      "november 23",
-      "june 22",
-      "may 16",
-      "may 25",
-      "may 3",
-      "may 29"
+      "september 12",
+      "july 13",
+      "august 7",
+      "august 19",
+      "december 7",
+      "april 10"
     ]
   },
   "time.decade": {
@@ -5073,12 +5073,12 @@
     "description": "Specific decades ranging from the 1800s to the 2050s",
     "total": 35,
     "examples": [
-      "40s",
-      "70s",
-      "1860s",
-      "1800s",
-      "1890s",
-      "1930s"
+      "1880s",
+      "60s",
+      "1870s",
+      "1990s",
+      "2040s",
+      "1960s"
     ]
   },
   "time.era": {
@@ -5087,12 +5087,12 @@
     "description": "Historical periods, cultural eras, and specific global conflicts",
     "total": 118,
     "examples": [
-      "early christianity",
+      "gilded age",
       "dark ages",
-      "mesolithic era",
-      "edo period",
-      "tanzimat era in ottoman empire",
-      "aztec empire"
+      "post-modern era",
+      "philippine revolution",
+      "belle époque",
+      "roaring twenties"
     ]
   },
   "time.festival": {
@@ -5101,12 +5101,12 @@
     "description": "Global cultural, religious, and film festivals and holidays",
     "total": 196,
     "examples": [
-      "ratha yatra",
-      "new year's eve",
-      "obon",
-      "nebuta matsuri",
-      "ugadi",
-      "thingyan"
+      "hemis festival",
+      "fete des citrons",
+      "janmashtami",
+      "krampusnacht",
+      "hanami",
+      "sundance film festival"
     ]
   },
   "time.historicalEra": {
@@ -5115,12 +5115,12 @@
     "description": "Historical empires, dynasties, and major technological or cultural ages",
     "total": 148,
     "examples": [
-      "digital age",
-      "regency era",
-      "reconstruction era",
-      "nara period",
-      "ancient rome",
-      "abbasid caliphate"
+      "jin dynasty",
+      "iron age",
+      "jomon period",
+      "elizabethan era",
+      "edwardian era",
+      "ming dynasty"
     ]
   },
   "time.season": {
@@ -5129,12 +5129,12 @@
     "description": "Astronomical, cultural, commercial, agricultural, and natural seasons",
     "total": 241,
     "examples": [
+      "autumnal season",
+      "hockey season",
       "berry season",
-      "mid-winter",
-      "pollen season",
-      "post-monsoon season",
-      "shearing season",
-      "tick season"
+      "festival season",
+      "election season",
+      "legislative season"
     ]
   },
   "time.timeOfDay": {
@@ -5143,12 +5143,12 @@
     "description": "Specific times of day and associated lighting or atmospheric conditions",
     "total": 201,
     "examples": [
-      "broad daylight",
-      "sunset light",
-      "morning fog",
-      "morning frost",
-      "mid-afternoon",
-      "nightfall"
+      "local midnight",
+      "magic hour",
+      "green flash",
+      "midnight fog",
+      "evening chill",
+      "belt of venus"
     ]
   },
   "time.year": {
@@ -5157,12 +5157,12 @@
     "description": "Specific individual years spanning the 19th to 21st centuries",
     "total": 251,
     "examples": [
-      "1934",
-      "1971",
-      "1952",
-      "1960",
-      "1853",
-      "1850"
+      "2019",
+      "1964",
+      "1905",
+      "1850",
+      "1869",
+      "1865"
     ]
   },
   "typography.feature": {
@@ -5171,12 +5171,12 @@
     "description": "Typographic design features, spacing, and specific letterform characteristics",
     "total": 69,
     "examples": [
-      "monolinear strokes",
-      "graceful curves",
-      "tall ascenders",
-      "irregular letterforms",
-      "optical sizing",
-      "tabular figures"
+      "double-story g",
+      "ball terminals",
+      "light weight",
+      "tight kerning",
+      "extended width",
+      "angular terminals"
     ]
   },
   "typography.fontType": {
@@ -5185,12 +5185,12 @@
     "description": "Typographic design movements and historical font classifications",
     "total": 62,
     "examples": [
-      "blackletter typography",
-      "old style typography",
-      "transitional typography",
       "gothic sans typography",
-      "fraktur typography",
-      "glitch typography"
+      "art deco typography",
+      "dadaist typography",
+      "rounded typography",
+      "comic typography",
+      "tuscan typography"
     ]
   },
   "typography.font": {
@@ -5199,12 +5199,12 @@
     "description": "Specific named typefaces and popular font families",
     "total": 89,
     "examples": [
-      "copperplate font",
+      "montserrat font",
+      "merriweather sans font",
+      "tahoma font",
+      "lato font",
       "ubuntu font",
-      "pacifico font",
-      "garamond font",
-      "univers font",
-      "fira code font"
+      "zapfino font"
     ]
   },
   "typography.style": {
@@ -5213,12 +5213,12 @@
     "description": "Font weights, widths, and specific stylistic typeface variations",
     "total": 76,
     "examples": [
+      "book style font",
       "display style font",
-      "black style font",
-      "medium italic style font",
-      "light italic style font",
-      "distressed style font",
-      "backslanted style font"
+      "all caps style font",
+      "book italic style font",
+      "compact style font",
+      "extra expanded style font"
     ]
   },
   "typography.typefaceStyle": {
@@ -5227,12 +5227,12 @@
     "description": "Various font styles, historical typefaces, and typographic classifications",
     "total": 69,
     "examples": [
-      "3d lettering font",
-      "art deco",
-      "humanist serif",
-      "expanded",
-      "inline",
-      "grotesque"
+      "bubble letter font",
+      "bastarda",
+      "display typeface",
+      "neo-grotesque",
+      "fraktur",
+      "bitmap"
     ]
   },
   "typography.wordArt": {
@@ -5241,12 +5241,12 @@
     "description": "Textures, materials, and visual effects applied to text and typography",
     "total": 137,
     "examples": [
-      "rotated text",
-      "holographic foil text",
-      "jigsaw text",
-      "burning text",
-      "brushstroke text",
-      "embossed text"
+      "diamond-encrusted text",
+      "warped text",
+      "anaglyph 3d text",
+      "cloudy text",
+      "concrete text",
+      "argyle text"
     ]
   },
   "vehicle.aircraft": {
@@ -5255,12 +5255,12 @@
     "description": "Various types of airplanes, helicopters, and specialized aerial vehicles",
     "total": 126,
     "examples": [
-      "tiltwing",
-      "unmanned combat aerial vehicle",
-      "trainer aircraft",
-      "hoverbike",
-      "bush plane",
-      "passenger plane"
+      "stealth drone",
+      "stealth fighter",
+      "ekranoplan",
+      "tiltrotor",
+      "swing-wing aircraft",
+      "maritime patrol aircraft"
     ]
   },
   "vehicle.car": {
@@ -5269,12 +5269,12 @@
     "description": "Specific modern car makes and models from various automotive manufacturers",
     "total": 329,
     "examples": [
-      "chevrolet tahoe",
-      "kia sorento",
-      "acura nsx",
-      "chevrolet bolt",
-      "cadillac xt4",
-      "bmw i4"
+      "buick lacrosse",
+      "dacia logan",
+      "bentley mulsanne",
+      "audi a4",
+      "buick enclave",
+      "ferrari 488"
     ]
   },
   "vehicle.classicCar": {
@@ -5283,12 +5283,12 @@
     "description": "Specific vintage, antique, and classic car models with their production years",
     "total": 161,
     "examples": [
-      "1933 auburn 12-165 speedster",
-      "1904 rolls-royce 10 hp",
-      "1914 buick model b-24",
-      "1916 cadillac type 53",
-      "1929 cadillac series 341a",
-      "1929 duesenberg model j"
+      "1905 renault type ag",
+      "1982 lamborghini countach lp500 s",
+      "1930 cord l-29",
+      "1903 oldsmobile curved dash runabout",
+      "1926 duesenberg model a",
+      "1912 cadillac model thirty"
     ]
   },
   "vehicle.famousCar": {
@@ -5297,12 +5297,12 @@
     "description": "Iconic cars and fictional vehicles from popular movies and film franchises",
     "total": 50,
     "examples": [
-      "the ecto-1 from ghostbusters",
-      "the volkswagen beetle from herbie goes to monte carlo",
-      "kitt from knight rider",
-      "bumblebee from transformers",
-      "the 1994 toyota supra from the fast and the furious",
-      "the a-team van from the a-team"
+      "christine from christine",
+      "professor zündapp from cars 2",
+      "optimus prime from transformers",
+      "the 1961 ferrari 250 gt california spyder from ferris bueller's day off",
+      "the a-team van from the a-team",
+      "the delorean from back to the future"
     ]
   },
   "vehicle.fastCar": {
@@ -5311,12 +5311,12 @@
     "description": "Specific models of high-performance sports cars, supercars, and luxury vehicles",
     "total": 98,
     "examples": [
-      "aston martin vantage",
-      "mclaren 650s",
-      "rolls-royce ghost",
-      "aston martin db7",
-      "bugatti bolide",
-      "koenigsegg cc850"
+      "audi rs6 avant",
+      "porsche 918 spyder",
+      "bugatti chiron",
+      "lamborghini aventador sv",
+      "rolls-royce phantom",
+      "ferrari fxx evoluzione"
     ]
   },
   "vehicle.motorcycle": {
@@ -5325,12 +5325,12 @@
     "description": "Various styles, classes, and specialized types of motorcycles and motorbikes",
     "total": 121,
     "examples": [
-      "scooter sidecar",
-      "track-only bike",
-      "utility motorcycle",
-      "street tracker",
-      "retro motorcycle",
-      "touring motorcycle"
+      "land speed record motorcycle",
+      "dragster",
+      "hardtail",
+      "fire motorcycle",
+      "enduro bike",
+      "motocross"
     ]
   },
   "vehicle.spacecraft": {
@@ -5339,12 +5339,12 @@
     "description": "Sci-fi spacecraft, starships, and specialized futuristic space vehicles",
     "total": 56,
     "examples": [
-      "cruiser",
-      "seed ship",
-      "cargo hauler",
-      "ufo",
-      "stealth ship",
-      "mining barge"
+      "flyby spacecraft",
+      "ark ship",
+      "orbital shuttle",
+      "mining barge",
+      "fusion rocket ship",
+      "rover"
     ]
   },
   "vehicle.type": {
@@ -5353,12 +5353,12 @@
     "description": "Broad categories of land, air, and water transportation vehicles",
     "total": 116,
     "examples": [
-      "paraglider",
-      "front-end loader",
+      "lunar module",
       "amphibious vehicle",
-      "helicopter",
-      "camper",
-      "garbage truck"
+      "ambulance",
+      "rickshaw",
+      "blimp",
+      "snow plow"
     ]
   },
   "vehicle.watercraft": {
@@ -5367,12 +5367,12 @@
     "description": "Various types of boats, ships, and marine vessels",
     "total": 188,
     "examples": [
-      "balsa raft",
-      "aircraft carrier",
-      "tall ship",
+      "ark",
       "scow",
-      "corvette",
-      "luxury yacht"
+      "deck boat",
+      "jet boat",
+      "destroyer",
+      "galleon"
     ]
   },
   "videoGame.action": {
@@ -5381,12 +5381,12 @@
     "description": "In-game character actions, abilities, and mechanics in video games",
     "total": 314,
     "examples": [
-      "levitating",
-      "meditating for mana regeneration",
-      "performing a super sprint",
-      "practicing wand movements",
-      "scaling walls",
-      "playing a mini-game"
+      "cloaking in invisibility",
+      "unlocking doors",
+      "kneeling",
+      "creating magical barriers",
+      "harnessing magical artifacts",
+      "manipulating time"
     ]
   },
   "videoGame.designer": {
@@ -5395,12 +5395,12 @@
     "description": "Names of prominent real-world video game designers and directors",
     "total": 68,
     "examples": [
-      "lucas pope",
-      "peter mcconnell",
-      "tetsuya mizuguchi",
-      "keiji inafune",
-      "ken levine",
-      "satoshi tajiri"
+      "chris avellone",
+      "masahiro sakurai",
+      "suda51",
+      "neil druckmann",
+      "yuji naka",
+      "ron gilbert"
     ]
   },
   "videoGame.engine": {
@@ -5409,12 +5409,12 @@
     "description": "Software frameworks and game engines used for developing video games",
     "total": 68,
     "examples": [
-      "monogame",
-      "build engine",
-      "lithtech engine",
-      "gamebryo",
-      "anvilnext",
-      "love2d"
+      "xenko",
+      "redengine",
+      "renderware",
+      "eclipse engine",
+      "havok vision engine",
+      "mt framework"
     ]
   },
   "videoGame.game": {
@@ -5423,12 +5423,12 @@
     "description": "Titles of popular video game franchises and specific game releases",
     "total": 319,
     "examples": [
-      "just cause",
-      "earthbound",
-      "the legend of zelda",
-      "need for speed",
-      "sayonara wild hearts",
-      "nioh"
+      "the witcher 3: wild hunt - hearts of stone",
+      "call of duty: black ops",
+      "borderlands 2",
+      "candy crush",
+      "alan wake",
+      "call of duty: modern warfare 2"
     ]
   },
   "videoGame.region": {
@@ -5437,12 +5437,12 @@
     "description": "Fictional environments, biomes, and level themes found in video games",
     "total": 118,
     "examples": [
-      "ancient forest",
-      "alpine region",
-      "atlantis region",
-      "mystic forest",
-      "coral kingdom",
-      "ninja region"
+      "desert region",
+      "cityscape kingdom",
+      "canyon region",
+      "mystic kingdom",
+      "canopy kingdom",
+      "undersea kingdom"
     ]
   },
   "word.adjective": {
@@ -5451,12 +5451,12 @@
     "description": "Various descriptive adjectives ranging from anatomical to behavioral",
     "total": 4980,
     "examples": [
-      "eminent",
-      "diverse",
-      "divine",
-      "coercive",
-      "deaf",
-      "dramatic"
+      "cosmopolitan",
+      "speculative",
+      "innermost",
+      "fertile",
+      "appalling",
+      "enviable"
     ]
   },
   "word.adverb": {
@@ -5465,12 +5465,12 @@
     "description": "Assorted adverbs modifying actions, states, or qualities",
     "total": 1798,
     "examples": [
-      "aft",
-      "ceaselessly",
-      "chemically",
-      "equitably",
-      "elaborately",
-      "inordinately"
+      "wrongly",
+      "immeasurably",
+      "awful",
+      "bravely",
+      "cold",
+      "approximately"
     ]
   },
   "word.noun": {
@@ -5479,12 +5479,12 @@
     "description": "A diverse mix of concrete objects, animals, and abstract conceptual nouns",
     "total": 24389,
     "examples": [
-      "four",
-      "subcompact",
-      "city",
-      "chlorpyrifos",
-      "evolutionist",
-      "colossus"
+      "skeptic",
+      "hypostasis",
+      "breaking",
+      "eggnog",
+      "animosity",
+      "fen"
     ]
   },
   "word.onomatopoeia": {
@@ -5493,12 +5493,12 @@
     "description": "Sound-imitating words including animal noises, human vocalizations, and impact sounds",
     "total": 159,
     "examples": [
-      "gurgle",
-      "ribbit",
-      "clang",
-      "jangle",
-      "boohoo",
-      "crackle"
+      "chomp",
+      "ping",
+      "croak",
+      "honk",
+      "caw",
+      "bong"
     ]
   },
   "word.verb": {
@@ -5507,12 +5507,12 @@
     "description": "Action words and verb forms across various tenses including past and gerunds",
     "total": 9950,
     "examples": [
-      "grabbed",
-      "planned",
-      "abhorred",
-      "dying",
-      "bag",
-      "barge"
+      "crooned",
+      "buckle",
+      "savoring",
+      "belts",
+      "guarantee",
+      "exhausts"
     ]
   }
 }

--- a/list-metadata.json
+++ b/list-metadata.json
@@ -1865,28 +1865,28 @@
     "title": "Avatar: The Last Airbender names",
     "category": "fiction",
     "description": "Places, peoples, spirits, bending arts, and factions from Avatar: The Last Airbender and The Legend of Korra",
-    "total": 131,
+    "total": 163,
     "examples": [
-      "airbending",
-      "southern air temple",
-      "mai",
-      "piandao",
-      "spirit oasis",
-      "naga"
+      "air temple island",
+      "earth kingdom",
+      "ba sing se upper ring",
+      "lightning bending",
+      "republic council",
+      "jeong jeong"
     ]
   },
   "fiction.barsoom": {
     "title": "Barsoom names",
     "category": "fiction",
     "description": "Places, peoples, creatures, titles, and artifacts from Edgar Rice Burroughs' Barsoom",
-    "total": 95,
+    "total": 125,
     "examples": [
-      "black martians",
-      "panthan",
-      "barsoom",
+      "martian",
+      "tharks",
+      "river iss",
       "synthetic men",
-      "zodanga",
-      "therns"
+      "oath of issus",
+      "u-gor"
     ]
   },
   "fiction.basLag": {
@@ -1895,12 +1895,12 @@
     "description": "Places, peoples, creatures, factions, and concepts from China Mieville's Bas-Lag fiction",
     "total": 147,
     "examples": [
-      "the militia",
       "rust",
-      "perdido",
-      "scabmettlers",
-      "salacus fields",
-      "scar"
+      "high cromlech",
+      "badside",
+      "cadnebar",
+      "grindylow",
+      "crobuzon"
     ]
   },
   "fiction.bookOfTheNewSun": {
@@ -1909,12 +1909,12 @@
     "description": "Unique names from The Book of the New Sun (Gene Wolfe) — places, peoples, creatures, factions, and ships combined.",
     "total": 227,
     "examples": [
-      "the curtain wall",
-      "the house of absolute",
-      "the picture room",
-      "the septs",
-      "the piteous gate",
-      "the manse"
+      "megatherian",
+      "the examination room",
+      "mutant",
+      "dinoceras",
+      "glyptodon",
+      "abaia"
     ]
   },
   "fiction.brokenEarth": {
@@ -1923,26 +1923,26 @@
     "description": "Unique names from The Broken Earth (N.K. Jemisin) — places, peoples, creatures, factions, and ships combined.",
     "total": 184,
     "examples": [
-      "the tuners",
-      "the tourmaline",
-      "the doctors",
-      "wire-chair",
-      "the coastles",
-      "the six-rings"
+      "the five-rings",
+      "rabbit",
+      "the antarctic fulcrum",
+      "old sanze",
+      "the arctic fulcrum",
+      "sanzed equatorial afrika"
     ]
   },
   "fiction.conan": {
     "title": "Hyborian Age names",
     "category": "fiction",
     "description": "Places, peoples, creatures, gods, and factions from Robert E. Howard's Conan and Hyborian Age",
-    "total": 107,
+    "total": 157,
     "examples": [
-      "kushites",
-      "western ocean",
-      "shem",
-      "shemites",
-      "the tree of death",
-      "pirate isles"
+      "belit",
+      "messantia",
+      "black seers",
+      "amool",
+      "bel",
+      "conan"
     ]
   },
   "fiction.cthulhuMythos": {
@@ -1951,12 +1951,12 @@
     "description": "Unique names from Cthulhu Mythos — places, peoples, creatures, factions, and ships combined.",
     "total": 758,
     "examples": [
-      "warwick",
-      "tcho-tcho",
-      "rat-thing",
-      "sefton asylum",
-      "shterot",
-      "shelter island"
+      "coasters harbor",
+      "lobby",
+      "the dunwich horror",
+      "coatlicue",
+      "cykranosh",
+      "mother hydra"
     ]
   },
   "fiction.culture": {
@@ -1965,12 +1965,12 @@
     "description": "Starship names, orbitals, planets, systems, species, and factions from Iain M. Banks' Culture series",
     "total": 198,
     "examples": [
-      "a series of unlikely explanations",
-      "a ship with a view",
-      "good fences",
-      "jernau morat gurgeh",
-      "demi-mind",
-      "charitable view, a"
+      "davu",
+      "funny, it worked last time",
+      "size isn't everything",
+      "lsf",
+      "peace faction",
+      "passing by reference"
     ]
   },
   "fiction.darkTower": {
@@ -1979,26 +1979,26 @@
     "description": "Places, peoples, creatures, factions, and powers from Stephen King's Dark Tower fiction",
     "total": 143,
     "examples": [
-      "susannah dean",
-      "fedoras",
-      "balazar",
-      "calla sench",
-      "arthur eld",
-      "can ka no rey"
+      "dixie pig",
+      "blue heaven",
+      "thunderclap",
+      "donald callahan",
+      "tandy",
+      "wolves of the calla"
     ]
   },
   "fiction.dc": {
     "title": "DC Universe names",
     "category": "fiction",
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from DC fiction",
-    "total": 95,
+    "total": 270,
     "examples": [
-      "parademon",
-      "justice society of america",
-      "apokolips",
-      "bat-signal",
-      "gcpd",
-      "hall of justice"
+      "themyscira",
+      "heat wave",
+      "victor zasz",
+      "trident of neptune",
+      "cheetah",
+      "destiny's garden"
     ]
   },
   "fiction.discworld": {
@@ -2007,12 +2007,12 @@
     "description": "Places, peoples, creatures, and groups from Terry Pratchett's Discworld",
     "total": 193,
     "examples": [
-      "fools' guild",
-      "nac mac feegle",
-      "muntab",
-      "pseudopolis",
-      "the tump",
-      "sourcerer"
+      "the isle of gods",
+      "merchants' guild",
+      "mort",
+      "pointless albatross",
+      "sto lat",
+      "musicians' guild"
     ]
   },
   "fiction.dragonBall": {
@@ -2021,26 +2021,26 @@
     "description": "Places, species, transformations, artifacts, and powers from Dragon Ball",
     "total": 150,
     "examples": [
-      "spirit bomb",
-      "android 19",
-      "great saiyaman",
-      "android 18",
-      "android 20",
-      "super saiyan blue"
+      "porunga",
+      "kid buu",
+      "destroyer god",
+      "cell games",
+      "dr gero",
+      "kamis lookout"
     ]
   },
   "fiction.dragonlance": {
     "title": "Dragonlance names",
     "category": "fiction",
     "description": "Places, peoples, factions, creatures, deities, and artifacts from Dragonlance",
-    "total": 128,
+    "total": 143,
     "examples": [
-      "tarsis",
+      "blue crystal staff",
+      "goldmoon",
+      "laurana kanan",
+      "caramon majere",
       "aurak draconian",
-      "mount nevermind",
-      "pax tharkas",
-      "silvanesti",
-      "dark queen"
+      "kender"
     ]
   },
   "fiction.dune": {
@@ -2049,26 +2049,26 @@
     "description": "Planets, cities, factions, houses, and political groups from Frank Herbert's Dune universe",
     "total": 157,
     "examples": [
-      "stilltent",
-      "farad'n corrino",
-      "arrakis",
-      "butlerian jihad",
-      "harvester",
-      "house fenring"
+      "maker hooks",
+      "sardaukar",
+      "lady jessica",
+      "ornithopter",
+      "sandworm",
+      "sand snorkel"
     ]
   },
   "fiction.elderScrolls": {
     "title": "Elder Scrolls names",
     "category": "fiction",
     "description": "Places, peoples, factions, creatures, artifacts, and deities from The Elder Scrolls",
-    "total": 98,
+    "total": 337,
     "examples": [
-      "anvil",
-      "soul cairn",
-      "daedra",
-      "hircine",
-      "the tribunal",
-      "dremora"
+      "aedra",
+      "ebony mail",
+      "scuttling void",
+      "bruma",
+      "high rock",
+      "brynjolf"
     ]
   },
   "fiction.expanse": {
@@ -2077,40 +2077,40 @@
     "description": "Places, factions, ships, peoples, and technologies from The Expanse",
     "total": 126,
     "examples": [
-      "amos burton",
-      "united nations",
-      "mcrn donnager",
-      "mei meng",
-      "earth-mars coalition",
-      "free navy"
+      "underground",
+      "adrastea",
+      "julie mao",
+      "bara gaon",
+      "donnager",
+      "filip inaros"
     ]
   },
   "fiction.forgottenRealms": {
     "title": "Forgotten Realms names",
     "category": "fiction",
     "description": "Places, peoples, factions, creatures, deities, and artifacts from the Forgotten Realms",
-    "total": 85,
+    "total": 331,
     "examples": [
-      "oakhaven",
-      "red wizards of thay",
-      "ankheg",
-      "tiamat",
-      "tempus",
-      "ymeen"
+      "lloth",
+      "blingdenstone",
+      "ched nasad",
+      "sylune silverhand",
+      "deep gnome",
+      "faerun"
     ]
   },
   "fiction.foundation": {
     "title": "Foundation names",
     "category": "fiction",
     "description": "Places, planets, factions, and groups from Isaac Asimov's Foundation universe",
-    "total": 92,
+    "total": 128,
     "examples": [
-      "solaria",
-      "mule",
-      "psychohistory",
-      "echegaray",
-      "61 cygni",
-      "r. daneel olivaw"
+      "the fifty",
+      "encyclopedists",
+      "lagash",
+      "sark",
+      "indburs",
+      "libair"
     ]
   },
   "fiction.gethen": {
@@ -2119,12 +2119,12 @@
     "description": "Planets, countries, towns, cultures, and organizations from Ursula K. Le Guin's Hainish Cycle and Earthsea",
     "total": 155,
     "examples": [
-      "othokhad",
-      "iskel",
+      "solea",
+      "earthsea",
       "fastness",
-      "ansible",
-      "ged",
-      "cetia"
+      "lorbanery",
+      "hain",
+      "gadan"
     ]
   },
   "fiction.gormenghast": {
@@ -2133,12 +2133,12 @@
     "description": "Unique names from Gormenghast (Mervyn Peake) — places, peoples, creatures, factions, and ships combined.",
     "total": 237,
     "examples": [
-      "the masters of ritual",
-      "the chefs",
-      "fuchsia's attic",
-      "the dark precincts",
-      "the mutants",
-      "the rust room"
+      "the glow-worms",
+      "gormenghast river",
+      "the subjects",
+      "the spit-turners",
+      "the sentries",
+      "the scullions"
     ]
   },
   "fiction.halo": {
@@ -2147,12 +2147,12 @@
     "description": "Places, factions, species, artifacts, ships, and installations from Halo",
     "total": 143,
     "examples": [
-      "flood",
-      "escharum",
-      "geas",
-      "librarian",
-      "greater ark",
-      "installation 07"
+      "offensive bias",
+      "jun-266",
+      "cortana",
+      "constructor",
+      "halo array",
+      "combat evolved"
     ]
   },
   "fiction.harryPotter": {
@@ -2161,26 +2161,26 @@
     "description": "Places, schools, houses, creatures, objects, and groups from the Harry Potter and Wizarding World fiction",
     "total": 304,
     "examples": [
-      "stupefy",
-      "occlumency",
-      "occamy",
-      "riddikulus",
-      "order of merlin",
-      "reverse pass"
+      "splinch",
+      "godric gryffindor",
+      "the burrow",
+      "crookshanks",
+      "shell cottage",
+      "fang"
     ]
   },
   "fiction.hisDarkMaterials": {
     "title": "His Dark Materials names",
     "category": "fiction",
     "description": "Places, peoples, creatures, and concepts from Philip Pullman's His Dark Materials",
-    "total": 109,
+    "total": 116,
     "examples": [
-      "hester",
-      "amber spyglass",
-      "armored bears",
-      "sariel",
-      "oblation board",
-      "subtle knife"
+      "cazimi",
+      "bodley's library",
+      "himalaya",
+      "fen country",
+      "anbaric light",
+      "iorek byrnison"
     ]
   },
   "fiction.hitchhikers": {
@@ -2189,12 +2189,12 @@
     "description": "Places, species, spacecraft, and groups from The Hitchhiker's Guide to the Galaxy",
     "total": 257,
     "examples": [
-      "constant",
-      "hactar",
-      "han",
-      "jagger",
-      "bistromath",
-      "arcturan megadonkeys"
+      "the book",
+      "depressed robot",
+      "bistromathics",
+      "arcturan mega-elephants",
+      "halfrunt",
+      "hotblack desiato"
     ]
   },
   "fiction.hyperion": {
@@ -2203,12 +2203,12 @@
     "description": "Unique names from Hyperion Cantos — places, peoples, creatures, factions, and ships combined.",
     "total": 321,
     "examples": [
-      "yggdrasill",
-      "the hs force stevens",
-      "the hs force arthur clarke",
-      "the far end",
-      "the house of windsor-in-exile",
-      "new vatican"
+      "the st. dominic",
+      "the human ui",
+      "the hs force magellan",
+      "the metatron",
+      "the jesuits",
+      "the motile isles"
     ]
   },
   "fiction.lotr": {
@@ -2217,12 +2217,12 @@
     "description": "Places, races, creatures, and unique names from J.R.R. Tolkien's Middle-earth",
     "total": 464,
     "examples": [
-      "minas ithil",
-      "anfalas",
-      "nirnaeth arnoediad",
-      "landroval",
-      "imladris",
-      "marish"
+      "gwaihir",
+      "morwen",
+      "isen river",
+      "numenor",
+      "morgul pass",
+      "lossarnach"
     ]
   },
   "fiction.magicMultiverse": {
@@ -2231,40 +2231,40 @@
     "description": "Planes, peoples, factions, creatures, and artifacts from Magic: The Gathering fiction",
     "total": 136,
     "examples": [
-      "eldrazi",
-      "dragonlord silumgar",
-      "angel",
-      "keld",
-      "garruk wildspeaker",
-      "ashiok"
+      "shadowmoor",
+      "sorin markov",
+      "ugin",
+      "zendikar",
+      "theros",
+      "teferi"
     ]
   },
   "fiction.malazan": {
     "title": "Malazan names",
     "category": "fiction",
     "description": "Places, peoples, creatures, and groups from the Malazan Book of the Fallen",
-    "total": 163,
+    "total": 282,
     "examples": [
-      "kurald emurlahn",
-      "the whirlwind",
-      "burn",
-      "anomander rake",
-      "crimson guard",
-      "capustan"
+      "artanthos",
+      "kellenved",
+      "the glass desert",
+      "ornfawn",
+      "omhanas",
+      "meckros"
     ]
   },
   "fiction.marvel": {
     "title": "Marvel Universe names",
     "category": "fiction",
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction",
-    "total": 200,
+    "total": 347,
     "examples": [
-      "hatut zeraze",
-      "brotherhood of mutants",
-      "cancerverse",
-      "champions",
-      "ego",
-      "all-black the necrosword"
+      "eternals",
+      "grandmaster",
+      "west coast avengers",
+      "iron man armor",
+      "a-force",
+      "arcade"
     ]
   },
   "fiction.massEffect": {
@@ -2273,12 +2273,12 @@
     "description": "Places, species, factions, ships, artifacts, and powers from Mass Effect",
     "total": 201,
     "examples": [
-      "militia",
-      "aria",
-      "data",
+      "zero",
+      "asari",
+      "anderson",
+      "citadel space",
       "aria t'loak",
-      "donnel udina",
-      "council"
+      "batarians"
     ]
   },
   "fiction.narnia": {
@@ -2287,12 +2287,12 @@
     "description": "Places, peoples, creatures, and magical beings from C.S. Lewis's Chronicles of Narnia",
     "total": 160,
     "examples": [
-      "cor",
-      "terebinthia",
-      "prince caspian",
-      "aslan",
-      "minotaurs",
-      "peepiceek"
+      "trufflehunter",
+      "jadis",
+      "stone table",
+      "rishda tarkaan",
+      "chippingford",
+      "centaurs"
     ]
   },
   "fiction.onePiece": {
@@ -2301,12 +2301,12 @@
     "description": "Places, factions, peoples, creatures, ships, powers, and treasures from One Piece",
     "total": 160,
     "examples": [
-      "drum island",
-      "zou",
-      "conquerors haki",
-      "the four emperors",
-      "gomu gomu no mi",
-      "charlotte linlin"
+      "wano country",
+      "shanks",
+      "skypiea",
+      "capone bege",
+      "whole cake island",
+      "whitebeard"
     ]
   },
   "fiction.pokemon": {
@@ -2315,12 +2315,12 @@
     "description": "Regions, species, legendary Pokemon, teams, and artifacts from Pokemon",
     "total": 1137,
     "examples": [
-      "naclstack",
-      "kricketune",
-      "floette",
-      "feebas",
-      "finizen",
-      "hariyama"
+      "glimmora",
+      "doublade",
+      "love ball",
+      "pachirisu",
+      "calyrex",
+      "cherrim"
     ]
   },
   "fiction.starTrek": {
@@ -2329,12 +2329,12 @@
     "description": "Unique names from Star Trek — places, peoples, creatures, factions, and ships combined.",
     "total": 721,
     "examples": [
-      "uss bozeman",
-      "q continuum",
-      "the gatherers",
-      "talaxian resistance",
-      "shatras",
-      "romulan star empire"
+      "terra prime",
+      "detapa council",
+      "akira-class",
+      "new orleans",
+      "nova squadron",
+      "enterprise nx-01"
     ]
   },
   "fiction.starWars": {
@@ -2343,12 +2343,12 @@
     "description": "Unique names from Star Wars — places, peoples, creatures, factions, and ships combined.",
     "total": 784,
     "examples": [
-      "the death troopers",
-      "ryloth",
-      "protector",
-      "thyferra",
-      "houk",
-      "mustafarian"
+      "sarlacc",
+      "altier",
+      "gungan",
+      "ansion",
+      "avenger",
+      "kell dragon"
     ]
   },
   "fiction.transformers": {
@@ -2357,12 +2357,12 @@
     "description": "Places, factions, species, artifacts, and groups from Transformers",
     "total": 350,
     "examples": [
-      "ratchet",
-      "bitstream",
-      "die-cast",
-      "hardhead",
-      "fracture",
-      "barricade"
+      "chemjet",
+      "magmatron",
+      "the allspark",
+      "skyfire",
+      "sector 7",
+      "skydive"
     ]
   },
   "fiction.warcraft": {
@@ -2371,12 +2371,12 @@
     "description": "Places, peoples, factions, creatures, artifacts, and powers from the Warcraft universe",
     "total": 335,
     "examples": [
-      "tempest keep",
-      "mag'har orc",
-      "nazjatar",
-      "warchief",
-      "razorfen downs",
-      "naxxramas"
+      "anasterian",
+      "dark iron dwarf",
+      "shadowfang keep",
+      "thunderfury",
+      "arthas menethil",
+      "chen stormstout"
     ]
   },
   "fiction.warhammer40k": {
@@ -2385,12 +2385,12 @@
     "description": "Unique names from Warhammer 40,000 — places, peoples, creatures, factions, and ships combined.",
     "total": 653,
     "examples": [
-      "slaanesh",
-      "altansar",
-      "ambull",
-      "divine right",
-      "canoptek scarab",
-      "cthonia"
+      "order of the bloody rose",
+      "ferrum",
+      "hive crone",
+      "khrave",
+      "hive fleet leviathan",
+      "il-kaithe"
     ]
   },
   "fiction.wheelOfTime": {
@@ -2399,12 +2399,12 @@
     "description": "Places, peoples, creatures, and groups from The Wheel of Time",
     "total": 282,
     "examples": [
-      "whitebridge",
-      "mazrim taim",
-      "nym",
-      "raken",
-      "saldaea",
-      "sammael"
+      "alanna mosvani",
+      "kandor",
+      "machin shin",
+      "coramoor",
+      "caemlyn",
+      "choedan kal"
     ]
   },
   "fiction.witcher": {
@@ -2413,12 +2413,12 @@
     "description": "Places, kingdoms, schools, peoples, creatures, and objects from The Witcher",
     "total": 161,
     "examples": [
-      "endrega",
-      "tretogor",
-      "mantichore school",
-      "redania",
-      "school of the cat",
-      "the unseen elder"
+      "kikimore",
+      "doppler",
+      "alder folk",
+      "dijkstra",
+      "bonhart",
+      "aedirn"
     ]
   },
   "fiction.zelda": {
@@ -2427,12 +2427,12 @@
     "description": "Places, peoples, creatures, artifacts, and powers from The Legend of Zelda",
     "total": 149,
     "examples": [
-      "fi",
-      "tulin",
-      "skull kid",
-      "stamina vessel",
-      "zora's domain",
-      "snowhead"
+      "tetra",
+      "goron",
+      "dark world",
+      "death mountain",
+      "daruk",
+      "hylian shield"
     ]
   },
   "food.bakery": {
@@ -2441,12 +2441,12 @@
     "description": "Assorted baked goods including cakes, pies, pastries, and sweet breads",
     "total": 176,
     "examples": [
-      "macarons",
-      "dolmades (stuffed grape leaves)",
-      "macaron",
-      "sfogliatelle (shell-shaped pastry)",
-      "fruit sorbet",
-      "ciabatta"
+      "coffee cake",
+      "brownies",
+      "tarts",
+      "turnovers",
+      "bread",
+      "victoria sponge"
     ]
   },
   "food.bbq": {
@@ -2456,11 +2456,11 @@
     "total": 41,
     "examples": [
       "grilled oysters",
-      "burnt ends",
-      "burgers",
-      "veggie kebab",
-      "ribs",
-      "chicken kebab"
+      "chicken wings",
+      "veggie burgers",
+      "grilled shrimp skewers",
+      "pork ribs",
+      "grilled portobello mushrooms"
     ]
   },
   "food.beverage": {
@@ -2469,12 +2469,12 @@
     "description": "Various alcoholic and non-alcoholic drinks including cocktails, coffees, and teas",
     "total": 224,
     "examples": [
-      "vermouth",
-      "ouzo",
-      "whiskey sour",
-      "wine",
-      "pomegranate juice",
-      "pisco sour"
+      "limoncello",
+      "carajillo",
+      "gose",
+      "ipa",
+      "ayran",
+      "champagne"
     ]
   },
   "food.bread": {
@@ -2483,12 +2483,12 @@
     "description": "A diverse global selection of traditional breads, biscuits, and baked rolls",
     "total": 269,
     "examples": [
-      "tin loaf",
-      "agege bread",
-      "kulich",
-      "drop biscuit",
-      "kaiser roll",
-      "griddle scone"
+      "lángos",
+      "breadstick",
+      "baguette",
+      "croissant",
+      "hardtack",
+      "einkorn bread"
     ]
   },
   "food.breakfast": {
@@ -2497,12 +2497,12 @@
     "description": "Sweet and savory breakfast dishes including eggs, waffles, and avocado toast",
     "total": 86,
     "examples": [
-      "pop-tarts",
-      "monte cristo sandwich",
-      "huevos rancheros",
-      "oatmeal with toppings",
-      "portobello florentine",
-      "crab benedict"
+      "brioche french toast",
+      "muffins",
+      "quiche lorraine",
+      "bagel with cream cheese",
+      "english muffin with butter and jam",
+      "breakfast burrito bowl"
     ]
   },
   "food.cheese": {
@@ -2511,12 +2511,12 @@
     "description": "A wide variety of international cheeses from different regions and styles",
     "total": 515,
     "examples": [
-      "orval",
-      "castigliano",
-      "idiazabal",
-      "kaşar",
-      "esrom",
-      "cooleeney"
+      "metton",
+      "dunsyre blue",
+      "brimsen",
+      "cheese curds",
+      "afuega'l pitu",
+      "geitost"
     ]
   },
   "food.cocktail": {
@@ -2525,12 +2525,12 @@
     "description": "Classic and modern mixed alcoholic drinks and cocktails",
     "total": 153,
     "examples": [
-      "pink lady",
-      "dark and stormy",
-      "brandy crusta",
-      "jack rose",
-      "hot toddy",
-      "bloody mary"
+      "manhattan",
+      "planter's punch",
+      "margarita",
+      "negroni",
+      "cosmopolitan",
+      "penicillin"
     ]
   },
   "food.cookingMethod": {
@@ -2539,12 +2539,12 @@
     "description": "Culinary techniques for preparing food, ranging from baking to dry aging",
     "total": 97,
     "examples": [
-      "barbecuing",
-      "oil roasting",
-      "roasting",
-      "oil poaching",
+      "reducing",
+      "sun drying",
+      "salt curing",
       "pan broiling",
-      "spit roasting"
+      "sous vide",
+      "shallow frying"
     ]
   },
   "food.cuisine": {
@@ -2553,12 +2553,12 @@
     "description": "Specific regional and national culinary traditions from around the world",
     "total": 340,
     "examples": [
-      "paraguayan cuisine",
-      "ligurian cuisine",
-      "abruzzese cuisine",
-      "bhutanese cuisine",
-      "acehnese cuisine",
-      "chilean cuisine"
+      "bangladeshi cuisine",
+      "belizean cuisine",
+      "awadhi cuisine",
+      "ashkenazi jewish cuisine",
+      "emirati cuisine",
+      "angolan cuisine"
     ]
   },
   "food.dessert": {
@@ -2567,12 +2567,12 @@
     "description": "Global sweet treats including cakes, puddings, pastries, and confections",
     "total": 174,
     "examples": [
-      "shortbread",
-      "rum cake",
-      "anmitsu",
-      "pineapple upside-down cake",
-      "beignet",
-      "turrón"
+      "milkshake",
+      "floating island",
+      "chocolate chip cookie",
+      "brigadeiro",
+      "cannoli",
+      "babka"
     ]
   },
   "food.drink": {
@@ -2581,11 +2581,11 @@
     "description": "Assorted beverages including sodas, juices, teas, milks, and alcoholic drinks",
     "total": 289,
     "examples": [
-      "distilled spirits",
-      "spirits",
-      "buttermilk",
+      "limeade",
+      "gunpowder tea",
+      "limoncello",
+      "lemon balm tea",
       "calvados",
-      "absinthe",
       "clamato juice"
     ]
   },
@@ -2595,12 +2595,12 @@
     "description": "Global fast food and street food items including burgers, fries, and rolls",
     "total": 164,
     "examples": [
-      "bun bo hue",
+      "general tso's chicken",
+      "banh mi",
       "cookies and cream milkshake",
-      "com tam (broken rice)",
-      "double cheeseburger",
-      "garlic fries",
-      "bun cha"
+      "sushi",
+      "sweet and sour fried chicken",
+      "veggie burger"
     ]
   },
   "food.fruit": {
@@ -2609,12 +2609,12 @@
     "description": "Common and exotic fruits, berries, and melons from around the world",
     "total": 142,
     "examples": [
-      "canistel",
-      "mango",
-      "apple",
-      "blood orange",
-      "boysenberry",
-      "apricot"
+      "juneberry",
+      "acai",
+      "avocado",
+      "grapes",
+      "lime",
+      "kiwi"
     ]
   },
   "food.herbSpice": {
@@ -2623,12 +2623,12 @@
     "description": "Various culinary herbs, spices, and seeds used for flavoring food",
     "total": 50,
     "examples": [
-      "cumin",
-      "mustard seed",
-      "bay leaf",
-      "fenugreek",
-      "white pepper",
-      "caraway"
+      "chives",
+      "marjoram",
+      "spearmint",
+      "sesame seed",
+      "allspice",
+      "turmeric"
     ]
   },
   "food.pastaShape": {
@@ -2637,12 +2637,12 @@
     "description": "Various types of traditional and novelty pasta shapes",
     "total": 145,
     "examples": [
-      "rotelle",
-      "cannelloni",
-      "maccheroni",
-      "acini di pepe",
-      "astri",
-      "lasagnette"
+      "tubini",
+      "pizzoccheri",
+      "rotini",
+      "maltagliati",
+      "sfoglini",
+      "funghetti"
     ]
   },
   "food.platingStyle": {
@@ -2651,12 +2651,12 @@
     "description": "Artistic and structural techniques for arranging and presenting food on a plate",
     "total": 104,
     "examples": [
-      "afternoon tea style",
-      "vertical",
-      "traditional",
-      "casual",
-      "tower style",
-      "landscape"
+      "deconstructed",
+      "maximalist",
+      "artisanal",
+      "gourmet",
+      "architectural",
+      "chef's table style"
     ]
   },
   "food.tea": {
@@ -2665,12 +2665,12 @@
     "description": "Specific varieties of traditional, herbal, and regional teas",
     "total": 193,
     "examples": [
-      "thai tea",
-      "liubao tea",
+      "ceylon white tea",
       "licorice root tea",
-      "jasmine green tea",
-      "assam",
-      "neem tea"
+      "sassafras tea",
+      "nettle tea",
+      "pu-erh",
+      "longjing"
     ]
   },
   "food.vegetable": {
@@ -2679,12 +2679,12 @@
     "description": "Various vegetables, legumes, squashes, and edible plant sprouts",
     "total": 266,
     "examples": [
-      "bobby beans",
-      "spaghetti squash",
-      "sorrel",
-      "squash (vegetable)",
-      "serrano pepper",
-      "squash blossoms"
+      "marrowfat peas",
+      "belgian endive",
+      "cardoon",
+      "chioggia beet",
+      "escarole",
+      "flageolet beans"
     ]
   },
   "geography.city": {
@@ -2693,12 +2693,12 @@
     "description": "Specific global cities listed with their respective regions and countries",
     "total": 22953,
     "examples": [
-      "Abeokuta, Ogun, Nigeria",
-      "Nicholasville, Kentucky, United States",
-      "Panauti̇̄, Central Region, Nepal",
-      "Masterton, Wellington, New Zealand",
-      "Deogarh, Odisha, India",
-      "Mexicali, Baja California, Mexico"
+      "Budapest IV. kerület, Budapest, Hungary",
+      "Sidi Ifni, Souss-Massa-Drâa, Morocco",
+      "Périgueux, Aquitaine-Limousin-Poitou-Charentes, France",
+      "Benidorm, Valencia, Spain",
+      "Santa Luzia, Minas Gerais, Brazil",
+      "Blois, Centre, France"
     ]
   },
   "geography.country": {
@@ -2707,12 +2707,12 @@
     "description": "A diverse list of sovereign nations and countries around the world",
     "total": 199,
     "examples": [
-      "Sierra Leone",
-      "East Germany",
-      "Bhutan",
-      "Benin",
-      "Belgium",
-      "Bulgaria"
+      "Venezuela",
+      "Finland",
+      "Kiribati",
+      "Bangladesh",
+      "Liberia",
+      "Armenia"
     ]
   },
   "geography.ethnicGroup": {
@@ -2721,12 +2721,12 @@
     "description": "The following groups are commonly identified as \"ethnic groups\", as opposed to ethno-linguistic phyla, national groups, racial groups or similar.\n",
     "total": 1055,
     "examples": [
-      "mormon",
-      "albanians",
-      "hadiya",
-      "dyula",
-      "kalinago",
-      "gujarati"
+      "khonds",
+      "aneuk jamee",
+      "balti",
+      "imraguen",
+      "kulin",
+      "hutu"
     ]
   },
   "geography.language": {
@@ -2735,12 +2735,12 @@
     "description": "A list of language names (glossonyms)",
     "total": 609,
     "examples": [
-      "domari",
-      "thai",
-      "indonesian",
-      "cook islands māori",
-      "eyak",
-      "ge'ez"
+      "arabela",
+      "bai",
+      "english",
+      "adioukrou",
+      "gagauz",
+      "basque"
     ]
   },
   "geography.nationality": {
@@ -2749,12 +2749,12 @@
     "description": "Adjectives describing nationalities and citizenships from various countries",
     "total": 206,
     "examples": [
-      "liechtensteiner",
-      "vietnamese",
-      "swedish",
+      "swiss",
       "senegalese",
-      "luxembourger",
-      "soviet"
+      "hungarian",
+      "slovak",
+      "saint lucian",
+      "paraguayan"
     ]
   },
   "geography.territory": {
@@ -2763,12 +2763,12 @@
     "description": "Global territories, dependencies, emirates, and non-sovereign geographic regions",
     "total": 79,
     "examples": [
-      "Gibraltar",
-      "Greenland",
-      "Bonaire",
-      "Falkland Islands",
-      "French Polynesia",
-      "Ceuta"
+      "Bermuda",
+      "Guam",
+      "Baker Island",
+      "Christmas Island",
+      "Akrotiri",
+      "Ajman"
     ]
   },
   "interaction.coupleNegative": {
@@ -2777,12 +2777,12 @@
     "description": "Toxic, emotional, and negative behavioral interactions between romantic partners",
     "total": 70,
     "examples": [
-      "feeling isolated from each other",
+      "feeling dejected with each other",
       "accusing each other",
-      "bickering with each other",
-      "walking away mid-argument",
-      "harboring unspoken resentment",
-      "feeling helpless with each other"
+      "checking phone while being spoken to",
+      "feeling annoyed with each other",
+      "feeling hopeless with each other",
+      "feeling stressed with each other"
     ]
   },
   "interaction.couple": {
@@ -2791,12 +2791,12 @@
     "description": "Positive and negative relational dynamics and activities between couples",
     "total": 69,
     "examples": [
-      "collaboration",
-      "mentoring a protégé",
-      "reconciliation",
-      "sharing wisdom",
-      "making a confession",
-      "giving a warm hug"
+      "assistance",
+      "bonding",
+      "exchange of glances",
+      "experiencing nostalgia",
+      "having a picnic in the park",
+      "having a romance"
     ]
   },
   "interaction.crowd": {
@@ -2805,12 +2805,12 @@
     "description": "Collective actions, events, and emotional responses experienced by large crowds",
     "total": 64,
     "examples": [
-      "joining a flash mob",
-      "participating in a demonstration",
-      "participating in a march",
-      "raising fists in solidarity",
-      "celebrating a cultural tradition",
-      "attending a parade"
+      "gathering for a memorial",
+      "attending a memorial service",
+      "gathering for a political speech",
+      "gathering for a celebration",
+      "attending a march",
+      "doing the wave at a stadium"
     ]
   },
   "interaction.danceStyle": {
@@ -2819,12 +2819,12 @@
     "description": "Diverse global dance genres, traditional styles, and modern rhythmic movements",
     "total": 266,
     "examples": [
-      "semba",
-      "ribbon dance",
-      "polka",
-      "quickstep",
-      "odissi",
-      "salpuri"
+      "contact improvisation",
+      "conga",
+      "butoh",
+      "isicathamiya",
+      "jazz",
+      "danzonete"
     ]
   },
   "interaction.group": {
@@ -2833,12 +2833,12 @@
     "description": "Collaborative group activities ranging from mundane events to dramatic fictional scenarios",
     "total": 70,
     "examples": [
-      "becoming a superhero",
-      "playing a tabletop board game",
-      "participating in a protest",
-      "escaping a cult",
-      "building a campfire",
-      "dealing with a life-threatening illness"
+      "taking part in a paranormal investigation",
+      "facing a personal challenge",
+      "running for public office",
+      "doing a trust fall exercise",
+      "searching for lost treasure",
+      "solving a puzzle"
     ]
   },
   "interaction.individualDetailed": {
@@ -2847,12 +2847,12 @@
     "description": "Highly specific, multi-step physical actions and behavioral sequences performed by individuals",
     "total": 214,
     "examples": [
-      "clears throat, takes a sip of water, and begins to speak",
-      "adjusts rearview mirror, checks blind spot, and then changes lanes",
-      "blows out a candle, watches the smoke curl up, and then waves a hand to clear the air",
-      "drums fingers on the table, looks up at the clock, and sighs impatiently",
-      "adjusts the volume on headphones, nods head to the beat, and then closes eyes to focus on the music",
-      "adjusts glasses, squints at something in the distance, then nods in understanding"
+      "brushes crumbs off the table, wipes it down with a cloth, and then sets the table",
+      "clicks a pen open, jots down a quick note, and then clicks the pen closed",
+      "knocks on a door, waits for a response, and then knocks again",
+      "giggles, covers mouth with a hand, and then tries to compose oneself",
+      "blows on a spoonful of hot soup, sips it carefully, and then nods in approval",
+      "folds a paper airplane, throws it, and then watches it glide"
     ]
   },
   "interaction.individual": {
@@ -2861,12 +2861,12 @@
     "description": "Simple, everyday physical gestures, adjustments, and actions performed by a single person",
     "total": 424,
     "examples": [
-      "kisses fingertips and blows it like a chef",
-      "nods head in agreement",
-      "draws circles on a steamy window",
-      "flicks a bug off arm",
-      "arches an eyebrow",
-      "nods in agreement"
+      "bounces a ball against a wall",
+      "strokes beard contemplatively",
+      "drags a stick through the dirt",
+      "draws a deep breath",
+      "scratches head in confusion",
+      "crosses and uncrosses legs"
     ]
   },
   "interaction.martialArt": {
@@ -2875,12 +2875,12 @@
     "description": "Traditional and modern martial arts and combat systems from around the world",
     "total": 110,
     "examples": [
-      "aikido",
-      "kendo",
-      "wing chun",
-      "silambam",
-      "laamb",
-      "tahtib"
+      "kyudo",
+      "ringen",
+      "wrestling",
+      "sanshou",
+      "shuai jiao",
+      "krav maga"
     ]
   },
   "keyword.detailed": {
@@ -2889,12 +2889,12 @@
     "description": "Descriptive adjectives used to prompt high-resolution, intricate, and textured artwork",
     "total": 58,
     "examples": [
-      "ultra-high-definition",
-      "clear",
-      "artistically-detailed",
-      "detailed picture",
-      "immaculately-detailed",
-      "elaborate"
+      "accurate",
+      "fine-grained",
+      "ultra-realistic",
+      "high-quality",
+      "richly-detailed",
+      "in-focus"
     ]
   },
   "keyword.epic": {
@@ -2903,12 +2903,12 @@
     "description": "Evocative adjectives for generating dramatic, majestic, and awe-inspiring visual atmospheres",
     "total": 129,
     "examples": [
-      "meticulous",
-      "delightful",
-      "venerable",
-      "dynamic",
-      "wonderful",
-      "stunning"
+      "captivating",
+      "admirable",
+      "awesome",
+      "breathtakingly-grand",
+      "aetherial",
+      "delightful"
     ]
   },
   "keyword.genre": {
@@ -2917,12 +2917,12 @@
     "description": "Sci-fi, historical, and punk-themed aesthetic art genres and styles",
     "total": 65,
     "examples": [
-      "silkpunk",
-      "post-apocalyptic",
-      "post-cyberpunk",
-      "sword and sorcery",
-      "medieval",
-      "gothic romance"
+      "cyber-medieval",
+      "lovecraftian horror",
+      "steamwave",
+      "grimdark",
+      "fantasy noir",
+      "medieval"
     ]
   },
   "keyword.glitch": {
@@ -2931,12 +2931,12 @@
     "description": "Digital and analog visual artifacts, distortions, and glitch effects",
     "total": 56,
     "examples": [
-      "rolling shutter effect",
-      "scrambled signal",
-      "screen tear",
+      "scanline distortion",
       "burn-in",
-      "bit-crushed",
-      "datamosh"
+      "bug",
+      "hiccup",
+      "image corruption",
+      "dropped frames"
     ]
   },
   "keyword.modifier": {
@@ -2945,12 +2945,12 @@
     "description": "Keywords that modify the style of an image (Noodle Soup prompts)",
     "total": 88,
     "examples": [
-      "anaglyph filter",
-      "ambrotype",
-      "dutch golden age",
-      "bioluminescent glow",
-      "cottagecore",
-      "afrofuturism"
+      "doge",
+      "glitch art",
+      "60s kitsch and psychedelia",
+      "photorealism",
+      "gothic art",
+      "stained glass style"
     ]
   },
   "keyword.negative": {
@@ -2959,12 +2959,12 @@
     "description": "Negative prompt keywords for avoiding bad anatomy, artifacts, and low quality",
     "total": 90,
     "examples": [
-      "floating limbs",
-      "extra fingers",
-      "jumbled",
-      "malformed limbs",
-      "blur",
-      "poorly drawn"
+      "low-res",
+      "mangled",
+      "poor quality",
+      "low quality",
+      "poorly drawn hands",
+      "text"
     ]
   },
   "keyword.prayer": {
@@ -2973,12 +2973,12 @@
     "description": "Quality-enhancing prompt modifiers for high resolution and masterpiece renders",
     "total": 67,
     "examples": [
-      "award winning",
-      "16k resolution",
-      "intricate",
-      "lifelike",
-      "hdr",
-      "magnum opus"
+      "hyper-realistic",
+      "ultra-realistic",
+      "sophisticated",
+      "realistic",
+      "masterpiece",
+      "ultra-high definition"
     ]
   },
   "keyword.trending": {
@@ -2987,12 +2987,12 @@
     "description": "Keywords referencing trending or featured artwork on popular portfolio websites",
     "total": 35,
     "examples": [
-      "featured on artstation",
-      "trending on pixiv",
-      "trending on unsplash",
-      "trending on midjourney",
-      "featured on getty images",
-      "trending on behance"
+      "trending on getty images",
+      "featured on flickr",
+      "featured on cgsociety",
+      "trending on artstation",
+      "featured on deviantart",
+      "trending on unsplash"
     ]
   },
   "keyword.unusual": {
@@ -3001,12 +3001,12 @@
     "description": "Adjectives describing weird, unique, unusual, or abnormal subjects",
     "total": 62,
     "examples": [
-      "eccentric",
-      "unique",
+      "bewildering",
+      "kooky",
       "out-there",
-      "curiosity-inducing",
-      "unusual",
-      "curiouser-and-curiouser"
+      "odd",
+      "curious",
+      "anomalous"
     ]
   },
   "music.artist": {
@@ -3015,12 +3015,12 @@
     "description": "Diverse musical artists and bands with distinct musical styles",
     "total": 114,
     "examples": [
-      "erykah badu",
-      "astrud gilberto",
-      "enya",
-      "billie holiday",
-      "chuck berry",
-      "gogol bordello"
+      "nine inch nails",
+      "massive attack",
+      "joy division",
+      "the stooges",
+      "john cage",
+      "can"
     ]
   },
   "music.bpm": {
@@ -3029,12 +3029,12 @@
     "description": "Various musical tempos measured in beats per minute",
     "total": 42,
     "examples": [
-      "190 bpm",
-      "150 bpm",
-      "115 bpm",
-      "160 bpm",
-      "165 bpm",
-      "170 bpm"
+      "140 bpm",
+      "170 bpm",
+      "60 bpm",
+      "210 bpm",
+      "290 bpm",
+      "50 bpm"
     ]
   },
   "music.composer": {
@@ -3044,11 +3044,11 @@
     "total": 190,
     "examples": [
       "franz xaver süssmayr",
-      "alan hovhaness",
-      "ignaz pleyel",
-      "benjamin britten",
-      "dmitri shostakovich",
-      "antonio vivaldi"
+      "charles wuorinen",
+      "alessandro stradella",
+      "michael torke",
+      "alban berg",
+      "johann nepomuk hummel"
     ]
   },
   "music.drop": {
@@ -3057,12 +3057,12 @@
     "description": "Specific electronic dance music subgenre drops and rhythmic transitions",
     "total": 39,
     "examples": [
-      "gabber distorted kick drop",
-      "psytrance triplets drop",
-      "uk garage speed garage bassline drop",
-      "minimal techno sub-bass rumble drop",
-      "big room drop",
-      "hardstyle reverse bass drop"
+      "future bass chord drop",
+      "acid techno 303 squelch drop",
+      "chillstep ambient pads drop",
+      "electro house bass drop",
+      "drum and bass roller drop",
+      "future house bouncy drop"
     ]
   },
   "music.dynamic": {
@@ -3071,12 +3071,12 @@
     "description": "Musical tempo, dynamic, and articulation terms with their definitions",
     "total": 89,
     "examples": [
-      "dolce (sweetly, with a gentle and tender expression)",
-      "con fuoco (with fire, with great passion and energy)",
-      "morendo (dying away, gradually softer and slower)",
-      "decrescendo poco a poco (gradually getting softer little by little)",
-      "scherzando (playfully, jokingly and lightheartedly)",
-      "sforzando forte (sudden emphasis followed by loud)"
+      "allegretto (moderately fast and light)",
+      "agitato (agitated, with a sense of agitation or restlessness)",
+      "fortepiano (loud followed immediately by soft)",
+      "leggiero (lightly, with a delicate and nimble touch)",
+      "brillante (brilliantly, with dazzling and sparkling quality)",
+      "maestoso (majestically, with a stately and dignified style)"
     ]
   },
   "music.feature": {
@@ -3085,12 +3085,12 @@
     "description": "Specific instrumental, vocal, and atmospheric musical elements and techniques",
     "total": 206,
     "examples": [
-      "booming 808 sub-bass kicks",
-      "airy flute melodies",
-      "breakdown sections",
-      "counterpoint melodies",
+      "hypnotic modular synth sequences",
+      "ethereal vocal falsettos",
       "acoustic guitars",
-      "driving country fiddle solos"
+      "cascading synthesizer bells",
+      "funky guitar riffs",
+      "aggressive vocal delivery"
     ]
   },
   "music.genre": {
@@ -3099,12 +3099,12 @@
     "description": "Diverse music genres ranging from electronic and rock to folk",
     "total": 305,
     "examples": [
-      "breakbeat",
-      "zydeco punk",
-      "death-doom metal",
-      "deathcore",
-      "ambient dub",
-      "mathcore"
+      "ethno jazz",
+      "freakbeat",
+      "drone",
+      "folk metal",
+      "power metal",
+      "kawaii metal"
     ]
   },
   "music.harmony": {
@@ -3113,12 +3113,12 @@
     "description": "Various types of musical harmonies and chordal structures",
     "total": 38,
     "examples": [
-      "spectral harmony",
-      "chromatic harmony",
-      "polyphonic harmony",
-      "vocal harmony",
-      "consonant harmony",
-      "triadic harmony"
+      "open harmony",
+      "microtonal harmony",
+      "tonal harmony",
+      "major harmony",
+      "four-part harmony",
+      "suspended harmony"
     ]
   },
   "music.instrument": {
@@ -3127,12 +3127,12 @@
     "description": "Traditional, classical, and world music instruments",
     "total": 216,
     "examples": [
-      "kalimba thumb piano",
-      "dulcimer",
-      "trumpet",
-      "guitar",
-      "requinto",
-      "mellophone"
+      "conga",
+      "piano",
+      "ney",
+      "maracas",
+      "steel drums",
+      "mellotron"
     ]
   },
   "music.key": {
@@ -3141,12 +3141,12 @@
     "description": "Major and minor musical keys",
     "total": 35,
     "examples": [
-      "a major",
-      "b minor",
+      "eb minor",
+      "c# major",
       "g# major",
-      "db minor",
-      "ab major",
-      "gb major"
+      "a minor",
+      "gb minor",
+      "bb major"
     ]
   },
   "music.melody": {
@@ -3155,12 +3155,12 @@
     "description": "Descriptive types of musical melodies with their definitions",
     "total": 94,
     "examples": [
-      "antiphonal melody (alternating phrases between different groups)",
-      "cannon melody (melodic imitation at different times)",
-      "delicate melody (gentle and fragile)",
-      "falling melody (descending motion with gradual decrease in pitch)",
-      "legato melody (smooth and connected)",
-      "jazzy melody (incorporating jazz-style elements)"
+      "brooding melody (dark, low-pitched, and contemplative)",
+      "fluttering melody (quick and fluttering notes)",
+      "melancholic melody (deeply sad, reflective, and expressive)",
+      "hocket melody (interlocking notes between voices or instruments)",
+      "angular chromatic melody (chromatic intervals with angular shape)",
+      "birdsong-inspired melody (mimicking the sounds of birds)"
     ]
   },
   "music.mode": {
@@ -3170,11 +3170,11 @@
     "total": 55,
     "examples": [
       "acoustic scale mode",
-      "double harmonic scale mode",
-      "japanese scale mode",
-      "half-whole diminished mode",
-      "pentatonic minor mode",
-      "maqam saba mode"
+      "neapolitan major mode",
+      "pentatonic major mode",
+      "whole-tone scale mode",
+      "ryukyu scale mode",
+      "persian scale mode"
     ]
   },
   "music.mood": {
@@ -3183,12 +3183,12 @@
     "description": "Emotional and atmospheric musical moods or vibes",
     "total": 117,
     "examples": [
-      "ecstatic",
+      "aggressive",
       "enigmatic",
-      "abrasive",
-      "comforting",
-      "energetic",
-      "bouncy"
+      "edgy",
+      "groovy",
+      "euphoric",
+      "abrasive"
     ]
   },
   "music.musicGenre": {
@@ -3197,12 +3197,12 @@
     "description": "Diverse global music genres and subgenres",
     "total": 63,
     "examples": [
-      "baroque pop",
-      "krautrock",
-      "psychobilly",
-      "flamenco",
-      "amapiano",
-      "vaporwave"
+      "house",
+      "witch house",
+      "reggae",
+      "drum and bass",
+      "hardcore techno",
+      "synthpop"
     ]
   },
   "music.percussive": {
@@ -3211,12 +3211,12 @@
     "description": "Specific percussion instruments and percussive sound makers",
     "total": 145,
     "examples": [
-      "agogo bells",
-      "bamboo tube",
-      "flexatone",
-      "bass drum",
-      "caxixi",
-      "boomwhackers"
+      "frame drum beater",
+      "wood block",
+      "wind gong",
+      "washboard",
+      "timbales",
+      "surdo beater"
     ]
   },
   "music.recording": {
@@ -3225,12 +3225,12 @@
     "description": "Various formats and styles of audio recordings",
     "total": 72,
     "examples": [
-      "acapella recording",
-      "digital recording",
-      "high-fidelity recording",
-      "analog recording",
-      "live recording",
-      "bootleg recording"
+      "livestream concert recording",
+      "live stream recording",
+      "conceptual recording",
+      "stereo recording",
+      "chamber music recording",
+      "mashup recording"
     ]
   },
   "music.rhythm": {
@@ -3239,12 +3239,12 @@
     "description": "Specific rhythmic patterns and timing structures in music",
     "total": 27,
     "examples": [
-      "broken rhythm",
-      "additive rhythm",
-      "dotted rhythm",
       "stutter rhythm",
-      "compound rhythm",
-      "shuffle rhythm"
+      "motorik rhythm",
+      "dotted rhythm",
+      "straight rhythm",
+      "shuffle rhythm",
+      "backbeat rhythm"
     ]
   },
   "music.songSection": {
@@ -3253,12 +3253,12 @@
     "description": "Structural components and sections of a musical composition",
     "total": 37,
     "examples": [
-      "middle eight",
-      "solo",
-      "breakdown",
-      "pre-chorus",
-      "variation",
-      "pre-verse"
+      "post-chorus",
+      "intro",
+      "theme",
+      "ad-lib section",
+      "call and response",
+      "pre-chorus"
     ]
   },
   "music.vocalStyle": {
@@ -3267,12 +3267,12 @@
     "description": "Specific vocal techniques, styles, and singing methods",
     "total": 187,
     "examples": [
-      "tenuto",
-      "field holler",
-      "diphonic singing",
-      "fall",
-      "enka",
-      "cante alentejano"
+      "puirt à beul",
+      "ad-lib",
+      "acciaccatura",
+      "dhrupad",
+      "alap",
+      "copla"
     ]
   },
   "music.vocal": {
@@ -3281,12 +3281,12 @@
     "description": "Descriptive styles and textures of vocal performances",
     "total": 119,
     "examples": [
-      "breathy vocals",
-      "vibrant falsetto",
-      "vocal harmonies",
-      "theatrical vocals",
-      "shimmering vocal layers",
-      "hushed ethereal vocals"
+      "smooth crooning",
+      "choir chants",
+      "atmospheric whispers",
+      "gravelly blues vocals",
+      "airy vocal textures",
+      "dynamic vocals"
     ]
   },
   "mythical.artifact": {
@@ -3295,12 +3295,12 @@
     "description": "Mythological, religious, and fictional magical items and artifacts",
     "total": 215,
     "examples": [
-      "arkenstone",
-      "mirror of opposition",
-      "ameno-nuhoko",
-      "aladdin's lamp",
-      "kantele of väinämöinen",
-      "crystal orb"
+      "staff of power",
+      "syamantaka",
+      "seamless robe of jesus",
+      "sampo",
+      "wand of orcus",
+      "srivatsa"
     ]
   },
   "mythical.chinese": {
@@ -3309,12 +3309,12 @@
     "description": "Deities, creatures, and figures from Chinese mythology",
     "total": 83,
     "examples": [
-      "qilin (麒麟)",
-      "di jun (帝俊)",
-      "ba she (巴蛇)",
-      "lei gong (雷公)",
-      "nine sons of the dragon (龍生九子)",
-      "kui (夔)"
+      "meng po (孟婆)",
+      "feng bo (風伯)",
+      "chiyou's brothers (蚩尤兄弟)",
+      "he xiangu (何仙姑)",
+      "erlang shen (二郎神)",
+      "di jun (帝俊)"
     ]
   },
   "mythical.dndRace": {
@@ -3323,12 +3323,12 @@
     "description": "Playable character races from Dungeons and Dragons",
     "total": 66,
     "examples": [
-      "orc",
-      "loxodon",
-      "plasmoid",
-      "astral elf",
-      "bugbear",
-      "tortle"
+      "eladrin",
+      "kobold",
+      "reborn",
+      "kalashtar",
+      "simic hybrid",
+      "aven"
     ]
   },
   "mythical.dragon": {
@@ -3337,12 +3337,12 @@
     "description": "Specific named dragons and dragon types from global mythologies",
     "total": 86,
     "examples": [
-      "cherokee uktena dragon",
-      "babylonian tiamat dragon",
-      "greek ismenian dragon",
-      "chinese zhulong dragon",
-      "egyptian apep dragon",
-      "hittite illuyanka dragon"
+      "hawaiian mo'o dragon",
+      "babylonian mušḫuššu dragon",
+      "arabian falak dragon",
+      "germanic lindworm dragon",
+      "irish ollipheist dragon",
+      "french peluda dragon"
     ]
   },
   "mythical.magicTheGathering": {
@@ -3351,12 +3351,12 @@
     "description": "Specific card names from the game Magic: The Gathering",
     "total": 32340,
     "examples": [
-      "auger spree",
-      "rift sower",
-      "gale force",
-      "clawing torment",
-      "dune drifter",
-      "aether revolt"
+      "mugging",
+      "hikari, twilight guardian",
+      "fungal bloom",
+      "arbiter of woe",
+      "battle at the bridge",
+      "bristlebud farmer"
     ]
   },
   "mythical.magicType": {
@@ -3365,12 +3365,12 @@
     "description": "Various schools, disciplines, and types of magical arts",
     "total": 53,
     "examples": [
-      "hydromancy",
-      "nature magic",
-      "banishment",
-      "soul magic",
-      "angelology",
-      "pyromancy"
+      "wizardry",
+      "evocation",
+      "voodoo",
+      "summoning",
+      "astral magic",
+      "void magic"
     ]
   },
   "mythical.mythicalCreature": {
@@ -3379,12 +3379,12 @@
     "description": "Famous monsters and creatures from global mythology and folklore",
     "total": 61,
     "examples": [
+      "sphinx",
       "phoenix",
-      "jersey devil",
-      "werewolf",
-      "gorgon",
-      "cockatrice",
-      "cerberus"
+      "basilisk",
+      "wyvern",
+      "jormungandr",
+      "mermaid"
     ]
   },
   "nature.areaOfNaturalBeauty": {
@@ -3393,12 +3393,12 @@
     "description": "Specific national parks, landmarks, and natural wonders worldwide",
     "total": 625,
     "examples": [
-      "wulingyuan national park",
-      "great wall",
-      "aberdare national park",
-      "ai-ais/richtersveld transfrontier park",
-      "beomeosa temple",
-      "cape point"
+      "tassili n'ajjer",
+      "kata tjuta",
+      "beni snassen mountains",
+      "almaty's medeo skating rink",
+      "langtang national park",
+      "banaue rice terraces"
     ]
   },
   "nature.biome": {
@@ -3407,12 +3407,12 @@
     "description": "Diverse ecological biomes and natural environmental zones",
     "total": 62,
     "examples": [
-      "desert",
-      "cave system",
+      "riparian zone",
+      "chaparral",
       "coral reef",
-      "cold desert",
-      "maquis",
-      "desert shrubland"
+      "peatland",
+      "cloud forest",
+      "prairie"
     ]
   },
   "nature.cloudType": {
@@ -3421,12 +3421,12 @@
     "description": "Specific meteorological cloud formations and types",
     "total": 40,
     "examples": [
-      "lenticular cloud",
-      "undulatus",
-      "pileus cloud",
-      "nacreous",
-      "stratus",
-      "pyrocumulus"
+      "cirrostratus",
+      "cumulus",
+      "shelf cloud",
+      "roll cloud",
+      "wall cloud",
+      "contrail"
     ]
   },
   "nature.flower": {
@@ -3435,12 +3435,12 @@
     "description": "Various flowering plants, herbs, and ornamental garden blooms",
     "total": 547,
     "examples": [
-      "marigold (tagetes)",
-      "parrot's beak (lotus berthelotii)",
-      "oxalis (oxalis)",
-      "impatiens (impatiens walleriana)",
-      "jewelweed (impatiens capensis)",
-      "franklin tree flower"
+      "trumpet vine (campsis radicans)",
+      "columbine (aquilegia)",
+      "hepatica (hepatica)",
+      "aster (aster)",
+      "blood lily (scadoxus multiflorus)",
+      "firebush (hamelia patens)"
     ]
   },
   "nature.fungus": {
@@ -3449,12 +3449,12 @@
     "description": "Assorted species of wild mushrooms and fungi",
     "total": 214,
     "examples": [
-      "conifer tuft mushroom",
-      "red-belted polypore fungus",
-      "shiitake mushroom",
-      "poison pie mushroom",
-      "oak bracket fungus",
-      "panther cap mushroom"
+      "chaga mushroom",
+      "spotted toughshank mushroom",
+      "common puffball",
+      "winter polypore fungus",
+      "brain mushroom",
+      "cloud ear fungus"
     ]
   },
   "nature.gemstone": {
@@ -3463,12 +3463,12 @@
     "description": "Various precious gemstones, crystals, and mineral specimens",
     "total": 375,
     "examples": [
-      "schorl",
-      "heliodor",
-      "dravite",
-      "blue calcite",
-      "alexandrite",
-      "augelite"
+      "sandstone",
+      "gypsum",
+      "chrysocolla",
+      "bronzite",
+      "jasper",
+      "jet (lignite)"
     ]
   },
   "nature.landscape": {
@@ -3477,12 +3477,12 @@
     "description": "Geological formations and large-scale geographical landscape features",
     "total": 51,
     "examples": [
-      "dune",
-      "bay",
-      "pass",
-      "gulf",
-      "escarpment",
-      "caldera"
+      "precipice",
+      "karst",
+      "butte",
+      "crater",
+      "oasis",
+      "hot spring"
     ]
   },
   "nature.mineral": {
@@ -3491,12 +3491,12 @@
     "description": "Specific mineral specimens, crystals, and semi-precious stones",
     "total": 275,
     "examples": [
-      "greenockite",
-      "franklinite",
-      "howlite",
-      "grossular",
-      "garnet",
-      "gibbsite"
+      "tourmaline",
+      "lazurite",
+      "lazulite",
+      "prehnite",
+      "oligoclase",
+      "almandine"
     ]
   },
   "nature.moonPhase": {
@@ -3505,12 +3505,12 @@
     "description": "Traditional, seasonal, and descriptive names for lunar phases",
     "total": 117,
     "examples": [
-      "young moon",
-      "last quarter",
-      "lenten moon",
-      "quarter moon",
-      "wet moon",
-      "milk moon"
+      "mothers' moon",
+      "honey moon",
+      "blood moon",
+      "micro full moon",
+      "da vinci glow",
+      "paschal moon"
     ]
   },
   "nature.naturalPhenomenon": {
@@ -3519,12 +3519,12 @@
     "description": "Rare atmospheric, meteorological, and natural optical phenomena",
     "total": 45,
     "examples": [
-      "rainbow",
-      "geyser",
-      "moonbow",
-      "elves",
-      "dust devil",
-      "ball lightning"
+      "superbloom",
+      "blue jets",
+      "mirage",
+      "lenticular cloud glow",
+      "aurora borealis",
+      "waterspout"
     ]
   },
   "nature.plant": {
@@ -3533,12 +3533,12 @@
     "description": "Common indoor houseplants and decorative potted foliage",
     "total": 55,
     "examples": [
-      "dumb cane",
-      "staghorn fern",
-      "bromeliad",
-      "prayer plant",
+      "begonia",
+      "fern",
       "fiddle leaf fig",
-      "snake plant"
+      "calathea",
+      "tillandsia",
+      "sempervivum"
     ]
   },
   "nature.sceneModifier": {
@@ -3547,12 +3547,12 @@
     "description": "Atmospheric conditions, weather, and mood modifiers for scenes",
     "total": 49,
     "examples": [
-      "crepuscular rays",
-      "rugged",
-      "windswept",
-      "pristine",
-      "arid",
-      "cloudy"
+      "frost-covered",
+      "aurora",
+      "moody",
+      "wet",
+      "snow-capped",
+      "overgrown"
     ]
   },
   "nature.scene": {
@@ -3561,12 +3561,12 @@
     "description": "Diverse natural environments, biomes, and landscape settings",
     "total": 84,
     "examples": [
+      "sea view",
+      "cityscape",
       "marsh",
-      "town",
-      "cavern",
-      "archipelago",
-      "flowers",
-      "delta"
+      "desert",
+      "crater",
+      "coral reef"
     ]
   },
   "nature.sky": {
@@ -3575,12 +3575,12 @@
     "description": "Specific sky conditions, times of day, and cloud formations",
     "total": 198,
     "examples": [
-      "smoggy sky",
-      "sulfur-yellow sky",
-      "wind-swept sky",
-      "tornado sky",
-      "sepia sunrise sky",
-      "nebula sky"
+      "undulatus cloud sky",
+      "lunar halo sky",
+      "luminous sky",
+      "deep space nebula sky",
+      "heavy rainclouds",
+      "full moon sky"
     ]
   },
   "nature.texture": {
@@ -3589,12 +3589,12 @@
     "description": "Assorted natural and artificial surface textures and patterns",
     "total": 167,
     "examples": [
-      "shattered sea ice",
-      "fabric folds",
-      "alligator skin",
-      "cork",
-      "leaf veins",
-      "distressed leather"
+      "painted brick wall",
+      "embroidered fabric",
+      "glossy ceramic tiles",
+      "granite wall",
+      "fractal pattern",
+      "brushed metal"
     ]
   },
   "nature.treeType": {
@@ -3603,12 +3603,12 @@
     "description": "Various species of deciduous, coniferous, and tropical trees",
     "total": 71,
     "examples": [
-      "acacia",
-      "mahogany",
+      "aspen",
+      "norfolk island pine",
       "ash",
-      "joshua tree",
+      "dragon's blood tree",
       "fan palm",
-      "banyan"
+      "ebony"
     ]
   },
   "nature.tree": {
@@ -3617,12 +3617,12 @@
     "description": "Assorted tree species, fruiting trees, and woody plants",
     "total": 158,
     "examples": [
-      "walnut",
-      "fir",
-      "northern white cedar",
-      "beech",
-      "pecan",
-      "honeylocust"
+      "sitka spruce",
+      "ebony",
+      "linden",
+      "giant sequoia",
+      "leyland cypress",
+      "locust"
     ]
   },
   "nature.tropicalHouseplant": {
@@ -3631,12 +3631,12 @@
     "description": "Tropical flowering plants, orchids, and decorative botanicals",
     "total": 104,
     "examples": [
-      "billbergia",
-      "salvia farinacea",
-      "aechmea",
-      "chamaedorea",
-      "euphorbia",
-      "catasetum"
+      "tradescantia",
+      "thunbergia",
+      "lobelia",
+      "zamioculcas",
+      "nemesia",
+      "justicia"
     ]
   },
   "nature.waterBody": {
@@ -3645,12 +3645,12 @@
     "description": "Various types of natural and artificial water formations",
     "total": 109,
     "examples": [
-      "swamp",
-      "lagoon",
-      "chute",
-      "aquifer",
-      "boiling lake",
-      "salt marsh"
+      "ditch",
+      "liman",
+      "crater lake",
+      "firth",
+      "kettle lake",
+      "arroyo"
     ]
   },
   "nature.weather": {
@@ -3659,12 +3659,12 @@
     "description": "Meteorological events, cloud types, and severe weather conditions",
     "total": 156,
     "examples": [
-      "fog",
-      "snow flurry",
-      "smoggy",
-      "hail",
-      "icicles",
-      "warm front"
+      "diamond dust",
+      "freezing",
+      "balmy",
+      "crisp",
+      "asperitas clouds",
+      "downpour"
     ]
   },
   "nature.wood": {
@@ -3673,12 +3673,12 @@
     "description": "Specific types of hardwood and softwood timber materials",
     "total": 66,
     "examples": [
-      "lacewood",
-      "cedar",
-      "aspen",
-      "cork",
-      "hemlock",
-      "beech"
+      "basswood",
+      "bamboo",
+      "ironwood",
+      "birch",
+      "bloodwood",
+      "elm"
     ]
   },
   "people.accent": {
@@ -3687,12 +3687,12 @@
     "description": "Various global and regional spoken accents and dialects",
     "total": 126,
     "examples": [
-      "hebrew",
-      "korean",
-      "canadian",
-      "appalachian",
-      "caribbean",
-      "finnish"
+      "armenian",
+      "doric",
+      "irish",
+      "african-american vernacular",
+      "geordie",
+      "italian"
     ]
   },
   "people.beautifulFeminine": {
@@ -3701,12 +3701,12 @@
     "description": "Adjectives describing feminine beauty, grace, and physical attractiveness",
     "total": 48,
     "examples": [
-      "lovely",
-      "ravishing",
-      "stylish",
-      "gorgeous",
-      "fashionable",
-      "sensational"
+      "dazzling",
+      "radiant",
+      "slim",
+      "angelic",
+      "sultry",
+      "delicate"
     ]
   },
   "people.beautifulMasculine": {
@@ -3715,12 +3715,12 @@
     "description": "Personality traits and physical characteristics associated with masculine appeal",
     "total": 106,
     "examples": [
-      "insightful",
-      "devoted",
-      "glowing skin",
-      "debonair",
-      "well mannered",
-      "content"
+      "broad-shouldered",
+      "secure",
+      "robust",
+      "intelligent",
+      "strong",
+      "handsome features"
     ]
   },
   "people.bodyType": {
@@ -3729,12 +3729,12 @@
     "description": "Detailed descriptions of various human body shapes, builds, and proportions",
     "total": 115,
     "examples": [
-      "banana-shaped with straight hips and shoulders",
-      "burly and thickset with a wide frame",
-      "curvy silhouette with balanced proportions",
-      "inverted triangle with lean lower body",
-      "fat with an oval silhouette",
-      "fat with soft, rounded contours"
+      "small in height and frame",
+      "tall and willowy with subtle curves",
+      "naturally muscular and athletic build",
+      "round all over, especially midsection",
+      "narrow shoulders, wider hips and thighs",
+      "top-heavy figure with slender legs"
     ]
   },
   "people.celebrity": {
@@ -3743,12 +3743,12 @@
     "description": "Famous actors, singers, influencers, and members of British royalty",
     "total": 646,
     "examples": [
-      "queen elizabeth ii",
-      "evangeline lilly",
-      "elle fanning",
-      "alejandra guilmant",
-      "brie larson",
-      "bruno mars"
+      "adele",
+      "julia fox",
+      "denzel washington",
+      "alyssa milano",
+      "christina hendricks",
+      "mark ruffalo"
     ]
   },
   "people.common": {
@@ -3757,12 +3757,12 @@
     "description": "Broad age groups, life stages, and general demographic categories",
     "total": 34,
     "examples": [
-      "gen-zer",
-      "toddler girl",
       "adult",
-      "woman",
       "millennial",
-      "lady"
+      "middle-aged woman",
+      "lady",
+      "child",
+      "schoolboy"
     ]
   },
   "people.couple": {
@@ -3771,12 +3771,12 @@
     "description": "Various romantic, platonic, and professional two-person relationship dynamics",
     "total": 36,
     "examples": [
-      "colleagues",
-      "roommates",
-      "spouses",
-      "romantic partners",
-      "married couple",
-      "acquaintances"
+      "couple",
+      "acquaintances",
+      "double date",
+      "companions",
+      "life partners",
+      "dating couple"
     ]
   },
   "people.dance": {
@@ -3785,12 +3785,12 @@
     "description": "Traditional, cultural, and modern dance styles from around the world",
     "total": 119,
     "examples": [
-      "merengue",
-      "ballroom dance",
-      "jive",
-      "khmer classical dance",
-      "foxtrot",
-      "electric slide dance"
+      "tap dancing",
+      "waacking dance",
+      "santhali dance",
+      "sattriya dance",
+      "pole dance",
+      "samba dance"
     ]
   },
   "people.expression": {
@@ -3799,12 +3799,12 @@
     "description": "Highly detailed descriptions of facial expressions and emotional body language",
     "total": 471,
     "examples": [
-      "wrinkled nose with curled upper lip",
-      "frown with downturned corners of the mouth and furrowed brow",
-      "open-mouthed gasp with raised eyebrows and widened eyes",
-      "scowl with narrowed eyes and a slightly jutted chin",
-      "quivering chin with watery eyes and slightly parted lips",
-      "boisterous laugh with clapping hands and stomping feet"
+      "beaming smile that lights up the entire face",
+      "broad grin with teeth showing and eyes crinkling",
+      "beaming with pride, chest puffed and chin high",
+      "slack-jawed expression with raised eyebrows and widened eyes",
+      "frown with a trembling lower lip and misty eyes",
+      "exaggerated duck lips with posed grin"
     ]
   },
   "people.eyeColor": {
@@ -3813,12 +3813,12 @@
     "description": "Natural and fantasy eye colors including gem-like and vivid shades",
     "total": 46,
     "examples": [
-      "amethyst eyes",
-      "brown eyes",
-      "violet eyes",
-      "deep brown eyes",
-      "electric blue eyes",
-      "sky blue eyes"
+      "hazel-green eyes",
+      "blue eyes",
+      "coral eyes",
+      "hazel eyes",
+      "charcoal eyes",
+      "smoky grey eyes"
     ]
   },
   "people.festival": {
@@ -3827,12 +3827,12 @@
     "description": "Major international cultural, religious, and seasonal festivals and holidays",
     "total": 59,
     "examples": [
-      "albuquerque international balloon fiesta",
+      "yi peng lantern festival",
       "inty raymi",
-      "hanukkah",
-      "festival of colors",
-      "pingxi sky lantern festival",
-      "holi"
+      "independence day",
+      "tomorrowland",
+      "san fermin",
+      "harbin ice festival"
     ]
   },
   "people.group": {
@@ -3841,12 +3841,12 @@
     "description": "Collective nouns and terms for various groups or gatherings of people",
     "total": 71,
     "examples": [
-      "flock",
-      "individuals",
-      "guild",
-      "travelers",
-      "people",
-      "coalition"
+      "delegates",
+      "society",
+      "band",
+      "patrons",
+      "tourists",
+      "caravan"
     ]
   },
   "people.hairstyle": {
@@ -3855,12 +3855,12 @@
     "description": "Diverse haircuts, styling techniques, and hair textures for men and women",
     "total": 58,
     "examples": [
-      "bob cut",
-      "chignon",
-      "pigtails",
-      "mohawk",
+      "wolf cut",
       "flat top",
-      "bantu knots"
+      "twists",
+      "top knot",
+      "bouffant",
+      "layer cut"
     ]
   },
   "people.hobby": {
@@ -3869,12 +3869,12 @@
     "description": "Wide range of creative, physical, and intellectual hobbies and interests",
     "total": 291,
     "examples": [
-      "video game streaming",
-      "writing therapy",
-      "qigong",
-      "lock picking",
-      "palm reading",
-      "writing"
+      "macramé",
+      "leatherworking",
+      "soap making",
+      "mountaineering",
+      "mindfulness-based stress reduction",
+      "metal engraving"
     ]
   },
   "people.job": {
@@ -3883,12 +3883,12 @@
     "description": "Various professional occupations, roles, and employment titles",
     "total": 612,
     "examples": [
-      "groundskeeper",
-      "purchasing manager",
-      "pararescuemen",
-      "neurologist",
-      "school bus driver",
-      "teacher assistant"
+      "surveyor",
+      "security guard",
+      "recon",
+      "teacher assistant",
+      "payroll administrator",
+      "package delivery driver"
     ]
   },
   "people.makeupStyle": {
@@ -3897,12 +3897,12 @@
     "description": "Historical, trendy, and artistic makeup styles and cosmetic techniques",
     "total": 73,
     "examples": [
-      "1920s flapper makeup",
-      "1950s pin-up makeup",
-      "draping blush",
+      "monochrome makeup",
       "bronzed makeup",
-      "90s brown lip",
-      "matte makeup"
+      "1960s mod makeup",
+      "avant-garde makeup",
+      "alt-makeup",
+      "cut crease makeup"
     ]
   },
   "people.posePortrait": {
@@ -3911,12 +3911,12 @@
     "description": "Specific camera angles, body positioning, and framing for portrait photography",
     "total": 45,
     "examples": [
-      "looking through window",
-      "close-up",
-      "looking off into the distance",
-      "back turned to camera looking over shoulder",
-      "propped up on one elbow (resting)",
-      "leaning against a wall"
+      "leaning forward",
+      "wide shot",
+      "arms crossed",
+      "full body shot",
+      "crouched portrait",
+      "silhouette portrait"
     ]
   },
   "people.pose": {
@@ -3925,12 +3925,12 @@
     "description": "Dynamic body postures, gestures, and physical actions for characters",
     "total": 201,
     "examples": [
-      "dancing or jumping in mid-air with a joyful expression",
-      "crouching down with hands on ground in front of body",
-      "looking confident with hands on hips",
-      "crouching with one hand on the knee",
-      "sitting on the ground with knees hugged to chest",
-      "looking straight into the camera"
+      "leaning forward with arms outstretched",
+      "sitting on a ledge with legs dangling",
+      "sitting with weight on one side",
+      "sitting on the edge",
+      "standing on one leg with other leg bent at the knee",
+      "standing proud"
     ]
   },
   "people.profession": {
@@ -3939,12 +3939,12 @@
     "description": "Specific historical, scientific, and specialized professions and trades",
     "total": 60,
     "examples": [
-      "brewmaster",
+      "conservator",
+      "taxonomist",
       "bookbinder",
-      "distiller",
-      "watchmaker",
-      "archaeologist",
-      "librarian"
+      "lighthouse keeper",
+      "theologian",
+      "brewmaster"
     ]
   },
   "photography.apertureLook": {
@@ -3953,12 +3953,12 @@
     "description": "Photographic effects related to bokeh, depth of field, focus, and lens flares",
     "total": 52,
     "examples": [
-      "bubble bokeh",
-      "swirly bokeh",
-      "hyperfocal focus",
-      "anamorphic bokeh",
+      "bokeh",
+      "hyperfocal distance focus",
+      "split-diopter focus",
+      "anamorphic flare",
       "rack focus",
-      "focus stacking"
+      "lens flare"
     ]
   },
   "photography.cameraMovement": {
@@ -3967,12 +3967,12 @@
     "description": "Cinematography terms for dynamic camera movements, rigs, and tracking shots",
     "total": 50,
     "examples": [
-      "shaky cam",
-      "camera roll",
-      "steadicam shot",
-      "roll",
-      "sweeping pan",
-      "snorricam shot"
+      "trucking shot",
+      "drone sweep",
+      "steadicam",
+      "360-degree rotation",
+      "gimbal shot",
+      "handheld shot"
     ]
   },
   "photography.camera": {
@@ -3981,12 +3981,12 @@
     "description": "Specific models of professional cinema cameras, DSLRs, and digital cameras",
     "total": 187,
     "examples": [
-      "canon 5d mark iii",
-      "sony f65",
-      "sony a6000",
-      "ricoh gr ii",
+      "canon eos r",
+      "canon 7",
+      "canon powershot a2300",
+      "xiaomi mi sphere 360 camera",
       "sony alpha nex-7 body only compact system camera",
-      "sony"
+      "lomography lomo'instant automat glass magellan edition"
     ]
   },
   "photography.composition": {
@@ -3995,12 +3995,12 @@
     "description": "Visual composition techniques, framing styles, and spatial balance methods",
     "total": 117,
     "examples": [
-      "left-to-right rule",
-      "pyramid composition",
-      "vertical lines",
-      "o-shape composition",
-      "minimalist composition",
-      "open composition"
+      "leading lines",
+      "subject isolation",
+      "background separation",
+      "chiaroscuro",
+      "asymmetrical composition",
+      "baroque diagonal"
     ]
   },
   "photography.filmStock": {
@@ -4009,12 +4009,12 @@
     "description": "Specific brands, models, and ISO speeds of analog photographic film stocks",
     "total": 52,
     "examples": [
+      "ilford fp4 plus",
+      "foma fomapan 100",
       "fujicolor industrial 100",
-      "ilford delta 400",
-      "cinestill 50d",
-      "polaroid originals film",
-      "kodak portra 160",
-      "kodak ektar 100"
+      "ilford hp5 plus",
+      "rollei retro 80s",
+      "ilford sfx 200"
     ]
   },
   "photography.film": {
@@ -4023,12 +4023,12 @@
     "description": "Specific analog photography film types, brands, and ISO speeds",
     "total": 102,
     "examples": [
-      "kodak portra 400 film",
-      "adox pan 100 film",
-      "fuji velvia 100 film",
+      "kodak elite 200s film",
+      "fuji neopan acros 100 film",
+      "kodak ektar 100 film",
+      "ilford pan f plus 50 film",
       "fuji provia 400x rdpiii film",
-      "fuji superia reala 100 film",
-      "kodak professional portra 800 film"
+      "lomography redscale film"
     ]
   },
   "photography.landscapeKeyword": {
@@ -4037,12 +4037,12 @@
     "description": "Broad photography concepts, subjects, and techniques related to outdoor photography",
     "total": 81,
     "examples": [
-      "objects",
-      "graveyards",
-      "leaves",
-      "canyons",
-      "b&w",
-      "fire"
+      "moon",
+      "mist",
+      "patterns",
+      "lines",
+      "horizons",
+      "grass"
     ]
   },
   "photography.landscapeSubjectDetailed": {
@@ -4051,12 +4051,12 @@
     "description": "Highly descriptive, full-sentence prompts of vivid nature and landscape scenes",
     "total": 158,
     "examples": [
-      "a dramatic thunderstorm brewing over a vast golden wheat field",
-      "a peaceful river with calm waters and rocky banks",
-      "a dense jungle with a variety of primates and other wildlife",
-      "a colorful hot spring with steam rising from the water",
-      "a peaceful river valley with a variety of bird species",
-      "a misty mountain peak surrounded by clouds"
+      "a roaring waterfall cascading over rocks",
+      "a serene alpine lake with a mirrored surface and snow-capped peaks",
+      "a misty mountain peak surrounded by clouds",
+      "a picturesque valley with a meandering river",
+      "a remote island with rugged coastlines and diverse marine life",
+      "a colorful autumn forest with vibrant foliage"
     ]
   },
   "photography.landscapeSubject": {
@@ -4065,12 +4065,12 @@
     "description": "Various natural and man-made outdoor locations, structures, and landscape features",
     "total": 132,
     "examples": [
-      "outcropping",
-      "cove",
-      "botanical garden",
-      "fountain",
-      "ghost town",
-      "footpath"
+      "tide pool",
+      "skyscraper",
+      "mine",
+      "rock formation",
+      "delta",
+      "vineyard"
     ]
   },
   "photography.lensType": {
@@ -4079,12 +4079,12 @@
     "description": "General categories, optical designs, and specialized styles of photographic lenses",
     "total": 52,
     "examples": [
-      "wide-angle",
-      "prime",
-      "pinhole lens",
-      "achromatic doublet",
-      "telephoto",
-      "perspective-control"
+      "ultra-wide lens",
+      "pinhole",
+      "aspherical lens",
+      "reflex lens",
+      "super-telephoto lens",
+      "apochromatic"
     ]
   },
   "photography.lens": {
@@ -4093,12 +4093,12 @@
     "description": "Specific focal lengths and exact branded camera lens models",
     "total": 87,
     "examples": [
-      "nikon af-s 17-35mm",
-      "sony fe 16-35mm",
-      "sony fe 24-70mm",
-      "tamron sp 45mm",
-      "nikon z 24-70mm",
-      "sony fe 70-200mm"
+      "sigma 35mm",
+      "sigma 105mm",
+      "sony fe 24mm",
+      "canon ef 70-200mm",
+      "fujifilm xf 18-55mm",
+      "nikon z 100-400mm"
     ]
   },
   "photography.lightSource": {
@@ -4107,12 +4107,12 @@
     "description": "Natural, artificial, and specialized light sources and lighting equipment",
     "total": 64,
     "examples": [
-      "matchstick",
-      "starlight",
-      "skylight",
-      "campfire",
+      "fluorescent tube",
+      "ring light",
+      "oil lamp light",
+      "moonlight",
       "light emitting diode",
-      "phosphorescence"
+      "gaslight"
     ]
   },
   "photography.light": {
@@ -4121,12 +4121,12 @@
     "description": "Descriptive lighting styles, natural light conditions, and illumination techniques",
     "total": 136,
     "examples": [
-      "lit by street light",
-      "glowing radioactivity",
-      "evening",
-      "light reflecting",
-      "split lighting",
-      "lit by fluorescent lamps"
+      "warm glowing light",
+      "lit from top",
+      "morbid light",
+      "fill light",
+      "night",
+      "caustics lights"
     ]
   },
   "photography.lightingSetup": {
@@ -4135,12 +4135,12 @@
     "description": "Studio lighting techniques, setups, and directional illumination styles",
     "total": 52,
     "examples": [
-      "badger lighting",
-      "loop lighting",
-      "bounce lighting",
-      "butterfly lighting",
-      "moody lighting",
-      "soft lighting"
+      "beauty lighting",
+      "soft lighting",
+      "kicker lighting",
+      "rembrandt lighting",
+      "badge lighting",
+      "key lighting"
     ]
   },
   "photography.perspective": {
@@ -4149,12 +4149,12 @@
     "description": "Camera angles, viewpoints, and geometric perspective techniques for visual framing",
     "total": 129,
     "examples": [
-      "zero-point perspective",
-      "extreme wide-angle perspective",
-      "bottom-up view",
-      "cylindrical perspective",
-      "cutaway view",
-      "expanded perspective"
+      "wide-angle perspective",
+      "extreme close-up perspective",
+      "aerial perspective",
+      "bird's-eye perspective",
+      "canted perspective",
+      "extreme high-angle view"
     ]
   },
   "photography.photographer": {
@@ -4163,12 +4163,12 @@
     "description": "Names of famous photographers paired with their specific genres or styles",
     "total": 960,
     "examples": [
-      "nada harib (documentary photographer)",
-      "richard mosse (documentary photographer)",
-      "sigmar polke (conceptual and fine art photographer)",
-      "tracey moffatt (conceptual photographer)",
-      "wolfgang tillmans (conceptual photographer)",
-      "max dupain (documentary and commercial photographer)"
+      "mick rock (music photographer)",
+      "gunnie moberg (landscape and documentary photographer)",
+      "anne geddes (portrait photographer)",
+      "alexander khokhlov (portrait and fashion photographer)",
+      "anastasia tsayder (documentary and fine art photographer)",
+      "aaron siskind (abstract photographer)"
     ]
   },
   "photography.portraitPhotographer": {
@@ -4177,12 +4177,12 @@
     "description": "Names of renowned portrait, fine art, and fashion photographers",
     "total": 79,
     "examples": [
-      "peter lindbergh",
-      "jimmy nelson",
-      "jürgen teller",
-      "elliott erwitt",
-      "bill brandt",
-      "andres serrano"
+      "peter menzel",
+      "richard avedon",
+      "weegee",
+      "martin parr",
+      "robert frank",
+      "man ray"
     ]
   },
   "photography.shotType": {
@@ -4191,11 +4191,11 @@
     "description": "Various camera angles and framing techniques for photography and film",
     "total": 43,
     "examples": [
+      "aerial shot",
       "dutch angle",
-      "close-up",
-      "high angle shot",
-      "extreme wide shot",
-      "satellite shot",
+      "hip level shot",
+      "medium wide shot",
+      "point-of-view shot",
       "medium close-up"
     ]
   },
@@ -4205,12 +4205,12 @@
     "description": "Idyllic, warm-weather outdoor scenes, landscapes, and summer activities",
     "total": 47,
     "examples": [
-      "a quaint village with flower boxes in every window",
-      "a rustic beach shack surrounded by sand dunes and sea grass",
-      "a beach at sunset",
-      "a tropical beach with hammocks strung between leaning coconut palms",
-      "a pathway lined with blooming hydrangeas leading to a seaside cottage",
-      "a village fair with games, rides, and cotton candy"
+      "a beachside boardwalk lined with palm trees",
+      "a rolling green hill dotted with grazing sheep",
+      "a refreshing swimming hole surrounded by smooth river rocks and mossy trees",
+      "a sun-drenched patio with a glass of iced lemonade and blooming potted plants",
+      "a mountain lake surrounded by trees",
+      "a city park with lush green trees and flowers in full bloom"
     ]
   },
   "photography.summerTropicalBeach": {
@@ -4219,12 +4219,12 @@
     "description": "Sensory details and vibrant scenes of a tropical beach vacation",
     "total": 67,
     "examples": [
-      "coconut shells and tropical fruit platters arranged on a woven picnic mat",
-      "the sound of laughter and joy from vacationers enjoying themselves",
-      "soft, powdery white sand stretching as far as the eye can see",
-      "a collection of starfish resting in a shallow, sun-warmed tidal pool",
-      "a wooden signpost pointing to different exotic tropical destinations",
-      "the silhouette of a catamaran sailing across a blazing golden sunset"
+      "children splashing in the gentle, warm shallows of a protected lagoon",
+      "footprints in the wet sand slowly washed away by the incoming tide",
+      "a flock of pelicans soaring gracefully overhead",
+      "a collection of brightly colored fishing boats bobbing in the water",
+      "a vibrant, colorful reef visible just offshore",
+      "a picture-perfect sunset, with oranges and pinks streaking across the sky"
     ]
   },
   "photojournalism.newsExtreme": {
@@ -4233,12 +4233,12 @@
     "description": "Catastrophic, world-altering, and extreme global news events and disasters",
     "total": 68,
     "examples": [
-      "a massive synthetic biology lab leak creates a highly aggressive, invasive plant species that destroys concrete",
-      "a revolutionary new form of renewable energy is discovered",
-      "a new form of social media changes the world",
+      "a major celebrity's private life is exposed in a major scandal",
+      "a massive new casino is built in a major city, bringing in billions of dollars",
+      "a huge protest against an ai company that's taken over people's jobs",
       "a major city is hit by a massive blizzard, shutting down transportation and power",
-      "a sudden, massive sinkhole swallows an entire city block during rush hour",
-      "a major new discovery in the world of astronomy"
+      "a massive new dinosaur fossil is discovered",
+      "a global agricultural blight rapidly destroys half of the world's wheat and corn crops"
     ]
   },
   "photojournalism.newsNormal": {
@@ -4247,12 +4247,12 @@
     "description": "Standard major news headlines covering science, politics, business, and society",
     "total": 57,
     "examples": [
-      "a historic museum heist occurs, with thieves stealing priceless masterpieces overnight",
-      "a major labor union goes on a nationwide strike, halting public transit and shipping",
-      "a breakthrough in agricultural technology allows crops to be grown in arid, desert conditions",
-      "a major development in international relations, such as a new trade deal or a new peace treaty",
-      "a major cultural festival, celebrating the traditions and customs of a particular group or region",
-      "a major climate change summit, bringing together world leaders to discuss solutions to the crisis"
+      "a city council meeting erupts in heated debate over new zoning laws and gentrification",
+      "a major climate disaster, such as a tornado or a record-breaking heatwave",
+      "a major business scandal, such as a ponzi scheme or insider trading",
+      "a mass shooting or act of domestic terrorism, leaving communities reeling from the violence",
+      "a massive oil spill, devastating a major coastal community and harming wildlife",
+      "a prominent social media influencer is banned from major platforms, sparking intense debate on free speech"
     ]
   },
   "photojournalism.newsSpecific": {
@@ -4261,12 +4261,12 @@
     "description": "Highly detailed, specific descriptions of major global news events and crises",
     "total": 38,
     "examples": [
-      "a bold environmental protest: activists scale a major oil rig in the north sea, unfurling a massive banner protesting deep-sea drilling",
-      "a massive wildfire: a fire sweeps through the australian outback, destroying homes and forcing thousands of residents to evacuate",
-      "a new scientific discovery: scientists discover a new species of dinosaur, providing new insights into the prehistoric world and sparking excitement among paleontologists and the public alike",
-      "a breakthrough in the fight against cancer: researchers develop a new type of cancer treatment that uses the body's own immune system to target and destroy cancer cells",
-      "a landmark supreme court ruling: justices hand down a historic decision on privacy rights in the digital age, limiting government surveillance",
-      "a historic environmental recovery: the bald eagle population is officially declared fully recovered and removed from the endangered species list"
+      "a major celebrity scandal: a top hollywood actor is caught in a massive cheating scandal, leading to the collapse of his marriage and a major hit to his career",
+      "a massive refugee migration: thousands of families flee gang violence in central america, forming a massive caravan traveling toward the border",
+      "a mass shooting or act of domestic terrorism: a gunman opens fire at a crowded concert in las vegas, killing dozens and injuring hundreds more",
+      "a historic moment: the first manned mission to mars successfully lands on the red planet, opening up a new era of space exploration",
+      "a major civil rights movement: the black lives matter movement gains widespread support and leads to major policy changes, including police reform and the removal of confederate statues",
+      "a bold environmental protest: activists scale a major oil rig in the north sea, unfurling a massive banner protesting deep-sea drilling"
     ]
   },
   "photojournalism.styleProtest": {
@@ -4275,12 +4275,12 @@
     "description": "Various photographic styles and techniques used in photojournalism and documentary photography",
     "total": 38,
     "examples": [
-      "action photography: capturing the movement and energy of the protesters in action",
-      "intentional camera movement: deliberately moving the camera during a longer exposure to create a dynamic, abstract representation of chaos and action",
-      "documentary photography: providing a historical record of the protests and the people involved",
-      "cinematic photojournalism: utilizing anamorphic lenses, wide aspect ratios, and dramatic color grading to evoke a movie-like atmosphere",
-      "monochrome photojournalism: stripping away color to emphasize form, texture, shadow, and the pure raw emotion of the moment",
-      "first-person point-of-view photography: shooting from eye-level within the thick of the crowd, giving the viewer an immersive sense of being there"
+      "analog film photography: using traditional 35mm or medium format film to create a raw, grain-textured aesthetic with natural color tones",
+      "black and white photography: creating a timeless and classic aesthetic that emphasizes contrast and emotion",
+      "underwater and rain-spattered photography: shooting through wet lenses or during heavy downpours to capture the grueling physical conditions of outdoor protests",
+      "candid photography: capturing the spontaneous moments of protests and the raw emotions of the participants",
+      "macro photography: focusing on the small details of protests and individual participants",
+      "panoramic photography: capturing the scale and size of large-scale protests and demonstrations"
     ]
   },
   "photojournalism.types": {
@@ -4289,12 +4289,12 @@
     "description": "Diverse subjects and thematic beats covered in photojournalism and documentary reporting",
     "total": 87,
     "examples": [
-      "advocacy photojournalism, documenting specific causes to raise awareness and inspire social change",
-      "environmental photojournalism, focusing on the impact of industry on natural habitats",
-      "aging and retirement",
-      "aging infrastructure and maintenance issues",
-      "gender identity and gender expression",
-      "scientific research and discoveries"
+      "investigative reporting on corporate corruption and misconduct",
+      "medical breakthroughs and innovations",
+      "travel and tourism",
+      "labor and workers' rights",
+      "photojournalistic coverage of the refugee crisis and displacement",
+      "investigative reporting on police brutality and misconduct"
     ]
   },
   "places.home": {
@@ -4303,12 +4303,12 @@
     "description": "Various types of residential dwellings and architectural housing styles",
     "total": 103,
     "examples": [
-      "trullo",
-      "guest house",
+      "skyscraper",
+      "igloo",
+      "bungalow",
+      "container home",
       "brownstone",
-      "earth sheltered home",
-      "cob home",
-      "bungalow"
+      "duplex"
     ]
   },
   "places.interiorSpace": {
@@ -4317,12 +4317,12 @@
     "description": "Diverse indoor environments ranging from mundane rooms to specialized workspaces",
     "total": 481,
     "examples": [
-      "botanical conservatory",
-      "sauna",
-      "cloisters walk",
-      "infirmary",
-      "dry cleaner",
-      "classroom"
+      "wine shop",
+      "inn tavern",
+      "natatorium",
+      "pizzeria",
+      "post office sorting room",
+      "mill interior"
     ]
   },
   "places.public": {
@@ -4331,12 +4331,12 @@
     "description": "Common public venues, recreational areas, and civic facilities",
     "total": 94,
     "examples": [
-      "city hall",
-      "art museum",
-      "beach restaurant",
-      "lighthouse",
-      "waterfront",
-      "picnic area"
+      "planetarium",
+      "hiking trail",
+      "children's museum",
+      "cemetery",
+      "baseball field",
+      "beach park"
     ]
   },
   "places.roomType": {
@@ -4345,12 +4345,12 @@
     "description": "Specific, often historical or grand interior rooms and specialized chambers",
     "total": 71,
     "examples": [
-      "conservatory",
-      "banquet hall",
+      "laboratory",
+      "larder",
       "sitting room",
-      "lobby",
-      "refectory",
-      "archive"
+      "vestibule",
+      "wardrobe",
+      "trophy room"
     ]
   },
   "places.room": {
@@ -4359,12 +4359,12 @@
     "description": "Standard functional rooms and spaces found in typical modern homes",
     "total": 51,
     "examples": [
-      "boardroom",
-      "guest room",
-      "cellar",
+      "hallway",
+      "mail room",
+      "server room",
+      "waiting room",
       "closet",
-      "kitchen",
-      "copy room"
+      "classroom"
     ]
   },
   "places.urbanFeature": {
@@ -4373,12 +4373,12 @@
     "description": "Structural elements, fixtures, and infrastructure found in city environments",
     "total": 196,
     "examples": [
-      "pedestrian overpass",
-      "cul-de-sac",
-      "fire hydrant",
-      "billboard",
-      "balcony",
-      "cell tower"
+      "drinking fountain",
+      "e-scooter parking zone",
+      "driveway",
+      "bridge",
+      "catenary wires",
+      "newsstand"
     ]
   },
   "plot.action": {
@@ -4387,12 +4387,12 @@
     "description": "High-stakes, thrilling scenarios involving combat, heists, rescues, and survival",
     "total": 66,
     "examples": [
-      "defending against a military attack",
-      "preventing a dangerous weapon from falling into the wrong hands",
-      "participating in a heist or caper",
+      "stopping a rogue ai or weapon of mass destruction",
+      "breaking into a secure location",
+      "infiltrating a spy or espionage organization",
       "escaping from a burning building or other disaster",
-      "infiltrating a cartel or organized crime group",
-      "stopping a political uprising or revolution"
+      "escaping from a dangerous maze or labyrinth",
+      "intercepting a deadly smuggler shipment at sea"
     ]
   },
   "plot.arthouse": {
@@ -4401,12 +4401,12 @@
     "description": "Introspective narratives focusing on emotional struggles, relationships, and personal crises",
     "total": 66,
     "examples": [
-      "battling with a chronic illness",
-      "being held captive",
-      "being caught in a love triangle",
-      "forming a secret society",
       "facing an ethical dilemma",
-      "going on a dangerous adventure"
+      "challenging authority",
+      "battling with a chronic illness",
+      "experiencing a surreal breakdown of linear time",
+      "going on a dangerous adventure",
+      "dealing with a moral dilemma"
     ]
   },
   "plot.fantasy": {
@@ -4415,12 +4415,12 @@
     "description": "Magical and supernatural adventures involving mythical creatures, curses, and epic quests",
     "total": 66,
     "examples": [
-      "rescuing a captive or hostage",
-      "escaping from an enchanted forest or maze",
-      "dealing with the power struggles between kingdoms",
-      "reclaiming a throne usurped by a puppet king",
-      "training to become a powerful wizard or warrior",
-      "overcoming personal demons or fears"
+      "surviving in a world filled with monsters and creatures",
+      "navigating through a magical jungle or swamp",
+      "discovering a hidden society of magic-users",
+      "overcoming obstacles in a world filled with magic",
+      "navigating the shifting rules of a court of fae nobility",
+      "hunting down a legendary shape-shifting assassin"
     ]
   },
   "plot.general": {
@@ -4429,12 +4429,12 @@
     "description": "A mix of everyday life events, personal goals, and lighthearted adventures",
     "total": 109,
     "examples": [
-      "starting a startup",
-      "becoming a superhero",
-      "participating in a scavenger hunt",
-      "attending a high school reunion",
-      "going on a road trip",
-      "going on a cross-country road trip"
+      "hosting a house party",
+      "learning to dance",
+      "navigating a midlife career change",
+      "starting a wedding planning company",
+      "retiring from a lifelong career and finding a new purpose",
+      "participating in a sporting event"
     ]
   },
   "plot.horror": {
@@ -4443,12 +4443,12 @@
     "description": "Horror and survival scenarios involving supernatural entities, monsters, and deadly environments",
     "total": 65,
     "examples": [
-      "trapped in a haunted mansion",
-      "investigating an old videotape that curses whoever watches it",
-      "surviving a night in a museum where the exhibits come alive aggressively",
-      "trapped in a haunted hotel",
-      "staying alive in a zombie outbreak",
-      "surviving a night in a high-tech smart home that turns hostile"
+      "staying alive in a world overrun by genetically modified creatures",
+      "staying alive in a post-apocalyptic wasteland",
+      "staying alive in a world overrun by robots",
+      "searching for a missing expedition team",
+      "uncovering a horrific sacrificial cult in a picture-perfect suburb",
+      "searching for a lost city of gold"
     ]
   },
   "plot.musical": {
@@ -4457,12 +4457,12 @@
     "description": "Storylines focused on musical competitions, bands, solo artists, and creative collaborations",
     "total": 66,
     "examples": [
-      "overcoming creative differences in a musical collaboration",
-      "dealing with the challenges of being a solo artist",
-      "rekindling a love of music after a period of burnout",
-      "balancing a secret identity as a rising pop star and a normal student",
+      "discovering a hidden singing talent in an unassuming street busker",
+      "helping a formerly famous diva find her voice again",
+      "struggling to write a hit song under a strict label deadline",
       "dealing with the stress of performing live",
-      "learning to work together as a musical team"
+      "overcoming creative differences in a musical collaboration",
+      "staging an unauthorized underground musical"
     ]
   },
   "plot.romance": {
@@ -4471,12 +4471,12 @@
     "description": "Romantic storylines about overcoming personal, social, and communication obstacles to find love",
     "total": 65,
     "examples": [
-      "falling in love while teaching each other different languages",
-      "going on a romantic adventure or journey",
-      "finding love in an unexpected place",
-      "coping with infertility or other family-related challenges",
-      "navigating the ups and downs of a long-distance relationship",
-      "dealing with jealousy or insecurity"
+      "falling in love while trapped together in a cozy cabin during a blizzard",
+      "navigating the ups and downs of dating",
+      "overcoming addiction or other personal struggles",
+      "navigating a romance that blooms during a scenic culinary tour",
+      "overcoming fear of commitment",
+      "coping with infidelity or trust issues"
     ]
   },
   "plot.scifiCyberpunk": {
@@ -4485,12 +4485,12 @@
     "description": "Cyberpunk scenarios involving hacking, rogue AI, cyborgs, and dystopian corporate espionage",
     "total": 66,
     "examples": [
-      "navigating through a cyber-controlled wasteland",
-      "discovering a ghost in the machine within a colossal city-wide mainframe",
       "defending against a powerful ai or rogue program",
-      "escaping from a dangerous city or dystopian world",
-      "dealing with the power struggles between corporations",
-      "hacking into a corporation's computer systems"
+      "searching for a way to defeat a rogue ai",
+      "overcoming a technological apocalypse",
+      "defending against a cyber-controlled army",
+      "participating in a virtual race or competition",
+      "escaping a digital quarantine zone inside a virtual reality network"
     ]
   },
   "plot.scifi": {
@@ -4499,12 +4499,12 @@
     "description": "Science fiction scenarios featuring space exploration, alien encounters, and planetary disasters",
     "total": 185,
     "examples": [
-      "making first contact with an alien race",
-      "dealing with a malfunctioning spacecraft",
+      "investigating the sudden silence of a deep-space research outpost",
+      "a group of survivors try to rebuild society after a massive emp destroys all technology",
+      "escaping a virtual reality",
+      "finding a new home for humanity",
       "dealing with the consequences of time travel",
-      "discovering a hidden society in space",
-      "destroying a rogue planet or moon",
-      "infiltrating a space-based military base"
+      "finding a way to reverse a planetary catastrophe"
     ]
   },
   "plot.war": {
@@ -4513,12 +4513,12 @@
     "description": "Military and tactical operations including covert missions, sieges, and defensive stands",
     "total": 66,
     "examples": [
-      "saving civilian lives during conflict",
-      "stopping a traitor or mole within the group",
-      "defending a field hospital during a surprise enemy counter-offensive",
-      "defending a strategic location from enemy forces",
-      "infiltrating a coastal artillery battery to disable its guns",
-      "infiltrating enemy territory"
+      "carrying out a dangerous mission",
+      "escaping from a booby-trapped area",
+      "guiding a civilian convoy through a highly contested sniper alley",
+      "rescuing a captured comrade",
+      "escaping from a besieged city or village",
+      "conducting a sabotage mission"
     ]
   },
   "science.astronomy": {
@@ -4527,12 +4527,12 @@
     "description": "Astronomical concepts, phenomena, and celestial structures like black holes and dark matter",
     "total": 54,
     "examples": [
-      "star cluster",
-      "supernova",
-      "kuiper belt",
-      "meteor",
-      "neutron star",
-      "asteroid"
+      "asteroid",
+      "cosmic ray",
+      "comet",
+      "solar wind",
+      "exoplanet",
+      "quasar"
     ]
   },
   "science.chemicalElement": {
@@ -4541,12 +4541,12 @@
     "description": "Various chemical elements from the periodic table",
     "total": 118,
     "examples": [
-      "osmium",
-      "fluorine",
-      "neodymium",
-      "cadmium",
-      "gadolinium",
-      "francium"
+      "nickel",
+      "mercury",
+      "silicon",
+      "potassium",
+      "zirconium",
+      "rutherfordium"
     ]
   },
   "science.constellation": {
@@ -4555,12 +4555,12 @@
     "description": "Names of recognized star constellations in the night sky",
     "total": 88,
     "examples": [
-      "corona borealis",
-      "andromeda",
-      "eridanus",
-      "chamaeleon",
-      "hercules",
-      "dorado"
+      "lacerta",
+      "antlia",
+      "caelum",
+      "hydrus",
+      "fornax",
+      "camelopardalis"
     ]
   },
   "science.geometry": {
@@ -4569,12 +4569,12 @@
     "description": "Advanced mathematical shapes, fractals, attractors, and geometric concepts",
     "total": 117,
     "examples": [
-      "non-crystallographic symmetry",
-      "julia set",
-      "fibonacci spiral",
-      "archimedean",
-      "fractal dimension",
-      "julia set fractal"
+      "pentagonal",
+      "penrose tiling",
+      "tetrahedron",
+      "mandelbrot set",
+      "riemann hypothesis",
+      "quasicrystals"
     ]
   },
   "science.isotope": {
@@ -4583,12 +4583,12 @@
     "description": "Specific radioactive and stable isotopes of various chemical elements",
     "total": 56,
     "examples": [
-      "molybdenum-99",
-      "uranium-235",
-      "radon-222",
-      "barium-133",
+      "plutonium-241",
+      "calcium-48",
+      "potassium-40",
       "cobalt-60",
-      "lutetium-177"
+      "radon-222",
+      "sodium-22"
     ]
   },
   "science.medicalImages": {
@@ -4597,12 +4597,12 @@
     "description": "Medical imaging techniques and diagnostic scanning procedures",
     "total": 45,
     "examples": [
-      "fundus photography",
-      "micro-ct",
-      "3d ultrasound",
-      "sonography",
+      "mammogram",
+      "doppler imaging",
       "dexa scan",
-      "photoacoustic imaging"
+      "pet scan",
+      "functional mri",
+      "echocardiography"
     ]
   },
   "science.planetBody": {
@@ -4611,12 +4611,12 @@
     "description": "Specific planets, moons, asteroids, and other named celestial bodies",
     "total": 224,
     "examples": [
-      "aeneas",
-      "ferdinand",
-      "hale-bopp",
-      "ida",
-      "perdita",
-      "lutetia"
+      "troilus",
+      "51 pegasi b",
+      "despina",
+      "neptune",
+      "lutetia",
+      "chiron"
     ]
   },
   "science.robotType": {
@@ -4625,12 +4625,12 @@
     "description": "Various types of industrial, agricultural, and specialized autonomous robots and drones",
     "total": 328,
     "examples": [
-      "serpentine robot",
-      "anthropomorphic robot",
-      "pickup-and-place robot",
-      "lunar rover",
-      "space manipulator",
-      "sewer crawler"
+      "hazardous environment robot",
+      "aquatic robot",
+      "robotic arm",
+      "master-slave manipulator",
+      "autonomous surface vehicle",
+      "automated tugger"
     ]
   },
   "science.scifiTech": {
@@ -4639,12 +4639,12 @@
     "description": "Fictional science fiction technology, gadgets, and futuristic devices",
     "total": 63,
     "examples": [
-      "android",
-      "laser pistol",
-      "exosuit",
-      "teleporter",
+      "quantum computer",
+      "mecha suit",
       "matter replicator",
-      "jetpack"
+      "hyperdrive",
+      "bacta tank",
+      "anti-gravity boots"
     ]
   },
   "set.describeStyle": {
@@ -4653,12 +4653,12 @@
     "description": "Eclectic art styles, hashtags, and artist names used in AI image generation",
     "total": 17756,
     "examples": [
-      "elaborate drapery",
-      "dark and dramatic chiaroscuro portraits",
-      "dark purple and dark bronze",
-      "eugène boudin",
-      "david welker",
-      "dark white and yellow"
+      "étienne adolphe piot",
+      "aminollah rezaei",
+      "hypnotic",
+      "georges gimel",
+      "gray and azure",
+      "hashimoto gahō"
     ]
   },
   "set.describeSubject": {
@@ -4667,12 +4667,12 @@
     "description": "Highly specific, random AI-generated image prompts and surreal subject descriptions",
     "total": 139614,
     "examples": [
-      "a cartoon with a man standing in a white suit",
-      "a drawing of a female vampire with sword",
-      "a man with a colored face and chest",
-      "a female figure dressed in black hat with swords and a star pendant",
-      "a man faces the camera and wears a device",
-      "an abstract colorful splashed stream of paint coming out of a notebook"
+      "a tall building in a desert nightscape",
+      "a female character with long hair and a sword",
+      "a bunch of different colored circles surrounding a black background",
+      "a black monster like creature standing",
+      "a painting of weird mushroom land",
+      "a pagoda with moon above it"
     ]
   },
   "set.memeDescription": {
@@ -4681,12 +4681,12 @@
     "description": "Popular internet memes paired with brief descriptions of their visual content",
     "total": 44,
     "examples": [
-      "american chopper argument meme - father and son yelling, throwing chair",
-      "felt cute might delete later meme - selfie caption, often used ironically",
-      "ceiling cat meme - cat peering through hole in ceiling",
+      "dat boi meme - frog riding unicycle with \"o shit waddup\" caption",
+      "coffin dance meme - same as dancing pallbearers",
       "gibby on icarly \"i don't care if you broke your elbow\" meme - gibby responding callously",
-      "harlem shake meme - group suddenly dancing wildly to song",
-      "ancient aliens guy meme - man with wild hair gesturing \"aliens"
+      "distracted girlfriend meme - woman looking back at another man",
+      "awkward penguin meme - penguin with blue and red backgrounds for situations",
+      "all your base are belong to us meme - engrish phrase from zero wing game"
     ]
   },
   "set.meme": {
@@ -4695,12 +4695,12 @@
     "description": "Popular internet memes and viral image macros",
     "total": 44,
     "examples": [
-      "baby yoda meme",
-      "change my mind meme",
-      "american chopper argument meme",
-      "condescending wonka meme",
-      "harlem shake meme",
-      "ceiling cat meme"
+      "bad luck brian meme",
+      "futurama fry meme",
+      "here comes dat boi meme",
+      "crying michael jordan meme",
+      "dolan meme",
+      "baby yoda meme"
     ]
   },
   "set.moviegenBench": {
@@ -4709,12 +4709,12 @@
     "description": "MovieGen Video Bench contains 1003 diverse prompts testing various aspects including human activities (motion, emotions), animals, nature/scenery, physics (fluids, gravity, collisions), and unusual subjects/activities. The prompts provide comprehensive coverage across high, medium and low motion scenarios.\n",
     "total": 1003,
     "examples": [
+      "A fencer engaged in a fast-paced duel.",
+      "A giraffe in a lifeguard outfit, sitting atop a high chair and watching over a crowded pool.",
+      "An adorable happy otter confidently stands on a surfboard wearing a yellow lifejacket, riding along turquoise tropical waters near lush tropical islands, 3D digital render art style.",
+      "Historical footage of California during the gold rush.",
       "A haunted mansion with flickering candles and eerie shadows.",
-      "A cyclist powering up a steep hill in a road race.",
-      "a real girl franatically running a dense forest with bushes, trees, in rainy day, the animals are running after her and she is screaming and shouting",
-      "A high-speed video of raindrops hitting a puddle, causing ripples and splashes.",
-      "A fox wearing a pirate hat and eyepatch, steering a ship through a stormy sea.",
-      "Static camera shot. A dinasour running near some lions and chasing them away."
+      "A slow-motion video of a liquid droplet bouncing on a water-repellent surface."
     ]
   },
   "set.parti": {
@@ -4723,12 +4723,12 @@
     "description": "PartiPrompts (P2) is a rich set of over 1600 prompts in English. P2 can be used to measure model capabilities across various categories and challenge aspects.\n",
     "total": 1632,
     "examples": [
-      "an eagle swooping down to catch a mouse",
-      "A richly textured oil painting of a young badger delicately sniffing a yellow rose next to a tree trunk. A small waterfall can be seen in the background.",
-      "The Great Pyramid of Giza situated in front of Mount Everest",
-      "beautiful fireworks in the sky with red, white and blue",
-      "the United States flag next to the flag of Texas",
-      "a photograph of a blue porsche 356 coming around a bend in the road"
+      "a portrait of a statue of the Egyptian god Anubis wearing aviator goggles, white t-shirt and leather jacket. A full moon over the city of Los Angeles is in the background at night.",
+      "a cartoon of a happy car on the road",
+      "several people putting their hands on a basketball",
+      "the moon with a smiling face",
+      "a red sphere on top of a yellow box",
+      "a circular brown trash bin in front of a brick wall"
     ]
   },
   "sport.all": {
@@ -4737,12 +4737,12 @@
     "description": "Various athletic sports, gymnastics, and competitive physical activities",
     "total": 470,
     "examples": [
-      "freestyle bmx",
-      "laser tag",
-      "javelin throw",
-      "sumo",
-      "skydiving",
-      "air racing"
+      "rugby fives",
+      "stand up paddleboarding",
+      "teqball",
+      "zorbing",
+      "track and field",
+      "throwball"
     ]
   },
   "thing.adjective": {
@@ -4751,12 +4751,12 @@
     "description": "Adjectives describing physical textures and material conditions",
     "total": 71,
     "examples": [
+      "bumpy",
+      "shiny",
+      "greasy",
       "flaky",
-      "pliable",
-      "springy",
-      "prickly",
-      "smoothed",
-      "worn"
+      "scorched",
+      "polished"
     ]
   },
   "thing.armor": {
@@ -4765,12 +4765,12 @@
     "description": "Historical and modern protective armor, helmets, and tactical vests",
     "total": 171,
     "examples": [
-      "surcoat",
-      "cabasset",
-      "dragon skin armor",
-      "gardbrace",
-      "combat helmet",
-      "corinthian helmet"
+      "liquid armor",
+      "camail",
+      "do-maru",
+      "chitin armor",
+      "combat armor",
+      "breastplate"
     ]
   },
   "thing.city": {
@@ -4779,12 +4779,12 @@
     "description": "Urban infrastructure, commercial buildings, and city street elements",
     "total": 216,
     "examples": [
-      "school",
-      "cafe",
-      "bar",
-      "botanical conservatory",
-      "fire escape",
-      "street sweeper"
+      "chinese restaurant",
+      "flag",
+      "souvenir kiosk",
+      "botanical garden",
+      "soccer field",
+      "nail salon"
     ]
   },
   "thing.everyday": {
@@ -4793,12 +4793,12 @@
     "description": "Common household objects, appliances, and everyday personal items",
     "total": 243,
     "examples": [
-      "pillow",
-      "sofa",
-      "tarp",
-      "towel rack",
-      "roller",
-      "paper"
+      "tent",
+      "toaster",
+      "truck",
+      "watch",
+      "tote bag",
+      "sunglasses"
     ]
   },
   "thing.fabric": {
@@ -4807,12 +4807,12 @@
     "description": "Various natural and synthetic textiles and fabric materials",
     "total": 56,
     "examples": [
-      "felt",
-      "fleece",
-      "organza",
-      "duck cloth",
-      "crepe",
-      "taffeta"
+      "herringbone",
+      "flannel",
+      "merino wool",
+      "hemp",
+      "faux leather",
+      "denim"
     ]
   },
   "thing.fantasy": {
@@ -4821,12 +4821,12 @@
     "description": "Fantasy characters, magical items, and mythical creatures",
     "total": 146,
     "examples": [
-      "goblins",
-      "castle wall",
-      "skeletons",
-      "elven princess",
-      "apprentice",
-      "elves"
+      "fang",
+      "dark elf",
+      "basilisk",
+      "dragon",
+      "battering ram",
+      "black ice"
     ]
   },
   "thing.furniture": {
@@ -4835,12 +4835,12 @@
     "description": "Various types of indoor and outdoor seating and storage furniture",
     "total": 58,
     "examples": [
-      "wingback chair",
-      "futon",
-      "end table",
-      "console table",
-      "eames chair",
-      "chesterfield sofa"
+      "side table",
+      "wardrobe",
+      "canopy bed",
+      "display cabinet",
+      "bunk bed",
+      "buffet"
     ]
   },
   "thing.gadget": {
@@ -4849,12 +4849,12 @@
     "description": "Electronic devices, musical gadgets, and modern technological equipment",
     "total": 417,
     "examples": [
-      "ultrasonic pest repeller",
-      "hydroponics controller",
-      "nintendo switch",
+      "microwave oven",
       "guitar amplifier",
-      "game console",
-      "label maker"
+      "electronic nebulizer",
+      "electronic luggage scale",
+      "electronic tuning fork",
+      "electronic keyboard (musical)"
     ]
   },
   "thing.gemstone": {
@@ -4863,12 +4863,12 @@
     "description": "Precious and semi-precious gemstones and mineral crystals",
     "total": 59,
     "examples": [
-      "azurite",
-      "chrysolite",
-      "demantoid",
-      "jadeite",
       "hawk's eye",
-      "spinel"
+      "morganite",
+      "chrysolite",
+      "zircon",
+      "rose quartz",
+      "jadeite"
     ]
   },
   "thing.icon": {
@@ -4877,12 +4877,12 @@
     "description": "Common digital interface icons and simple graphic symbols",
     "total": 132,
     "examples": [
-      "soccer",
-      "lock",
-      "magnifying glass",
-      "chess",
-      "download",
-      "headphones"
+      "stop",
+      "arrow up",
+      "cloud",
+      "thumbs up",
+      "bullhorn",
+      "needle"
     ]
   },
   "thing.material": {
@@ -4891,12 +4891,12 @@
     "description": "Various raw materials, plastics, stones, and crafting substances",
     "total": 68,
     "examples": [
-      "steel",
-      "platinum",
-      "copper material",
-      "silver",
-      "plaster",
-      "concrete"
+      "glass",
+      "amber",
+      "leather material",
+      "cast iron",
+      "mahogany",
+      "bakelite"
     ]
   },
   "thing.metal": {
@@ -4905,12 +4905,12 @@
     "description": "Various metallic elements, alloys, and metal finishes",
     "total": 273,
     "examples": [
-      "brushed bronze",
-      "hastelloy",
-      "cerium",
-      "chrome plating",
-      "copper-nickel",
-      "alnico"
+      "hammered bronze",
+      "maraging steel",
+      "nichrome",
+      "green gold",
+      "cesium",
+      "matte gold"
     ]
   },
   "thing.office": {
@@ -4919,12 +4919,12 @@
     "description": "Financial tools, office supplies, and business-related items",
     "total": 68,
     "examples": [
+      "hard hat",
+      "highlighter",
+      "computer mouse",
       "bank vault",
-      "stock certificate",
-      "monitor",
-      "desk lamp",
-      "rubber stamp",
-      "hole punch"
+      "label maker",
+      "keyboard"
     ]
   },
   "thing.pattern": {
@@ -4933,12 +4933,12 @@
     "description": "Decorative geometric, textile, and camouflage visual patterns",
     "total": 115,
     "examples": [
-      "brocade",
-      "cow print",
-      "tortoiseshell",
-      "zigzag",
-      "buffalo check",
-      "starry night"
+      "ditsy floral",
+      "chintz",
+      "shibori",
+      "ikat",
+      "fretwork",
+      "basketweave"
     ]
   },
   "thing.scary": {
@@ -4947,12 +4947,12 @@
     "description": "Creepy locations, paranormal entities, and horror-themed concepts",
     "total": 211,
     "examples": [
-      "hidden rooms",
-      "whispers in the dark",
-      "black magic",
-      "disembodied laughter",
-      "blood curdling screams",
-      "nightmares"
+      "ghost sightings",
+      "sinister clown",
+      "unexplained deaths",
+      "supernatural powers",
+      "the undead",
+      "skeletal remains"
     ]
   },
   "thing.sciFi": {
@@ -4961,12 +4961,12 @@
     "description": "Futuristic technology, AI systems, and science fiction transportation",
     "total": 204,
     "examples": [
-      "arc reactor",
-      "hoverbike",
-      "3d printing",
-      "mars terraforming machine",
-      "time machine",
-      "deep space data relay"
+      "ai personal assistant",
+      "space elevator capsule",
+      "brain-computer interface device",
+      "flying cars",
+      "automated lunar rover",
+      "force field generator"
     ]
   },
   "thing.space": {
@@ -4975,12 +4975,12 @@
     "description": "Celestial bodies, nebulae, moons, stars, and cosmic phenomena",
     "total": 158,
     "examples": [
-      "reflection nebula",
-      "kuiper belt",
-      "galaxies",
-      "black hole",
-      "dark cloud",
-      "euanthe"
+      "stellar nursery",
+      "galactic halo",
+      "main sequence star",
+      "exoplanet",
+      "pulsar wind nebula",
+      "ring nebula"
     ]
   },
   "thing.summer": {
@@ -4989,12 +4989,12 @@
     "description": "Summer recreation items, beach gear, and outdoor accessories",
     "total": 70,
     "examples": [
-      "corn on the cob",
-      "kite",
-      "portable speaker",
-      "tank top",
-      "pool float",
-      "campfire"
+      "sarong",
+      "iced tea",
+      "insect repellent",
+      "campfire",
+      "mosquito net",
+      "beach towel"
     ]
   },
   "thing.surfaceFinish": {
@@ -5003,12 +5003,12 @@
     "description": "Material surface treatments, textures, and manufacturing finishes",
     "total": 164,
     "examples": [
-      "hammered",
-      "bead-blasted",
-      "crackled",
-      "machined",
-      "blued",
-      "bleached"
+      "alodined",
+      "stained",
+      "bisque",
+      "coarse",
+      "wire-brushed",
+      "back-painted"
     ]
   },
   "thing.weapon": {
@@ -5017,12 +5017,12 @@
     "description": "Historical melee, ranged, and medieval combat weapons",
     "total": 55,
     "examples": [
-      "rapier",
+      "main-gauche",
       "billhook",
-      "longsword",
-      "club",
-      "bow",
-      "greatsword"
+      "scimitar",
+      "longbow",
+      "javelin",
+      "greataxe"
     ]
   },
   "thing.woodType": {
@@ -5031,12 +5031,12 @@
     "description": "Various tree species and types of woodworking lumber",
     "total": 150,
     "examples": [
-      "agarwood",
-      "kurogaki",
-      "ipe",
-      "anegre",
-      "cocobolo",
-      "monkeypod"
+      "imbuia",
+      "bamboo",
+      "spruce",
+      "pernambuco",
+      "lancewood",
+      "lignum vitae"
     ]
   },
   "time.century": {
@@ -5045,11 +5045,11 @@
     "description": "Specific centuries spanning BC and AD historical timelines",
     "total": 37,
     "examples": [
-      "17th century",
-      "18th century",
-      "24th century",
       "6th century bc",
-      "21st century",
+      "5th century bc",
+      "17th century",
+      "4th century",
+      "1st century",
       "8th century bc"
     ]
   },
@@ -5059,12 +5059,12 @@
     "description": "Specific calendar dates and notable days of the year",
     "total": 387,
     "examples": [
-      "december 12",
-      "december 16",
-      "june 11",
-      "december 6",
-      "june 27",
-      "february 21"
+      "august 3",
+      "january 12",
+      "november 14",
+      "june 17",
+      "june 14",
+      "june 19"
     ]
   },
   "time.decade": {
@@ -5073,12 +5073,12 @@
     "description": "Specific decades ranging from the 1800s to the 2050s",
     "total": 35,
     "examples": [
-      "1810s",
-      "1820s",
-      "2020s",
+      "1980s",
       "1830s",
-      "1860s",
-      "1960s"
+      "2030s",
+      "60s",
+      "1840s",
+      "2050s"
     ]
   },
   "time.era": {
@@ -5087,12 +5087,12 @@
     "description": "Historical periods, cultural eras, and specific global conflicts",
     "total": 118,
     "examples": [
-      "crusades",
-      "italian renaissance",
-      "enlightenment",
-      "glorious revolution",
-      "high middle ages",
-      "french and indian war"
+      "renaissance",
+      "ancient greece",
+      "cambrian period",
+      "iron age",
+      "french and indian war",
+      "first anglo-afghan war"
     ]
   },
   "time.festival": {
@@ -5101,12 +5101,12 @@
     "description": "Global cultural, religious, and film festivals and holidays",
     "total": 196,
     "examples": [
-      "edinburgh fringe",
-      "hogmanay",
-      "lantern festival",
-      "epiphany",
-      "holi",
-      "durga puja"
+      "cherry blossom festival",
+      "meskel",
+      "comic-con",
+      "christmas",
+      "awa odori",
+      "bisket jatra"
     ]
   },
   "time.historicalEra": {
@@ -5115,12 +5115,12 @@
     "description": "Historical empires, dynasties, and major technological or cultural ages",
     "total": 148,
     "examples": [
-      "dot-com bubble",
-      "renaissance",
-      "muromachi period",
-      "colonial america",
-      "maurya empire",
-      "maratha empire"
+      "mali empire",
+      "aztec empire",
+      "machine age",
+      "akkadian empire",
+      "mesolithic era",
+      "sui dynasty"
     ]
   },
   "time.season": {
@@ -5129,12 +5129,12 @@
     "description": "Astronomical, cultural, commercial, agricultural, and natural seasons",
     "total": 241,
     "examples": [
-      "ski season",
-      "hunting season",
-      "late autumn",
-      "election season",
-      "football season",
-      "fishing season"
+      "all-hallown summer",
+      "fleece season",
+      "cicada season",
+      "rugby season",
+      "winter solstice",
+      "apple cider season"
     ]
   },
   "time.timeOfDay": {
@@ -5143,12 +5143,12 @@
     "description": "Specific times of day and associated lighting or atmospheric conditions",
     "total": 201,
     "examples": [
-      "mid-morning",
-      "early night",
-      "crepuscule",
-      "early morning",
-      "breakfast time",
-      "evening dew"
+      "civil twilight",
+      "shadow hour",
+      "evening dew",
+      "dead of night",
+      "late night",
+      "astronomical twilight"
     ]
   },
   "time.year": {
@@ -5157,12 +5157,12 @@
     "description": "Specific individual years spanning the 19th to 21st centuries",
     "total": 251,
     "examples": [
-      "1924",
-      "1907",
-      "2003",
-      "1908",
-      "1856",
-      "1976"
+      "2044",
+      "2021",
+      "2027",
+      "2019",
+      "1979",
+      "2034"
     ]
   },
   "typography.feature": {
@@ -5171,12 +5171,12 @@
     "description": "Typographic design features, spacing, and specific letterform characteristics",
     "total": 69,
     "examples": [
-      "consistent stroke width",
-      "generous leading",
-      "playful swashes",
-      "ink traps",
-      "closed counters",
-      "overshooting"
+      "balanced letterforms",
+      "rounded corners",
+      "loose kerning",
+      "elegant ligatures",
+      "airy spacing",
+      "closed counters"
     ]
   },
   "typography.fontType": {
@@ -5185,12 +5185,12 @@
     "description": "Typographic design movements and historical font classifications",
     "total": 62,
     "examples": [
-      "condensed typography",
-      "grotesque typography",
-      "schwabacher typography",
-      "psychedelic typography",
-      "script typography",
-      "calligraphic typography"
+      "victorian typography",
+      "blackletter typography",
+      "sans-serif typography",
+      "glyphic typography",
+      "cybernetic typography",
+      "geometric typography"
     ]
   },
   "typography.font": {
@@ -5199,12 +5199,12 @@
     "description": "Specific named typefaces and popular font families",
     "total": 89,
     "examples": [
-      "century gothic font",
-      "noto sans font",
-      "barlow font",
-      "roboto font",
-      "lora font",
-      "space mono font"
+      "calibri font",
+      "arial black font",
+      "josefin sans font",
+      "merriweather sans font",
+      "akzidenz grotesk font",
+      "frutiger font"
     ]
   },
   "typography.style": {
@@ -5213,12 +5213,12 @@
     "description": "Font weights, widths, and specific stylistic typeface variations",
     "total": 76,
     "examples": [
-      "expanded style font",
-      "italic style font",
       "book style font",
-      "debossed style font",
-      "fat style font",
-      "compressed style font"
+      "compact style font",
+      "extra bold italic style font",
+      "textured style font",
+      "embossed style font",
+      "wide style font"
     ]
   },
   "typography.typefaceStyle": {
@@ -5227,12 +5227,12 @@
     "description": "Various font styles, historical typefaces, and typographic classifications",
     "total": 69,
     "examples": [
-      "old style",
-      "inline",
-      "rotunda",
-      "egyptienne",
-      "expanded",
-      "geometric sans"
+      "psychedelic font",
+      "display",
+      "humanist serif",
+      "clarendon",
+      "old style serif",
+      "3d lettering font"
     ]
   },
   "typography.wordArt": {
@@ -5241,12 +5241,12 @@
     "description": "Textures, materials, and visual effects applied to text and typography",
     "total": 137,
     "examples": [
-      "beaded text",
-      "slanted text",
-      "anaglyph 3d text",
-      "kaleidoscopic text",
-      "cloudy text",
-      "floral text"
+      "engraved text",
+      "perspective text",
+      "metallic text",
+      "stamped text",
+      "outer glow text",
+      "mirrored text"
     ]
   },
   "vehicle.aircraft": {
@@ -5255,12 +5255,12 @@
     "description": "Various types of airplanes, helicopters, and specialized aerial vehicles",
     "total": 126,
     "examples": [
-      "passenger plane",
-      "airborne early warning aircraft",
-      "hang glider",
-      "flying saucer",
-      "experimental aircraft",
-      "ground effect vehicle"
+      "canard aircraft",
+      "tandem-rotor helicopter",
+      "weather balloon",
+      "tanker aircraft",
+      "commercial jet",
+      "flying car"
     ]
   },
   "vehicle.car": {
@@ -5269,12 +5269,12 @@
     "description": "Specific modern car makes and models from various automotive manufacturers",
     "total": 329,
     "examples": [
-      "ford ecosport",
-      "hyundai santa fe",
-      "jaguar xe",
-      "bmw x3",
-      "bmw i4",
-      "buick encore"
+      "hyundai tucson",
+      "ford escape",
+      "chrysler aspen",
+      "honda hr-v",
+      "chevrolet impala",
+      "acura ilx"
     ]
   },
   "vehicle.classicCar": {
@@ -5283,12 +5283,12 @@
     "description": "Specific vintage, antique, and classic car models with their production years",
     "total": 161,
     "examples": [
-      "1987 buick gnx",
-      "1918 ford model t",
-      "1929 cadillac series 341a",
-      "1903 oldsmobile curved dash runabout",
-      "1907 rolls-royce 40/50 hp",
-      "1933 pierce-arrow silver arrow"
+      "1928 packard model 526",
+      "1910 buick model 17",
+      "1908 packard model 30",
+      "1915 dodge model 30-35",
+      "1916 cadillac type 53",
+      "1913 buick model 31"
     ]
   },
   "vehicle.famousCar": {
@@ -5297,12 +5297,12 @@
     "description": "Iconic cars and fictional vehicles from popular movies and film franchises",
     "total": 50,
     "examples": [
-      "the bluesmobile from the blues brothers",
-      "magnum's ferrari from magnum, p.i",
-      "eleanor from gone in 60 seconds",
-      "the ford explorer from jurassic world",
-      "mater from cars 2",
-      "finn mcmissile from cars 2"
+      "the a-team van from the a-team",
+      "the nissan skyline gt-r from 2 fast 2 furious",
+      "kitt from knight rider",
+      "the general lee from the dukes of hazzard",
+      "the delorean from back to the future",
+      "the jurassic park jeep wrangler from jurassic park"
     ]
   },
   "vehicle.fastCar": {
@@ -5311,12 +5311,12 @@
     "description": "Specific models of high-performance sports cars, supercars, and luxury vehicles",
     "total": 98,
     "examples": [
-      "aston martin db11",
-      "maserati mc12",
-      "aston martin vanquish",
-      "bentley bentayga mulliner",
-      "bugatti veyron",
-      "ferrari daytona sp3"
+      "pagani zonda f",
+      "jaguar f-type svr",
+      "ferrari daytona sp3",
+      "aston martin db11 amr",
+      "audi tt rs",
+      "jaguar xj220"
     ]
   },
   "vehicle.motorcycle": {
@@ -5325,12 +5325,12 @@
     "description": "Various styles, classes, and specialized types of motorcycles and motorbikes",
     "total": 121,
     "examples": [
-      "scrambler",
-      "tracker",
-      "sidecar",
-      "rat bike",
-      "super naked",
-      "speedway bike"
+      "tilting trike",
+      "pocket bike",
+      "pit bike",
+      "superbike",
+      "classic motorcycle",
+      "scooter sidecar"
     ]
   },
   "vehicle.spacecraft": {
@@ -5339,12 +5339,12 @@
     "description": "Sci-fi spacecraft, starships, and specialized futuristic space vehicles",
     "total": 56,
     "examples": [
-      "cargo hauler",
-      "research vessel",
-      "carrier",
+      "deep-space telescope",
       "cargo hauler spacecraft",
-      "fusion rocket ship",
-      "colony transport"
+      "generation ship",
+      "solar sailer",
+      "flyby spacecraft",
+      "cargo hauler"
     ]
   },
   "vehicle.type": {
@@ -5353,12 +5353,12 @@
     "description": "Broad categories of land, air, and water transportation vehicles",
     "total": 116,
     "examples": [
-      "zamboni",
-      "monorail",
-      "limousine",
-      "bulldozer",
-      "bicycle",
-      "yacht"
+      "airplane",
+      "school bus",
+      "glider",
+      "tricycle",
+      "cruise ship",
+      "unicycle"
     ]
   },
   "vehicle.watercraft": {
@@ -5367,12 +5367,12 @@
     "description": "Various types of boats, ships, and marine vessels",
     "total": 188,
     "examples": [
-      "amphibious vehicle",
-      "hospital ship",
-      "hovercraft",
-      "jukung",
-      "flyboat",
-      "clipper ship"
+      "wakeboard boat",
+      "galley",
+      "cog",
+      "ark",
+      "banana boat",
+      "canoe"
     ]
   },
   "videoGame.action": {
@@ -5381,12 +5381,12 @@
     "description": "In-game character actions, abilities, and mechanics in video games",
     "total": 314,
     "examples": [
-      "buffing allies",
-      "stealing",
-      "slide jumping",
-      "scrapping items",
-      "riding",
-      "opening a door"
+      "dispelling illusions",
+      "shield bashing",
+      "cooking",
+      "consuming energy",
+      "channeling cosmic energies",
+      "channeling energy"
     ]
   },
   "videoGame.designer": {
@@ -5395,12 +5395,12 @@
     "description": "Names of prominent real-world video game designers and directors",
     "total": 68,
     "examples": [
-      "masahiro sakurai",
-      "alex rigopulos",
+      "chris roberts",
+      "tetsuya mizuguchi",
+      "sam lake",
       "gunpei yokoi",
-      "amy hennig",
-      "ed boon",
-      "chris hecker"
+      "peter molyneux",
+      "michel ancel"
     ]
   },
   "videoGame.engine": {
@@ -5409,12 +5409,12 @@
     "description": "Software frameworks and game engines used for developing video games",
     "total": 68,
     "examples": [
-      "libgdx",
-      "adventure game studio",
-      "rage",
-      "marmalade sdk",
-      "source engine",
-      "renderware graphics"
+      "luminous engine",
+      "umbra 3",
+      "dunia engine",
+      "fox engine",
+      "gamebryo",
+      "libgdx"
     ]
   },
   "videoGame.game": {
@@ -5423,12 +5423,12 @@
     "description": "Titles of popular video game franchises and specific game releases",
     "total": 319,
     "examples": [
-      "soulcalibur iii",
-      "starcraft",
-      "star wars: knights of the old republic",
-      "tekken 6",
-      "super smash bros",
-      "the elder scrolls v: skyrim"
+      "untitled goose game",
+      "mario kart",
+      "grand theft auto 2",
+      "borderlands: the pre-sequel!",
+      "animal well",
+      "fallout 4"
     ]
   },
   "videoGame.region": {
@@ -5437,12 +5437,12 @@
     "description": "Fictional environments, biomes, and level themes found in video games",
     "total": 118,
     "examples": [
-      "sunset kingdom",
-      "ruins region",
-      "steampunk city",
-      "mushroom kingdom",
-      "mythical kingdom",
-      "rainbow isles"
+      "pirate kingdom",
+      "void region",
+      "snowy kingdom",
+      "mystic forest",
+      "undersea kingdom",
+      "time kingdom"
     ]
   },
   "word.adjective": {
@@ -5451,12 +5451,12 @@
     "description": "Various descriptive adjectives ranging from anatomical to behavioral",
     "total": 4980,
     "examples": [
-      "frailest",
-      "consultative",
-      "rousing",
-      "elder",
-      "discretionary",
-      "dromozootic"
+      "greenish",
+      "tricky",
+      "celtic",
+      "corrupt",
+      "desolate",
+      "counterfeit"
     ]
   },
   "word.adverb": {
@@ -5465,12 +5465,12 @@
     "description": "Assorted adverbs modifying actions, states, or qualities",
     "total": 1798,
     "examples": [
-      "unknowingly",
-      "abroad",
-      "aloft",
-      "cheaply",
-      "accidentally",
-      "chronically"
+      "soft",
+      "solidly",
+      "stirringly",
+      "wherewith",
+      "unsteadily",
+      "unavoidably"
     ]
   },
   "word.noun": {
@@ -5479,12 +5479,12 @@
     "description": "A diverse mix of concrete objects, animals, and abstract conceptual nouns",
     "total": 24389,
     "examples": [
-      "celeriac",
-      "buy",
-      "deviation",
-      "visitors",
-      "ditty",
-      "donkey"
+      "whirling",
+      "currencies",
+      "hitchhiker",
+      "adjunct",
+      "creator",
+      "bricklayer"
     ]
   },
   "word.onomatopoeia": {
@@ -5493,12 +5493,12 @@
     "description": "Sound-imitating words including animal noises, human vocalizations, and impact sounds",
     "total": 159,
     "examples": [
-      "gobble",
-      "purr",
-      "bash",
-      "ahem",
-      "buzz",
-      "cough"
+      "crash",
+      "sigh",
+      "plink",
+      "pop",
+      "hiss",
+      "crackle"
     ]
   },
   "word.verb": {
@@ -5507,12 +5507,12 @@
     "description": "Action words and verb forms across various tenses including past and gerunds",
     "total": 9950,
     "examples": [
-      "distributes",
-      "erupting",
-      "scream",
-      "lull",
-      "lasts",
-      "lingers"
+      "unclasping",
+      "report",
+      "promised",
+      "relieve",
+      "outnumber",
+      "presage"
     ]
   }
 }

--- a/list-metadata.json
+++ b/list-metadata.json
@@ -1823,14 +1823,14 @@
     "title": "Alien and Predator names",
     "category": "fiction",
     "description": "Places, species, factions, creatures, ships, and artifacts from Alien and Predator fiction",
-    "total": 57,
+    "total": 147,
     "examples": [
-      "chestburster",
-      "acheron",
-      "synthetic",
-      "uscss prometheus",
-      "xenomorph",
-      "hadley's hope"
+      "xenomorph hive",
+      "empress",
+      "berserker predator",
+      "85",
+      "cllemens",
+      "bishop"
     ]
   },
   "fiction.amber": {
@@ -1839,26 +1839,26 @@
     "description": "Places, powers, factions, and concepts from Roger Zelazny's Chronicles of Amber",
     "total": 65,
     "examples": [
-      "julian",
-      "benedict",
-      "brial",
-      "tir-na nog'th",
-      "bayle",
-      "julia barnes"
+      "ganelon",
+      "keep of the four worlds",
+      "the courts of chaos",
+      "cabal",
+      "shadow",
+      "the jewel of judgment"
     ]
   },
   "fiction.asoiaf": {
     "title": "A Song of Ice and Fire names",
     "category": "fiction",
     "description": "Places, houses, peoples, and creatures from A Song of Ice and Fire",
-    "total": 249,
+    "total": 449,
     "examples": [
-      "hrakkar",
-      "merling",
-      "sunspear",
-      "lys",
-      "ice dragon",
-      "squisher"
+      "deep den",
+      "house tarbeck",
+      "grumkin",
+      "house borrell",
+      "dorne",
+      "barrowton"
     ]
   },
   "fiction.avatar": {
@@ -1867,12 +1867,12 @@
     "description": "Places, peoples, spirits, bending arts, and factions from Avatar: The Last Airbender and The Legend of Korra",
     "total": 87,
     "examples": [
-      "agni kai",
-      "bending",
-      "swampbenders",
-      "the dai li",
-      "pro-bending arena",
-      "fire nation colonies"
+      "the fire lord",
+      "ba sing se upper ring",
+      "air nomads",
+      "hei bai",
+      "chi blocking",
+      "mechanist"
     ]
   },
   "fiction.barsoom": {
@@ -1881,12 +1881,12 @@
     "description": "Places, peoples, creatures, titles, and artifacts from Edgar Rice Burroughs' Barsoom",
     "total": 69,
     "examples": [
-      "blue men",
-      "odwar",
-      "great thoat",
-      "banths",
-      "great white apes",
-      "helium"
+      "plant men",
+      "tharkian hordes",
+      "warhoon",
+      "masena",
+      "xavarian",
+      "river iss"
     ]
   },
   "fiction.basLag": {
@@ -1895,12 +1895,12 @@
     "description": "Places, peoples, creatures, factions, and concepts from China Mieville's Bas-Lag fiction",
     "total": 61,
     "examples": [
-      "gengris",
-      "chimer",
-      "torque",
-      "remade",
-      "shadrach",
-      "mr. motley"
+      "lin",
+      "parliament",
+      "south badlands",
+      "khepri",
+      "malachite",
+      "jabber"
     ]
   },
   "fiction.bookOfTheNewSun": {
@@ -1909,12 +1909,12 @@
     "description": "Unique names from The Book of the New Sun (Gene Wolfe) — places, peoples, creatures, factions, and ships combined.",
     "total": 227,
     "examples": [
-      "abaia",
-      "the inn of lost loves",
-      "the cult of the conciliator",
-      "the cacogens",
-      "alzabo",
-      "the cave of the cumaean"
+      "triskele",
+      "chalicothere",
+      "scylla",
+      "father inire",
+      "miles",
+      "the client's room"
     ]
   },
   "fiction.brokenEarth": {
@@ -1923,12 +1923,12 @@
     "description": "Unique names from The Broken Earth (N.K. Jemisin) — places, peoples, creatures, factions, and ships combined.",
     "total": 184,
     "examples": [
-      "innovator",
-      "the stone eaters",
-      "the bastion",
-      "the castrima council",
-      "insular",
-      "dibars"
+      "the doctors",
+      "tasi",
+      "the tourmaline",
+      "the inner core",
+      "castrima-under",
+      "the dead moon"
     ]
   },
   "fiction.conan": {
@@ -1937,40 +1937,40 @@
     "description": "Places, peoples, creatures, gods, and factions from Robert E. Howard's Conan and Hyborian Age",
     "total": 71,
     "examples": [
-      "shemites",
-      "siptah",
-      "pirate isles",
-      "ophir",
-      "vendhya",
-      "set"
+      "kosala",
+      "amazon",
+      "atali",
+      "kordava",
+      "black circle",
+      "jemsha"
     ]
   },
   "fiction.cthulhuMythos": {
     "title": "Cthulhu Mythos",
     "category": "fiction",
     "description": "Unique names from Cthulhu Mythos — places, peoples, creatures, factions, and ships combined.",
-    "total": 343,
+    "total": 758,
     "examples": [
-      "kadath",
-      "the cult of the bloody tongue",
-      "insect from shaggai",
-      "inqua",
-      "atlantis",
-      "demhe"
+      "great race of yith",
+      "ngyr-korath",
+      "deep one",
+      "hicksville",
+      "gloucester",
+      "hingham"
     ]
   },
   "fiction.culture": {
     "title": "Culture series",
     "category": "fiction",
     "description": "Starship names, orbitals, planets, systems, species, and factions from Iain M. Banks' Culture series",
-    "total": 106,
+    "total": 61,
     "examples": [
-      "experiencing a significant gravitas shortfall",
-      "anticipation of a new lover's arrival, the",
-      "youthful indiscretion",
-      "gzilt homeworld",
-      "boisterous frame of mind, a",
-      "chiark orbital"
+      "ahforgetit tendency",
+      "cheradenine zakalwe",
+      "ablation",
+      "contact",
+      "chiark orbital",
+      "casualty of cause"
     ]
   },
   "fiction.darkTower": {
@@ -1979,12 +1979,12 @@
     "description": "Places, peoples, creatures, factions, and powers from Stephen King's Dark Tower fiction",
     "total": 74,
     "examples": [
-      "the beam",
-      "susannah dean",
-      "wizard's glass",
-      "gilead",
-      "farson",
-      "prim"
+      "the speaking demon",
+      "mohaine desert",
+      "ka-tet",
+      "arthur eld",
+      "calla bryn sturgis",
+      "tull"
     ]
   },
   "fiction.dc": {
@@ -1993,12 +1993,12 @@
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from DC fiction",
     "total": 85,
     "examples": [
-      "red hood",
-      "mr. mxyzptlk",
-      "the court of owls",
+      "hawkman",
+      "arkham knight",
       "amanda waller",
-      "yj",
-      "justice league"
+      "crime alley",
+      "intergang",
+      "the multiverse"
     ]
   },
   "fiction.discworld": {
@@ -2007,12 +2007,12 @@
     "description": "Places, peoples, creatures, and groups from Terry Pratchett's Discworld",
     "total": 143,
     "examples": [
-      "the gnarly ground",
-      "pictsies",
-      "muntab",
-      "sto helit",
-      "naiads",
-      "omnia"
+      "igors",
+      "curse-of-the-mummy scarab",
+      "bes pelargic",
+      "great a'tuin",
+      "hunchbroad",
+      "gnomes"
     ]
   },
   "fiction.dragonBall": {
@@ -2021,40 +2021,40 @@
     "description": "Places, species, transformations, artifacts, and powers from Dragon Ball",
     "total": 77,
     "examples": [
-      "trunks",
-      "capsule corporation",
-      "king kai's planet",
       "android 16",
-      "krillin",
-      "cell juniors"
+      "planet vegeta",
+      "other world",
+      "gohan",
+      "super saiyan blue",
+      "galactic patrol"
     ]
   },
   "fiction.dragonlance": {
     "title": "Dragonlance names",
     "category": "fiction",
     "description": "Places, peoples, factions, creatures, deities, and artifacts from Dragonlance",
-    "total": 51,
+    "total": 128,
     "examples": [
-      "the high clerist's tower",
-      "solace",
-      "dark queen",
-      "draconians",
-      "the conclave of wizards",
-      "sancrist"
+      "palanthas",
+      "balifor",
+      "tasslehoff burrfoot",
+      "ariakas",
+      "zakhal",
+      "tower of high sorcery at palanthas"
     ]
   },
   "fiction.dune": {
     "title": "Dune series",
     "category": "fiction",
     "description": "Planets, cities, factions, houses, and political groups from Frank Herbert's Dune universe",
-    "total": 42,
+    "total": 157,
     "examples": [
-      "carthag",
-      "house corrino",
       "arrakeen",
-      "ixians",
-      "tupile",
-      "richese"
+      "mohiam",
+      "duncan idaho",
+      "butlerian jihad",
+      "farad'n corrino",
+      "atrides"
     ]
   },
   "fiction.elderScrolls": {
@@ -2063,26 +2063,26 @@
     "description": "Places, peoples, factions, creatures, artifacts, and deities from The Elder Scrolls",
     "total": 82,
     "examples": [
-      "cheydinhal",
-      "alduin",
-      "imperial city",
-      "khajiit",
       "jarl",
-      "dark brotherhood"
+      "thalmor",
+      "blackreach",
+      "knights of the nine",
+      "winterhold",
+      "red mountain"
     ]
   },
   "fiction.expanse": {
     "title": "Expanse names",
     "category": "fiction",
     "description": "Places, factions, ships, peoples, and technologies from The Expanse",
-    "total": 58,
+    "total": 126,
     "examples": [
-      "transport union",
+      "new terra",
+      "sol gate",
       "auberon",
-      "draper station",
-      "the churn",
-      "jupiter system",
-      "earth-mars coalition"
+      "inazami",
+      "cotyar ghazi",
+      "phoebe station"
     ]
   },
   "fiction.forgottenRealms": {
@@ -2091,12 +2091,12 @@
     "description": "Places, peoples, factions, creatures, deities, and artifacts from the Forgotten Realms",
     "total": 65,
     "examples": [
-      "abeir-toril",
-      "selune",
-      "zhentil keep",
-      "darkhold",
-      "the cult of the dragon",
-      "sea of fallen stars"
+      "nine hells",
+      "red wizards",
+      "the order of the gauntlet",
+      "shadowdale",
+      "blackstaff tower",
+      "selune"
     ]
   },
   "fiction.foundation": {
@@ -2105,26 +2105,26 @@
     "description": "Places, planets, factions, and groups from Isaac Asimov's Foundation universe",
     "total": 74,
     "examples": [
-      "independents",
-      "tithonus",
-      "synnax",
-      "leporis",
-      "askone",
-      "melpomenia"
+      "lingane",
+      "nexon",
+      "florina",
+      "smitheus",
+      "orsha ii",
+      "comporellon"
     ]
   },
   "fiction.gethen": {
     "title": "Gethen and Hainish Cycle",
     "category": "fiction",
     "description": "Planets, countries, towns, cultures, and organizations from Ursula K. Le Guin's Hainish Cycle and Earthsea",
-    "total": 20,
+    "total": 155,
     "examples": [
-      "orgoreyn",
-      "shing",
-      "rer",
-      "gont",
-      "olleroo",
-      "athshe"
+      "haka",
+      "fastness",
+      "stabilizer",
+      "anarres",
+      "ged",
+      "esker faxe"
     ]
   },
   "fiction.gormenghast": {
@@ -2133,26 +2133,26 @@
     "description": "Unique names from Gormenghast (Mervyn Peake) — places, peoples, creatures, factions, and ships combined.",
     "total": 237,
     "examples": [
-      "the lion",
-      "the little kitchen",
-      "flay's cave",
-      "the courtyard",
-      "the death-owls",
-      "the armoury"
+      "the grooms",
+      "the professors",
+      "the scullions",
+      "the mud village",
+      "the owls",
+      "the magistrates"
     ]
   },
   "fiction.halo": {
     "title": "Halo names",
     "category": "fiction",
     "description": "Places, factions, species, artifacts, ships, and installations from Halo",
-    "total": 52,
+    "total": 143,
     "examples": [
-      "domain",
-      "combat evolved",
-      "banished",
-      "ringworld",
-      "spartan-ii",
-      "flood"
+      "master chief",
+      "atriox",
+      "edward buck",
+      "genesis",
+      "energy sword",
+      "doisac"
     ]
   },
   "fiction.harryPotter": {
@@ -2161,26 +2161,26 @@
     "description": "Places, schools, houses, creatures, objects, and groups from the Harry Potter and Wizarding World fiction",
     "total": 93,
     "examples": [
-      "sorting hat",
-      "flobberworm",
-      "acromantula",
       "chamber of secrets",
-      "firebolt",
-      "durmstrang"
+      "azkaban",
+      "hogsmeade",
+      "knight bus",
+      "the burrow",
+      "spellotape"
     ]
   },
   "fiction.hisDarkMaterials": {
     "title": "His Dark Materials names",
     "category": "fiction",
     "description": "Places, peoples, creatures, and concepts from Philip Pullman's His Dark Materials",
-    "total": 35,
+    "total": 109,
     "examples": [
-      "spectres",
-      "armored bears",
-      "oxford",
-      "witches",
-      "tualapi",
-      "panserbjorne"
+      "dust",
+      "torre degli angeli",
+      "kirjava",
+      "geneva",
+      "billy costa",
+      "dark matter"
     ]
   },
   "fiction.hitchhikers": {
@@ -2189,12 +2189,12 @@
     "description": "Places, species, spacecraft, and groups from The Hitchhiker's Guide to the Galaxy",
     "total": 72,
     "examples": [
-      "blagulon kappans",
-      "jatravartids",
-      "nowwhat",
-      "dentrassis",
-      "viltvodle vi",
-      "squornshellous zeta"
+      "golgafrinchans",
+      "prehistoric earth",
+      "alpha centauri",
+      "haggunenons",
+      "blagulon kappa",
+      "han wavel"
     ]
   },
   "fiction.hyperion": {
@@ -2204,39 +2204,39 @@
     "total": 321,
     "examples": [
       "kite-fox",
-      "the metasphere",
-      "south bight",
-      "t'ien shan",
-      "the cleft",
-      "pax mercantilus"
+      "angel",
+      "briareus construct",
+      "clone",
+      "deer park",
+      "cybrid-human hybrid"
     ]
   },
   "fiction.lotr": {
     "title": "Lord of the Rings",
     "category": "fiction",
     "description": "Places, races, creatures, and unique names from J.R.R. Tolkien's Middle-earth",
-    "total": 160,
+    "total": 464,
     "examples": [
-      "edoras",
-      "utumno",
-      "ainur",
-      "periannath",
-      "dorwinion",
-      "zarak-dûm"
+      "rhûn",
+      "thranduil",
+      "lune",
+      "orcs",
+      "ori",
+      "war of wrath"
     ]
   },
   "fiction.magicMultiverse": {
     "title": "Magic multiverse names",
     "category": "fiction",
     "description": "Planes, peoples, factions, creatures, and artifacts from Magic: The Gathering fiction",
-    "total": 59,
+    "total": 136,
     "examples": [
-      "khalni",
-      "phyrexia",
+      "dragonlord dromoka",
+      "temur",
+      "sarkhan vol",
       "golgari swarm",
-      "tarkir",
-      "theros",
-      "vampire nocturnus"
+      "elspeth tirel",
+      "abzan"
     ]
   },
   "fiction.malazan": {
@@ -2245,12 +2245,12 @@
     "description": "Places, peoples, creatures, and groups from the Malazan Book of the Fallen",
     "total": 98,
     "examples": [
-      "bhoka'ral",
       "barghast",
-      "forulkan",
-      "lest",
+      "korel",
       "maurik",
-      "the deragoth caves"
+      "eleint",
+      "coral",
+      "eres'al"
     ]
   },
   "fiction.marvel": {
@@ -2259,12 +2259,12 @@
     "description": "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction",
     "total": 97,
     "examples": [
-      "sword",
-      "blackbird",
-      "kree",
-      "mind stone",
-      "celestials",
-      "asgard"
+      "the defenders",
+      "a-force",
+      "spider-man",
+      "midnight sons",
+      "annihilus",
+      "new mutants"
     ]
   },
   "fiction.massEffect": {
@@ -2273,12 +2273,12 @@
     "description": "Places, species, factions, ships, artifacts, and powers from Mass Effect",
     "total": 79,
     "examples": [
-      "elcor",
-      "krogan",
-      "crucible",
-      "anderson",
-      "c-sec",
-      "grissom academy students"
+      "reaper",
+      "batarians",
+      "hanar",
+      "edi",
+      "aria t'loak",
+      "joker"
     ]
   },
   "fiction.narnia": {
@@ -2287,12 +2287,12 @@
     "description": "Places, peoples, creatures, and magical beings from C.S. Lewis's Chronicles of Narnia",
     "total": 80,
     "examples": [
-      "black dwarfs",
-      "bism",
-      "ettins",
       "eastern ocean",
-      "hags",
-      "cair paravel"
+      "merpeople",
+      "calormenes",
+      "telmarines",
+      "marsh-wiggles",
+      "wood between the worlds"
     ]
   },
   "fiction.onePiece": {
@@ -2301,54 +2301,54 @@
     "description": "Places, factions, peoples, creatures, ships, powers, and treasures from One Piece",
     "total": 80,
     "examples": [
-      "dressrosa",
-      "new world",
-      "grand line",
-      "baratie",
-      "kaido",
-      "marines"
+      "ohara",
+      "red line",
+      "shanks",
+      "seven warlords",
+      "one piece",
+      "mirror world"
     ]
   },
   "fiction.pokemon": {
     "title": "Pokemon names",
     "category": "fiction",
     "description": "Regions, species, legendary Pokemon, teams, and artifacts from Pokemon",
-    "total": 60,
+    "total": 1137,
     "examples": [
-      "articuno",
-      "bulbasaur",
-      "pokeball",
-      "pikachu",
-      "team skull",
-      "johto"
+      "swellow",
+      "minior",
+      "purrloin",
+      "sceptile",
+      "heracross",
+      "excadrill"
     ]
   },
   "fiction.starTrek": {
     "title": "Star Trek",
     "category": "fiction",
     "description": "Unique names from Star Trek — places, peoples, creatures, factions, and ships combined.",
-    "total": 553,
+    "total": 721,
     "examples": [
-      "macrovirus",
-      "memory alpha",
-      "korinas",
-      "remus",
-      "nyberrite alliance",
-      "qowat milat"
+      "peltian",
+      "deep space 9",
+      "ss santa maria",
+      "mari",
+      "oberth-class",
+      "brikar"
     ]
   },
   "fiction.starWars": {
     "title": "Star Wars",
     "category": "fiction",
     "description": "Unique names from Star Wars — places, peoples, creatures, factions, and ships combined.",
-    "total": 544,
+    "total": 784,
     "examples": [
-      "patriot",
-      "the millennium falcon",
-      "the scimitar",
-      "the zillo beast",
-      "negotiator",
-      "bloodfin"
+      "utoppan",
+      "tactician",
+      "porg",
+      "ruusan",
+      "the death troopers",
+      "the hidden path"
     ]
   },
   "fiction.transformers": {
@@ -2357,12 +2357,12 @@
     "description": "Places, factions, species, artifacts, and groups from Transformers",
     "total": 59,
     "examples": [
-      "cybertron",
-      "combaticons",
-      "stasis pod",
+      "quintessons",
+      "ironhide",
+      "devastator",
       "aerialbots",
-      "primus",
-      "beast wars"
+      "metroplex",
+      "starscream"
     ]
   },
   "fiction.warcraft": {
@@ -2371,26 +2371,26 @@
     "description": "Places, peoples, factions, creatures, artifacts, and powers from the Warcraft universe",
     "total": 91,
     "examples": [
-      "hellfire citadel",
-      "alleria",
-      "a'dal",
-      "ironforge",
-      "naga",
-      "maelstrom"
+      "azshara",
+      "pandaria",
+      "darnassus",
+      "kalimdor",
+      "gul'dan",
+      "durotar"
     ]
   },
   "fiction.warhammer40k": {
     "title": "Warhammer 40,000",
     "category": "fiction",
     "description": "Unique names from Warhammer 40,000 — places, peoples, creatures, factions, and ships combined.",
-    "total": 566,
+    "total": 653,
     "examples": [
-      "wages of sin",
-      "koronus expanse",
-      "iron hands",
-      "jokaero",
-      "exorcists",
-      "attila"
+      "plague planet",
+      "space wolves",
+      "novokh dynasty",
+      "order of the ebon chalice",
+      "pax imperialis",
+      "roboute guilliman"
     ]
   },
   "fiction.wheelOfTime": {
@@ -2399,12 +2399,12 @@
     "description": "Places, peoples, creatures, and groups from The Wheel of Time",
     "total": 109,
     "examples": [
-      "deven ride",
-      "malkier",
-      "lugard",
-      "mayene",
-      "braem wood",
-      "arad doman"
+      "kinslayer's dagger",
+      "salidar",
+      "jumara",
+      "s'redit",
+      "far madding",
+      "aelfinn"
     ]
   },
   "fiction.witcher": {
@@ -2413,12 +2413,12 @@
     "description": "Places, kingdoms, schools, peoples, creatures, and objects from The Witcher",
     "total": 81,
     "examples": [
-      "avallac'h",
-      "aretuza",
+      "the continent",
+      "aedirn",
+      "dryads",
+      "caer a'muirehen",
       "francesca findabair",
-      "golden dragon",
-      "cockatrice",
-      "caer morhen"
+      "golden dragon"
     ]
   },
   "fiction.zelda": {
@@ -2427,12 +2427,12 @@
     "description": "Places, peoples, creatures, artifacts, and powers from The Legend of Zelda",
     "total": 84,
     "examples": [
-      "goron",
-      "termina",
-      "death mountain crater",
-      "hyrule field",
-      "lon lon ranch",
-      "king dodongo"
+      "lanayru",
+      "great plateau",
+      "beedle",
+      "hyrule castle",
+      "blight ganon",
+      "gerudo"
     ]
   },
   "food.bakery": {
@@ -2441,12 +2441,12 @@
     "description": "Assorted baked goods including cakes, pies, pastries, and sweet breads",
     "total": 176,
     "examples": [
-      "tarte aux amandes",
-      "cornetto (italian croissant)",
-      "danishes",
-      "choux pastry",
-      "baked alaska",
-      "cannoli (tubular pastry filled with sweet ricotta cream)"
+      "swiss roll",
+      "cinnamon rolls",
+      "challah",
+      "apple pie",
+      "soda bread",
+      "chocolate fondue"
     ]
   },
   "food.bbq": {
@@ -2455,12 +2455,12 @@
     "description": "Grilled meats, seafood, vegetables, and fruits typical of barbecue cooking",
     "total": 41,
     "examples": [
-      "spareribs",
-      "grilled zucchini",
-      "beer can chicken",
       "grilled halloumi",
-      "steak",
-      "chicken skewers"
+      "burgers",
+      "corn on the cob",
+      "chicken wings",
+      "chicken skewers",
+      "elote"
     ]
   },
   "food.beverage": {
@@ -2469,12 +2469,12 @@
     "description": "Various alcoholic and non-alcoholic drinks including cocktails, coffees, and teas",
     "total": 224,
     "examples": [
-      "cold brew coffee",
-      "cashew milk",
-      "lambic",
-      "chocolate milk",
-      "soju",
-      "rooibos tea"
+      "hojicha",
+      "ginger tea",
+      "ayran",
+      "grape juice",
+      "café au lait",
+      "grog"
     ]
   },
   "food.bread": {
@@ -2483,12 +2483,12 @@
     "description": "A diverse global selection of traditional breads, biscuits, and baked rolls",
     "total": 269,
     "examples": [
-      "hallulla",
-      "pan de muerto",
-      "limpa",
+      "michetta",
+      "bath bun",
+      "buttermilk biscuit",
+      "arepa de huevo",
       "angel biscuit",
-      "banana bread",
-      "babka"
+      "kisra"
     ]
   },
   "food.breakfast": {
@@ -2497,12 +2497,12 @@
     "description": "Sweet and savory breakfast dishes including eggs, waffles, and avocado toast",
     "total": 86,
     "examples": [
-      "lobster royale",
-      "frittata",
-      "brioche french toast",
-      "freshly brewed coffee and tea",
-      "waffles and pancakes with a variety of syrups and toppings",
-      "portobello benedict"
+      "gourmet cheeses",
+      "congee",
+      "french toast",
+      "bagel with cream cheese",
+      "avocado toast",
+      "breakfast sausage"
     ]
   },
   "food.cheese": {
@@ -2511,12 +2511,12 @@
     "description": "A wide variety of international cheeses from different regions and styles",
     "total": 515,
     "examples": [
-      "alverca",
-      "raclette",
-      "coeur de chevre",
-      "bleu du vercors-sassenage",
-      "boerenkaas",
-      "caprino"
+      "nanclares",
+      "brossa",
+      "chhena",
+      "cabrales",
+      "imeruli",
+      "gervais"
     ]
   },
   "food.cocktail": {
@@ -2525,12 +2525,12 @@
     "description": "Classic and modern mixed alcoholic drinks and cocktails",
     "total": 153,
     "examples": [
-      "daiquiri",
-      "illegal",
-      "greyhound",
-      "jack rose",
-      "bellini",
-      "between the sheets"
+      "casino",
+      "harvey wallbanger",
+      "cosmopolitan",
+      "gin and tonic",
+      "irish coffee",
+      "air mail"
     ]
   },
   "food.cookingMethod": {
@@ -2539,12 +2539,12 @@
     "description": "Culinary techniques for preparing food, ranging from baking to dry aging",
     "total": 97,
     "examples": [
-      "salt curing",
-      "acidulating",
-      "boiling",
-      "hot smoking",
+      "rendering",
       "coal roasting",
-      "canning"
+      "blowtorching",
+      "butter poaching",
+      "dry curing",
+      "flash freezing"
     ]
   },
   "food.cuisine": {
@@ -2553,12 +2553,12 @@
     "description": "Specific regional and national culinary traditions from around the world",
     "total": 340,
     "examples": [
-      "genoese cuisine",
-      "teochew cuisine",
-      "indonesian cuisine",
-      "dagestani cuisine",
-      "icelandic cuisine",
-      "anatolian cuisine"
+      "betawi cuisine",
+      "kenyan cuisine",
+      "amish cuisine",
+      "kerala cuisine",
+      "badener cuisine",
+      "senegalese cuisine"
     ]
   },
   "food.dessert": {
@@ -2567,12 +2567,12 @@
     "description": "Global sweet treats including cakes, puddings, pastries, and confections",
     "total": 174,
     "examples": [
-      "rhubarb crumble",
-      "creme brulee",
-      "blancmange",
-      "affogato",
-      "gingerbread man",
-      "eclair"
+      "turkish delight",
+      "rugelach",
+      "panforte",
+      "loukoumades",
+      "taiyaki",
+      "oatmeal raisin cookie"
     ]
   },
   "food.drink": {
@@ -2581,12 +2581,12 @@
     "description": "Assorted beverages including sodas, juices, teas, milks, and alcoholic drinks",
     "total": 289,
     "examples": [
-      "pu-erh tea",
-      "smoothie",
-      "mocha",
-      "midori sour",
-      "manhattan cocktail",
-      "oat milk"
+      "distilled water",
+      "highball cocktail",
+      "white tea",
+      "ginger shot",
+      "cola",
+      "cashew milk"
     ]
   },
   "food.fast": {
@@ -2595,12 +2595,12 @@
     "description": "Global fast food and street food items including burgers, fries, and rolls",
     "total": 164,
     "examples": [
-      "sesame chicken",
-      "fajitas",
-      "honey mustard fried chicken",
-      "banh xeo (vietnamese crepes)",
-      "carbonara pizza",
-      "curly fries"
+      "spicy chicken burger",
+      "donburi",
+      "bufalina pizza",
+      "orange chicken",
+      "banana milkshake",
+      "katsu"
     ]
   },
   "food.fruit": {
@@ -2609,12 +2609,12 @@
     "description": "Common and exotic fruits, berries, and melons from around the world",
     "total": 142,
     "examples": [
-      "damson",
-      "crenshaw melon",
-      "date",
-      "kumquat",
-      "honeydew melon",
-      "medlar"
+      "feijoa",
+      "cherimoya",
+      "acai",
+      "blackcurrant",
+      "blueberry",
+      "crenshaw melon"
     ]
   },
   "food.herbSpice": {
@@ -2623,12 +2623,12 @@
     "description": "Various culinary herbs, spices, and seeds used for flavoring food",
     "total": 50,
     "examples": [
-      "anise",
-      "nutmeg",
       "mint",
-      "ginger",
-      "basil",
-      "marjoram"
+      "cilantro",
+      "cumin",
+      "paprika",
+      "sage",
+      "cardamom"
     ]
   },
   "food.pastaShape": {
@@ -2637,12 +2637,12 @@
     "description": "Various types of traditional and novelty pasta shapes",
     "total": 145,
     "examples": [
-      "lasagnette",
+      "mafaldine",
+      "ditalini",
+      "corallini",
       "acini di pepe",
-      "foglie d'olivo",
-      "trofie",
-      "elicoidali",
-      "maltagliati"
+      "croxetti",
+      "agnolini"
     ]
   },
   "food.platingStyle": {
@@ -2651,12 +2651,12 @@
     "description": "Artistic and structural techniques for arranging and presenting food on a plate",
     "total": 104,
     "examples": [
-      "cast-iron style",
-      "sculptural",
-      "shingled",
-      "abstract",
-      "hot pot style",
-      "clock method"
+      "freeform",
+      "architectural",
+      "banquet",
+      "skillet style",
+      "canape style",
+      "casual"
     ]
   },
   "food.tea": {
@@ -2665,12 +2665,12 @@
     "description": "Specific varieties of traditional, herbal, and regional teas",
     "total": 193,
     "examples": [
-      "black tea",
-      "slippery elm tea",
-      "enshi yulu",
-      "iced tea",
-      "dark tea",
-      "chun mee"
+      "junshan yinzhen",
+      "sarsaparilla tea",
+      "biluochun",
+      "jin xuan",
+      "chun mee",
+      "elderflower tea"
     ]
   },
   "food.vegetable": {
@@ -2679,12 +2679,12 @@
     "description": "Various vegetables, legumes, squashes, and edible plant sprouts",
     "total": 266,
     "examples": [
-      "ghost pepper",
-      "sea grape",
-      "daikon radish",
-      "horseradish",
-      "komatsuna",
-      "asparagus"
+      "grape tomato",
+      "yam",
+      "butternut squash",
+      "spinach",
+      "black salsify",
+      "celery"
     ]
   },
   "geography.city": {
@@ -2693,12 +2693,12 @@
     "description": "Specific global cities listed with their respective regions and countries",
     "total": 22953,
     "examples": [
-      "Benthuizen, South Holland, Netherlands",
-      "Male, Kaafu Atoll, Maldives",
-      "Kabba, Kogi, Nigeria",
-      "Bethesda, Maryland, United States",
-      "Bagheria, Sicily, Italy",
-      "Anan, Tokushima, Japan"
+      "Parras de la Fuente, Coahuila, Mexico",
+      "Richmond, Victoria, Australia",
+      "Kasterlee, Flanders, Belgium",
+      "Char Bhadrāsan, Dhaka, Bangladesh",
+      "Hājīganj, Chittagong, Bangladesh",
+      "Quixadá, Ceará, Brazil"
     ]
   },
   "geography.country": {
@@ -2707,12 +2707,12 @@
     "description": "A diverse list of sovereign nations and countries around the world",
     "total": 199,
     "examples": [
-      "Andorra",
-      "Barbados",
-      "Kazakhstan",
-      "Iraq",
-      "Benin",
-      "El Salvador"
+      "Lesotho",
+      "Sudan",
+      "Afghanistan",
+      "Angola",
+      "Burundi",
+      "Uzbekistan"
     ]
   },
   "geography.ethnicGroup": {
@@ -2721,12 +2721,12 @@
     "description": "The following groups are commonly identified as \"ethnic groups\", as opposed to ethno-linguistic phyla, national groups, racial groups or similar.\n",
     "total": 1055,
     "examples": [
-      "kumandins",
-      "tajiks",
-      "aikana",
-      "apache",
-      "akhvakhs",
-      "manjak"
+      "tagish",
+      "germans",
+      "gibraltarians",
+      "guajajara",
+      "erzyas",
+      "ghorbati"
     ]
   },
   "geography.language": {
@@ -2735,12 +2735,12 @@
     "description": "A list of language names (glossonyms)",
     "total": 609,
     "examples": [
-      "tübatulabal",
-      "jarawa",
-      "afade",
-      "amoy",
-      "betawi",
-      "akan"
+      "kumyk",
+      "erzya",
+      "cocos islands malay",
+      "hawaiian",
+      "igbo",
+      "inuktitut"
     ]
   },
   "geography.nationality": {
@@ -2749,12 +2749,12 @@
     "description": "Adjectives describing nationalities and citizenships from various countries",
     "total": 206,
     "examples": [
-      "cypriot",
-      "uruguayan",
-      "omani",
-      "malian",
-      "maldivian",
-      "panamanian"
+      "salvadoran",
+      "samoan",
+      "tobagonian",
+      "bissau-guinean",
+      "mosotho",
+      "argentine"
     ]
   },
   "geography.territory": {
@@ -2763,12 +2763,12 @@
     "description": "Global territories, dependencies, emirates, and non-sovereign geographic regions",
     "total": 79,
     "examples": [
-      "French Polynesia",
-      "Sint Maarten (Dutch part)",
-      "Guadeloupe",
-      "Johnston Atoll",
-      "Hong Kong",
-      "Abu Dhabi"
+      "American Samoa",
+      "Faroe Islands",
+      "British Virgin Islands",
+      "Jersey",
+      "Dhekelia",
+      "French Southern Territories"
     ]
   },
   "interaction.coupleNegative": {
@@ -2777,12 +2777,12 @@
     "description": "Toxic, emotional, and negative behavioral interactions between romantic partners",
     "total": 70,
     "examples": [
+      "feeling weak with each other",
+      "feeling defeated with each other",
       "accusing each other",
-      "feeling frustrated with each other",
-      "engaging in a fight",
-      "feeling irritated with each other",
-      "expressing displeasure towards each other",
-      "feeling helpless with each other"
+      "experiencing rejection from each other",
+      "feeling annoyed with each other",
+      "experiencing self-doubt with each other"
     ]
   },
   "interaction.couple": {
@@ -2791,12 +2791,12 @@
     "description": "Positive and negative relational dynamics and activities between couples",
     "total": 69,
     "examples": [
-      "sharing a dessert",
-      "betrayal",
-      "forehead touch",
-      "having a conversation",
-      "adoring someone",
-      "competition"
+      "showing compassion",
+      "mentorship",
+      "having tension",
+      "offering support",
+      "negotiating a deal",
+      "watching the sunrise together"
     ]
   },
   "interaction.crowd": {
@@ -2805,12 +2805,12 @@
     "description": "Collective actions, events, and emotional responses experienced by large crowds",
     "total": 64,
     "examples": [
-      "throwing confetti into the air",
-      "celebrating a cultural tradition",
-      "participating in a parade",
-      "marching down a city boulevard",
-      "attending a concert",
-      "mourning a loss"
+      "gathering for a festival",
+      "attending a sporting event",
+      "celebrating a birthday",
+      "holding a protest",
+      "attending a parade",
+      "holding a peaceful assembly"
     ]
   },
   "interaction.danceStyle": {
@@ -2819,12 +2819,12 @@
     "description": "Diverse global dance genres, traditional styles, and modern rhythmic movements",
     "total": 266,
     "examples": [
-      "mohiniyattam",
-      "raqs sharqi",
-      "maypole dance",
-      "macarena",
-      "morris dance",
-      "sand dance"
+      "ballet",
+      "nihon buyo",
+      "apache dance",
+      "boogie-woogie",
+      "burlesque",
+      "charleston"
     ]
   },
   "interaction.group": {
@@ -2833,12 +2833,12 @@
     "description": "Collaborative group activities ranging from mundane events to dramatic fictional scenarios",
     "total": 70,
     "examples": [
+      "running for public office",
+      "rescuing a hostage",
+      "trying to clear someone's name",
+      "training for a marathon together",
       "taking a journey of self-discovery",
-      "pursuing a dream",
-      "practicing a synchronized dance routine",
-      "surviving in space",
-      "studying for a final exam",
-      "staging a musical production"
+      "studying for a final exam"
     ]
   },
   "interaction.individualDetailed": {
@@ -2847,12 +2847,12 @@
     "description": "Highly specific, multi-step physical actions and behavioral sequences performed by individuals",
     "total": 214,
     "examples": [
-      "folds a paper airplane, throws it, and then watches it glide",
-      "folds a blanket, smooths out the wrinkles, and then places it over the back of a couch",
-      "pops a piece of gum into mouth, chews it, and then blows a bubble",
-      "sits cross-legged, rests hands on knees, and then closes eyes to meditate",
-      "slips on a pair of sunglasses, looks in the mirror, and then nods in approval",
-      "pops knuckles one by one, flexes fingers, and then begins to type"
+      "licks a finger, turns the page of a heavy book, and continues reading intently",
+      "sighs deeply, rubs forehead, and then looks up with a forced smile",
+      "knits brow, rubs chin thoughtfully, and then offers a suggestion",
+      "adjusts a watch on wrist, checks the time, and quickens their pace",
+      "flips through a book, finds the desired page, and begins reading",
+      "places a bookmark in a book, closes it, and then sets it aside"
     ]
   },
   "interaction.individual": {
@@ -2861,11 +2861,11 @@
     "description": "Simple, everyday physical gestures, adjustments, and actions performed by a single person",
     "total": 424,
     "examples": [
-      "stretches arms above head and yawns",
-      "straightens hair with a flat iron",
-      "wraps hands around a warm mug",
-      "stretches out on a couch",
-      "stamps foot",
+      "drops to the ground and does push-ups",
+      "slurps spaghetti noisily",
+      "taps fingers on a surface nervously",
+      "crawls under a table",
+      "sits cross-legged on the floor",
       "squishes play dough"
     ]
   },
@@ -2875,12 +2875,12 @@
     "description": "Traditional and modern martial arts and combat systems from around the world",
     "total": 110,
     "examples": [
-      "kuresh",
-      "jujutsu",
-      "brazilian jiu-jitsu",
-      "okinawan kobudo",
-      "pradal serey",
-      "xingyiquan"
+      "yoseikan budo",
+      "kickboxing",
+      "baguazhang",
+      "bando",
+      "bajiquan",
+      "kenpo"
     ]
   },
   "keyword.detailed": {
@@ -2889,12 +2889,12 @@
     "description": "Descriptive adjectives used to prompt high-resolution, intricate, and textured artwork",
     "total": 58,
     "examples": [
-      "clear",
-      "meticulously-detailed",
-      "sharp-focus",
-      "crystal-clear",
-      "impressively-detailed",
-      "painstakingly-detailed"
+      "well-defined",
+      "crisp",
+      "exquisitely-detailed",
+      "realistic",
+      "ultra-realistic",
+      "ultra-fine-detail"
     ]
   },
   "keyword.epic": {
@@ -2903,12 +2903,12 @@
     "description": "Evocative adjectives for generating dramatic, majestic, and awe-inspiring visual atmospheres",
     "total": 129,
     "examples": [
-      "transcendent",
-      "spellbinding",
-      "spectacular",
-      "supreme",
-      "stately",
-      "mind-bending"
+      "noble",
+      "marvelous",
+      "regal",
+      "virtuous",
+      "monumental",
+      "sensational"
     ]
   },
   "keyword.genre": {
@@ -2917,12 +2917,12 @@
     "description": "Sci-fi, historical, and punk-themed aesthetic art genres and styles",
     "total": 65,
     "examples": [
-      "cassette futurism",
-      "gothic romance",
-      "cyber gothic",
-      "cyber-renaissance",
-      "deco punk",
-      "vintage"
+      "hopepunk",
+      "cybergrunge",
+      "ancient",
+      "dieselpunk",
+      "futurism",
+      "art deco"
     ]
   },
   "keyword.glitch": {
@@ -2931,12 +2931,12 @@
     "description": "Digital and analog visual artifacts, distortions, and glitch effects",
     "total": 56,
     "examples": [
-      "compression artifact",
+      "rgb split",
+      "warping",
       "artifact",
-      "halo effect",
-      "chromatic aberration",
-      "bit-crushed",
-      "signal degradation"
+      "glitch-art",
+      "analog artifact",
+      "distortion"
     ]
   },
   "keyword.modifier": {
@@ -2945,12 +2945,12 @@
     "description": "Keywords that modify the style of an image (Noodle Soup prompts)",
     "total": 88,
     "examples": [
-      "american romanticism",
-      "dark academia",
-      "papercut art",
-      "synthwave",
-      "stuckism",
-      "retrowave"
+      "gothic",
+      "60s kitsch and psychedelia",
+      "afrofuturism",
+      "anime",
+      "anaglyph filter",
+      "folk art"
     ]
   },
   "keyword.negative": {
@@ -2959,12 +2959,12 @@
     "description": "Negative prompt keywords for avoiding bad anatomy, artifacts, and low quality",
     "total": 90,
     "examples": [
-      "worst quality",
-      "ugly",
-      "poorly drawn hands",
-      "double face",
-      "watermark",
-      "sketches"
+      "jpeg artifact",
+      "3d",
+      "noisy",
+      "mutated hands",
+      "cloned face",
+      "low resolution"
     ]
   },
   "keyword.prayer": {
@@ -2973,12 +2973,12 @@
     "description": "Quality-enhancing prompt modifiers for high resolution and masterpiece renders",
     "total": 67,
     "examples": [
-      "realistic",
-      "stunning",
-      "octane render",
-      "top-notch",
-      "vivid",
-      "unmatched quality"
+      "breathtaking detail",
+      "impeccable",
+      "superb rendering",
+      "8k",
+      "gorgeous lighting",
+      "unreal engine 5 render"
     ]
   },
   "keyword.trending": {
@@ -2987,12 +2987,12 @@
     "description": "Keywords referencing trending or featured artwork on popular portfolio websites",
     "total": 35,
     "examples": [
-      "trending on reddit",
-      "featured on behance",
-      "trending on flickr",
-      "featured on cgsociety",
-      "trending on artstation",
-      "trending on conceptartworld"
+      "featured on deviantart",
+      "featured on getty images",
+      "trending on midjourney",
+      "featured on zbrushcentral",
+      "trending on pinterest",
+      "trending on artstation hd"
     ]
   },
   "keyword.unusual": {
@@ -3001,12 +3001,12 @@
     "description": "Adjectives describing weird, unique, unusual, or abnormal subjects",
     "total": 62,
     "examples": [
-      "bizarre-looking",
-      "extraordinary",
-      "unexpected",
-      "eccentric-looking",
-      "otherworldly",
-      "surrealist"
+      "curious",
+      "unusual",
+      "peculiar",
+      "bewildering",
+      "unorthodox",
+      "confusing"
     ]
   },
   "music.artist": {
@@ -3015,12 +3015,12 @@
     "description": "Diverse musical artists and bands with distinct musical styles",
     "total": 114,
     "examples": [
-      "tangerine dream",
-      "sophie",
-      "the velvet underground",
-      "sepultura",
-      "sigur rós",
-      "tool"
+      "the smiths",
+      "kate bush",
+      "tame impala",
+      "fka twigs",
+      "leonard cohen",
+      "erykah badu"
     ]
   },
   "music.bpm": {
@@ -3029,12 +3029,12 @@
     "description": "Various musical tempos measured in beats per minute",
     "total": 42,
     "examples": [
-      "100 bpm",
-      "230 bpm",
-      "220 bpm",
-      "95 bpm",
+      "145 bpm",
+      "300 bpm",
+      "210 bpm",
       "135 bpm",
-      "280 bpm"
+      "200 bpm",
+      "130 bpm"
     ]
   },
   "music.composer": {
@@ -3043,12 +3043,12 @@
     "description": "Famous classical and contemporary music composers",
     "total": 190,
     "examples": [
-      "olivier messiaen",
-      "sergei rachmaninov",
-      "steve reich",
-      "sergei rachmaninoff",
-      "ned rorem",
-      "luigi cherubini"
+      "carl friedrich abel",
+      "pierre boulez",
+      "jean sibelius",
+      "joan tower",
+      "john harbison",
+      "richard wagner"
     ]
   },
   "music.drop": {
@@ -3057,12 +3057,12 @@
     "description": "Specific electronic dance music subgenre drops and rhythmic transitions",
     "total": 39,
     "examples": [
-      "psytrance triplets drop",
-      "chillstep ambient pads drop",
-      "acid techno 303 squelch drop",
-      "disco house brass stab drop",
-      "dubstep wobble drop",
-      "speedcore high-speed kick drop"
+      "electro house bass drop",
+      "big room drop",
+      "hardstyle reverse bass drop",
+      "progressive house melodic drop",
+      "hardstyle kick drop",
+      "moombahton beat drop"
     ]
   },
   "music.dynamic": {
@@ -3071,12 +3071,12 @@
     "description": "Musical tempo, dynamic, and articulation terms with their definitions",
     "total": 89,
     "examples": [
-      "accelerando (gradually faster tempo)",
+      "staccato (short and detached)",
       "morendo (dying away, gradually softer and slower)",
-      "molto piano (very soft)",
-      "marcando (marked, with distinct and emphasized accents)",
-      "adagio (slowly and expressively)",
-      "con grazia (with grace, in a graceful and elegant style)"
+      "lento (slowly, at a slow tempo)",
+      "portamento (sliding smoothly from one note to another)",
+      "pianissimo (very soft)",
+      "niente (gradually fade out to nothing)"
     ]
   },
   "music.feature": {
@@ -3085,12 +3085,12 @@
     "description": "Specific instrumental, vocal, and atmospheric musical elements and techniques",
     "total": 206,
     "examples": [
-      "dusty vinyl crackle textures",
-      "richly layered vocal arrangements",
-      "soft acoustic fingerpicking",
-      "funky guitar riffs",
-      "rhythmic hand percussion",
-      "epic choir vocals"
+      "catchy melodies",
+      "groovy bassline",
+      "driving rhythm section",
+      "acoustic guitars",
+      "cascading harpsichord arpeggios",
+      "searing guitar leads"
     ]
   },
   "music.genre": {
@@ -3099,12 +3099,12 @@
     "description": "Diverse music genres ranging from electronic and rock to folk",
     "total": 305,
     "examples": [
-      "soca",
-      "gospel",
-      "ethno jazz",
-      "folk punk",
-      "death-doom metal",
-      "freak jazz"
+      "breakcore",
+      "surf rock",
+      "space ambient",
+      "ska jazz",
+      "ska core",
+      "samba"
     ]
   },
   "music.harmony": {
@@ -3113,11 +3113,11 @@
     "description": "Various types of musical harmonies and chordal structures",
     "total": 38,
     "examples": [
-      "diatonic harmony",
-      "functional harmony",
-      "choral harmony",
-      "homophonic harmony",
-      "altered harmony",
+      "modal interchange harmony",
+      "parallel harmony",
+      "subdominant harmony",
+      "jazz harmony",
+      "spectral harmony",
       "consonant harmony"
     ]
   },
@@ -3127,12 +3127,12 @@
     "description": "Traditional, classical, and world music instruments",
     "total": 216,
     "examples": [
-      "appalachian dulcimer",
+      "zurna",
+      "ney",
       "nyckelharpa",
-      "electric guitar",
-      "dhol",
-      "castanets",
-      "banjo"
+      "piccolo",
+      "taonga pūoro",
+      "washboard"
     ]
   },
   "music.key": {
@@ -3141,12 +3141,12 @@
     "description": "Major and minor musical keys",
     "total": 35,
     "examples": [
-      "g# major",
-      "d minor",
-      "g# minor",
-      "ab major",
+      "a# minor",
+      "d# minor",
+      "f minor",
       "gb minor",
-      "cb major"
+      "f major",
+      "eb minor"
     ]
   },
   "music.melody": {
@@ -3155,12 +3155,12 @@
     "description": "Descriptive types of musical melodies with their definitions",
     "total": 94,
     "examples": [
-      "repetitive melody (with repeated patterns)",
-      "pulse-like melody (repeated notes creating a pulsating rhythm)",
-      "angular chromatic melody (chromatic intervals with angular shape)",
-      "dance-like melody (energetic and rhythmic)",
-      "hypnotic melody (highly repetitive and trance-inducing)",
-      "ascending melody (rising motion)"
+      "antiphonal melody (alternating phrases between different groups)",
+      "cascading melody (falling notes in a cascading fashion)",
+      "sequential melody (with repeated patterns at different pitch levels)",
+      "homophonic melody (melody accompanied by chords)",
+      "riff melody (repeated melodic pattern)",
+      "modal melody (based on a specific mode or scale)"
     ]
   },
   "music.mode": {
@@ -3169,12 +3169,12 @@
     "description": "Various musical scales, modes, and traditional tonal systems",
     "total": 55,
     "examples": [
-      "harmonic major mode",
-      "slendro scale mode",
-      "neapolitan major mode",
-      "hungarian minor mode",
-      "byzantine scale mode",
-      "mixolydian mode"
+      "blues scale mode",
+      "half-whole diminished mode",
+      "pentatonic major mode",
+      "maqam saba mode",
+      "lydian augmented mode",
+      "acoustic scale mode"
     ]
   },
   "music.mood": {
@@ -3183,12 +3183,12 @@
     "description": "Emotional and atmospheric musical moods or vibes",
     "total": 117,
     "examples": [
-      "ecstatic",
-      "enigmatic",
-      "moody",
-      "epic",
-      "sultry",
-      "majestic"
+      "hopeful",
+      "gloomy",
+      "catchy",
+      "abrasive",
+      "comforting",
+      "euphoric"
     ]
   },
   "music.musicGenre": {
@@ -3197,12 +3197,12 @@
     "description": "Diverse global music genres and subgenres",
     "total": 63,
     "examples": [
-      "noise rock",
-      "acid house",
-      "glitch hop",
-      "grime",
-      "gothic rock",
-      "witch house"
+      "rockabilly",
+      "death metal",
+      "calypso",
+      "dubstep",
+      "kwaito",
+      "gothic rock"
     ]
   },
   "music.percussive": {
@@ -3211,12 +3211,12 @@
     "description": "Specific percussion instruments and percussive sound makers",
     "total": 145,
     "examples": [
-      "kalimba",
-      "timbales",
-      "tambour",
-      "vibraslap",
-      "wood block",
-      "triangle"
+      "crotales",
+      "hand clap",
+      "cricket clicker",
+      "djembe",
+      "jawbone",
+      "bata drum"
     ]
   },
   "music.recording": {
@@ -3225,12 +3225,12 @@
     "description": "Various formats and styles of audio recordings",
     "total": 72,
     "examples": [
-      "remastered recording",
-      "multi-track recording",
-      "wax cylinder recording",
+      "binaural recording",
+      "acoustic session recording",
       "livestream concert recording",
+      "analog recording",
       "single recording",
-      "stereo recording"
+      "acoustic recording"
     ]
   },
   "music.rhythm": {
@@ -3239,11 +3239,11 @@
     "description": "Specific rhythmic patterns and timing structures in music",
     "total": 27,
     "examples": [
-      "irregular rhythm",
-      "dotted rhythm",
-      "offbeat rhythm",
-      "polymetric rhythm",
-      "hemiola rhythm",
+      "cross rhythm",
+      "broken rhythm",
+      "shuffle rhythm",
+      "swing rhythm",
+      "additive rhythm",
       "motorik rhythm"
     ]
   },
@@ -3253,12 +3253,12 @@
     "description": "Structural components and sections of a musical composition",
     "total": 37,
     "examples": [
-      "build-up",
-      "exposition",
-      "hook",
-      "outro",
-      "ad-lib section",
-      "variation"
+      "refrain",
+      "spoken word section",
+      "tag",
+      "cadenza",
+      "breakdown",
+      "interlude"
     ]
   },
   "music.vocalStyle": {
@@ -3267,12 +3267,12 @@
     "description": "Specific vocal techniques, styles, and singing methods",
     "total": 187,
     "examples": [
-      "solfège",
-      "biphonic singing",
-      "chest voice",
-      "barbershop harmony",
-      "a cappella",
-      "copla"
+      "growl",
+      "choral",
+      "ezenggileer",
+      "mixed voice",
+      "parlato",
+      "joik"
     ]
   },
   "music.vocal": {
@@ -3281,12 +3281,12 @@
     "description": "Descriptive styles and textures of vocal performances",
     "total": 119,
     "examples": [
-      "celestial vocals",
-      "whispered vocals",
-      "raw vocals",
-      "vocal scatting",
-      "harmonized whispers",
-      "sustained vibrato"
+      "ethereal vocals",
+      "adrenaline-fueled vocals",
+      "choral falsetto",
+      "dynamic vocals",
+      "rasp vocals",
+      "grunge vocals"
     ]
   },
   "mythical.artifact": {
@@ -3295,12 +3295,12 @@
     "description": "Mythological, religious, and fictional magical items and artifacts",
     "total": 215,
     "examples": [
-      "fragarach",
-      "dreamcatcher",
-      "amrita",
-      "cap of invisibility",
-      "kusanagi no tsurugi",
-      "crystal orb"
+      "deck of many things",
+      "seven-league boots",
+      "iron crown of lombardy",
+      "key of solomon",
+      "scabbard of excalibur",
+      "dowsing rod"
     ]
   },
   "mythical.chinese": {
@@ -3309,12 +3309,12 @@
     "description": "Deities, creatures, and figures from Chinese mythology",
     "total": 83,
     "examples": [
+      "taotie (饕餮)",
+      "nine sons of the dragon (龍生九子)",
+      "kui (夔)",
+      "bi fang (畢方)",
       "ba (巴)",
-      "xiang liu (相柳)",
-      "taowu (檮杌)",
-      "zhu rong (祝融)",
-      "ji gong (濟公)",
-      "di ku (帝嚳)"
+      "xi wangmu's tigers (金虎)"
     ]
   },
   "mythical.dndRace": {
@@ -3323,12 +3323,12 @@
     "description": "Playable character races from Dungeons and Dragons",
     "total": 66,
     "examples": [
-      "thri-kreen",
-      "hobgoblin",
-      "plasmoid",
-      "satyr",
-      "leonin",
-      "kor"
+      "dragonborn",
+      "bariaur",
+      "aven",
+      "svirfneblin",
+      "astral elf",
+      "bugbear"
     ]
   },
   "mythical.dragon": {
@@ -3337,12 +3337,12 @@
     "description": "Specific named dragons and dragon types from global mythologies",
     "total": 86,
     "examples": [
-      "babylonian mušḫuššu dragon",
-      "tibetan thunder dragon",
-      "estonian lendav dragon",
-      "cherokee uktena dragon",
-      "bulgarian lamya dragon",
-      "greek hydra dragon"
+      "babylonian tiamat dragon",
+      "norse nidhogg dragon",
+      "australian rainbow serpent dragon",
+      "chinese fucanglong dragon",
+      "french gargouille dragon",
+      "filipino bakunawa dragon"
     ]
   },
   "mythical.magicTheGathering": {
@@ -3351,12 +3351,12 @@
     "description": "Specific card names from the game Magic: The Gathering",
     "total": 32340,
     "examples": [
-      "retriever phoenix",
-      "gríma wormtongue",
-      "deicide",
-      "eat to extinction",
-      "elvish champion avatar",
-      "arwen, mortal queen"
+      "leyline of lightning",
+      "tax taker",
+      "chrome companion",
+      "fireshrieker",
+      "herald of slaanesh",
+      "fuel tank feaster"
     ]
   },
   "mythical.magicType": {
@@ -3365,12 +3365,12 @@
     "description": "Various schools, disciplines, and types of magical arts",
     "total": 53,
     "examples": [
-      "illusion",
-      "sorcery",
-      "dark magic",
-      "shadow magic",
-      "void magic",
-      "summoning"
+      "divination",
+      "light magic",
+      "elemental magic",
+      "nature magic",
+      "conjuration",
+      "druidry"
     ]
   },
   "mythical.mythicalCreature": {
@@ -3379,12 +3379,12 @@
     "description": "Famous monsters and creatures from global mythology and folklore",
     "total": 61,
     "examples": [
-      "manticore",
+      "sphinx",
       "cockatrice",
-      "chupacabra",
-      "wyvern",
-      "dwarf",
-      "siren"
+      "yeti",
+      "goblin",
+      "gorgon",
+      "ghoul"
     ]
   },
   "nature.areaOfNaturalBeauty": {
@@ -3393,12 +3393,12 @@
     "description": "Specific national parks, landmarks, and natural wonders worldwide",
     "total": 625,
     "examples": [
-      "atlas mountains",
-      "the manu national park",
-      "gullfoss waterfall",
-      "atacama desert",
-      "pamukkale hot springs",
-      "colca canyon"
+      "stone forest",
+      "kailash mountain",
+      "great barrier reef",
+      "jiayuguan pass",
+      "fiordland national park",
+      "kamchatka peninsula"
     ]
   },
   "nature.biome": {
@@ -3407,12 +3407,12 @@
     "description": "Diverse ecological biomes and natural environmental zones",
     "total": 62,
     "examples": [
-      "abyssal zone",
-      "riparian zone",
-      "alpine meadow",
-      "hot desert",
-      "chaparral",
-      "intertidal zone"
+      "karst",
+      "peatland",
+      "tropical dry forest",
+      "rainforest",
+      "benthic zone",
+      "ice sheet"
     ]
   },
   "nature.cloudType": {
@@ -3421,12 +3421,12 @@
     "description": "Specific meteorological cloud formations and types",
     "total": 40,
     "examples": [
-      "fallstreak cloud",
-      "noctilucent cloud",
-      "altocumulus",
-      "wall cloud",
+      "lacunosus",
       "nimbostratus",
-      "shelf cloud"
+      "roll cloud",
+      "pileus",
+      "arcus cloud",
+      "kelvin-helmholtz"
     ]
   },
   "nature.flower": {
@@ -3435,12 +3435,12 @@
     "description": "Various flowering plants, herbs, and ornamental garden blooms",
     "total": 547,
     "examples": [
-      "snowdrop (galanthus nivalis)",
-      "cornflower (centaurea cyanus)",
-      "calendula",
-      "himalayan blue poppy (meconopsis)",
-      "easter lily cactus (echinopsis)",
-      "easter lily (lilium longiflorum)"
+      "yellow bell (tecoma stans)",
+      "iberis (iberis)",
+      "encyclia orchid (encyclia)",
+      "false sunflower (heliopsis helianthoides)",
+      "fleur de lis (iris pseudacorus)",
+      "aconite (aconitum)"
     ]
   },
   "nature.fungus": {
@@ -3449,12 +3449,12 @@
     "description": "Assorted species of wild mushrooms and fungi",
     "total": 214,
     "examples": [
-      "porcelain fungus",
-      "livid pinkgill mushroom",
-      "chanterelle mushroom",
-      "butter cap mushroom",
+      "bicolored deceiver mushroom",
+      "black trumpet mushroom",
+      "jelly babies fungus",
       "devil's cigar",
-      "collared parachute mushroom"
+      "jelly antler fungus",
+      "glistening inkcap mushroom"
     ]
   },
   "nature.gemstone": {
@@ -3463,12 +3463,12 @@
     "description": "Various precious gemstones, crystals, and mineral specimens",
     "total": 375,
     "examples": [
-      "rose quartz",
-      "tiger iron",
-      "shungite",
-      "yellow diamond",
-      "vesuvianite",
-      "sulfur"
+      "arsenopyrite",
+      "cavansite",
+      "septarian",
+      "amblygonite",
+      "creedite",
+      "hessonite garnet"
     ]
   },
   "nature.landscape": {
@@ -3477,12 +3477,12 @@
     "description": "Geological formations and large-scale geographical landscape features",
     "total": 51,
     "examples": [
-      "badlands",
-      "arch",
-      "fjord",
-      "bay",
-      "natural bridge",
-      "precipice"
+      "delta",
+      "alluvial fan",
+      "precipice",
+      "plateau",
+      "caldera",
+      "bay"
     ]
   },
   "nature.mineral": {
@@ -3491,12 +3491,12 @@
     "description": "Specific mineral specimens, crystals, and semi-precious stones",
     "total": 275,
     "examples": [
-      "datolite",
-      "xenotime",
-      "bavenite",
-      "chabazite",
-      "brookite",
-      "chromite"
+      "wolframite",
+      "bornite",
+      "chrysocolla",
+      "erythrite",
+      "anatase",
+      "cristobalite"
     ]
   },
   "nature.moonPhase": {
@@ -3505,12 +3505,12 @@
     "description": "Traditional, seasonal, and descriptive names for lunar phases",
     "total": 117,
     "examples": [
-      "awakening moon",
-      "long night moon",
-      "frost moon",
-      "wyrt moon",
-      "honey moon",
-      "growing moon"
+      "hunter's moon",
+      "mothers' moon",
+      "alder moon",
+      "fish moon",
+      "claiming moon",
+      "hot moon"
     ]
   },
   "nature.naturalPhenomenon": {
@@ -3519,12 +3519,12 @@
     "description": "Rare atmospheric, meteorological, and natural optical phenomena",
     "total": 45,
     "examples": [
-      "ball lightning",
-      "fata morgana",
-      "lenticular cloud glow",
-      "elves",
-      "aurora australis",
-      "moon dog"
+      "catatumbo lightning",
+      "penitentes",
+      "rainbow",
+      "afterglow",
+      "fire rainbow",
+      "geyser"
     ]
   },
   "nature.plant": {
@@ -3533,12 +3533,12 @@
     "description": "Common indoor houseplants and decorative potted foliage",
     "total": 55,
     "examples": [
-      "echeveria",
-      "monstera",
-      "venus flytrap",
-      "croton",
       "philodendron",
-      "anthurium"
+      "anthurium",
+      "dumb cane",
+      "staghorn fern",
+      "nerve plant",
+      "sensitive plant"
     ]
   },
   "nature.sceneModifier": {
@@ -3547,12 +3547,12 @@
     "description": "Atmospheric conditions, weather, and mood modifiers for scenes",
     "total": 49,
     "examples": [
-      "cumulonimbus",
-      "picturesque",
-      "tranquil",
-      "aurora",
+      "sun-dappled",
       "foreboding",
-      "verdant"
+      "cumulonimbus",
+      "dark skies",
+      "apocalyptic",
+      "cloudy"
     ]
   },
   "nature.scene": {
@@ -3561,12 +3561,12 @@
     "description": "Diverse natural environments, biomes, and landscape settings",
     "total": 84,
     "examples": [
-      "cliffs",
-      "mangrove",
-      "geyser",
-      "shoreline",
-      "track",
-      "coral reef"
+      "folly",
+      "crater",
+      "glacier",
+      "island",
+      "archipelago",
+      "gorge"
     ]
   },
   "nature.sky": {
@@ -3575,12 +3575,12 @@
     "description": "Specific sky conditions, times of day, and cloud formations",
     "total": 198,
     "examples": [
-      "celestial sky",
-      "charcoal sky",
-      "clear night sky",
-      "dreamlike sky",
+      "zenith sky",
+      "brooding sky",
       "dramatic storm clouds",
-      "ominous storm sky"
+      "golden sunset sky",
+      "dreamlike sky",
+      "dusk sky"
     ]
   },
   "nature.texture": {
@@ -3589,12 +3589,12 @@
     "description": "Assorted natural and artificial surface textures and patterns",
     "total": 167,
     "examples": [
-      "knitted fabric",
-      "rough granite",
-      "bark with moss",
-      "abstract paint splatters",
-      "distressed plaster",
-      "cracked earth"
+      "rust",
+      "shag carpet",
+      "plastic",
+      "porous volcanic rock",
+      "rustic wood",
+      "ice"
     ]
   },
   "nature.treeType": {
@@ -3603,12 +3603,12 @@
     "description": "Various species of deciduous, coniferous, and tropical trees",
     "total": 71,
     "examples": [
-      "birch",
-      "chestnut",
-      "coconut palm",
-      "banyan",
-      "acacia",
-      "cherry blossom"
+      "larch",
+      "alder",
+      "hickory",
+      "linden",
+      "ash",
+      "bristlecone pine"
     ]
   },
   "nature.tree": {
@@ -3617,12 +3617,12 @@
     "description": "Assorted tree species, fruiting trees, and woody plants",
     "total": 158,
     "examples": [
-      "white oak",
+      "douglas fir",
+      "longleaf pine",
       "birch",
-      "black cherry",
-      "ash",
-      "blue ash",
-      "atlantic white cedar"
+      "arizona cypress",
+      "honeylocust",
+      "black walnut"
     ]
   },
   "nature.tropicalHouseplant": {
@@ -3631,12 +3631,12 @@
     "description": "Tropical flowering plants, orchids, and decorative botanicals",
     "total": 104,
     "examples": [
-      "orchid",
-      "billbergia",
-      "asplenium",
-      "celosia",
-      "anthurium",
-      "malva sylvestris"
+      "pentas",
+      "nemesia",
+      "maranta",
+      "pelargonium",
+      "spathiphyllum",
+      "verbena canadensis"
     ]
   },
   "nature.waterBody": {
@@ -3645,12 +3645,12 @@
     "description": "Various types of natural and artificial water formations",
     "total": 109,
     "examples": [
-      "phytotelma",
-      "pond",
-      "subterranean river",
-      "runnel",
-      "vernal pool",
-      "puddle"
+      "ocean",
+      "thermal spring",
+      "tributary",
+      "creeklet",
+      "source",
+      "waterhole"
     ]
   },
   "nature.weather": {
@@ -3659,12 +3659,12 @@
     "description": "Meteorological events, cloud types, and severe weather conditions",
     "total": 156,
     "examples": [
-      "waterspout",
-      "light snow",
-      "torrential rain",
-      "whiteout",
-      "storm surge",
-      "cumulonimbus clouds"
+      "sprinkle",
+      "mist",
+      "landspout",
+      "damp",
+      "kelvin-helmholtz clouds",
+      "rainy"
     ]
   },
   "nature.wood": {
@@ -3673,12 +3673,12 @@
     "description": "Specific types of hardwood and softwood timber materials",
     "total": 66,
     "examples": [
-      "purpleheart",
-      "cedar",
-      "basswood",
+      "koa",
       "figured bubinga",
-      "elm",
-      "balsa"
+      "butternut",
+      "hickory",
+      "jatoba",
+      "cedar"
     ]
   },
   "people.accent": {
@@ -3687,12 +3687,12 @@
     "description": "Various global and regional spoken accents and dialects",
     "total": 126,
     "examples": [
-      "canadian",
-      "korean",
-      "greek",
-      "catalan",
-      "indian",
-      "indonesian"
+      "cornish",
+      "castilian",
+      "french",
+      "geordie",
+      "hebrew",
+      "estonian"
     ]
   },
   "people.beautifulFeminine": {
@@ -3701,12 +3701,12 @@
     "description": "Adjectives describing feminine beauty, grace, and physical attractiveness",
     "total": 48,
     "examples": [
-      "sublime",
-      "divine",
-      "slim",
-      "beautiful",
-      "sultry",
-      "dazzling"
+      "lovely",
+      "angelic",
+      "alluring",
+      "delicate",
+      "splendid",
+      "classy"
     ]
   },
   "people.beautifulMasculine": {
@@ -3715,12 +3715,12 @@
     "description": "Personality traits and physical characteristics associated with masculine appeal",
     "total": 106,
     "examples": [
+      "loyal",
       "muscular",
-      "centered",
-      "reliable",
-      "trustworthy",
-      "well traveled",
-      "distinguished"
+      "peaceful",
+      "hard-working",
+      "dark skin",
+      "smooth skin"
     ]
   },
   "people.bodyType": {
@@ -3729,12 +3729,12 @@
     "description": "Detailed descriptions of various human body shapes, builds, and proportions",
     "total": 115,
     "examples": [
-      "fat with a defined waist",
-      "very fat with a rotund shape",
-      "apple-shaped torso with slim limbs",
-      "mesomorph build with naturally muscular shoulders",
-      "hourglass figure with short legs",
-      "inverted triangle with lean lower body"
+      "thin all over, little body fat",
+      "curvy shape with larger hips",
+      "hourglass figure with long legs",
+      "broad shoulders, narrow hips",
+      "banana-shaped with straight hips and shoulders",
+      "hourglass figure with short legs"
     ]
   },
   "people.celebrity": {
@@ -3743,12 +3743,12 @@
     "description": "Famous actors, singers, influencers, and members of British royalty",
     "total": 646,
     "examples": [
-      "jake gyllenhaal",
-      "barack obama",
-      "daniel radcliffe",
-      "demi lovato",
-      "cindy crawford",
-      "david letterman"
+      "adriana lima",
+      "whitney cummings",
+      "jenna coleman",
+      "jamie chung",
+      "judy greer",
+      "elizabeth debicki"
     ]
   },
   "people.common": {
@@ -3757,12 +3757,12 @@
     "description": "Broad age groups, life stages, and general demographic categories",
     "total": 34,
     "examples": [
-      "teenager",
-      "geek",
+      "middle-aged man",
+      "toddler",
+      "middle-aged woman",
+      "senior",
       "adolescent",
-      "schoolboy",
-      "old woman",
-      "kid"
+      "young man"
     ]
   },
   "people.couple": {
@@ -3771,12 +3771,12 @@
     "description": "Various romantic, platonic, and professional two-person relationship dynamics",
     "total": 36,
     "examples": [
-      "acquaintances",
-      "significant others",
-      "partners",
-      "sweethearts",
+      "married couple",
+      "same-sex couple",
+      "soulmates",
       "lovers",
-      "dating partners"
+      "teammates",
+      "duo"
     ]
   },
   "people.dance": {
@@ -3785,12 +3785,12 @@
     "description": "Traditional, cultural, and modern dance styles from around the world",
     "total": 119,
     "examples": [
-      "povada dance",
-      "english country dance",
-      "bihu dance",
-      "garba raas dance",
-      "hip hop dance",
-      "bachata"
+      "jitterbug dance",
+      "japanese butoh-fu dance",
+      "jive",
+      "charleston dance",
+      "chhau dance",
+      "lambada dance"
     ]
   },
   "people.expression": {
@@ -3799,12 +3799,12 @@
     "description": "Highly detailed descriptions of facial expressions and emotional body language",
     "total": 471,
     "examples": [
-      "lip curl with a sideways glance and a slightly jutted chin",
-      "bright smile with nose crinkled in delight",
-      "quivering chin with watery eyes and slightly parted lips",
-      "smiling softly with eyes crinkling at the corners",
-      "bawling loudly with red, puffy eyes",
-      "slight pout with furrowed brow and crossed arms"
+      "quivering upper lip with tear-filled eyes and a red face",
+      "soft, dreamy expression with a faraway look in the eyes",
+      "slight pout with puppy-dog eyes and raised inner eyebrows",
+      "scowl with furrowed brow and slightly protruding lower lip",
+      "slight pout with puppy-dog eyes and hunched shoulders",
+      "tight-lipped smile with one eyebrow raised inquisitively"
     ]
   },
   "people.eyeColor": {
@@ -3813,12 +3813,12 @@
     "description": "Natural and fantasy eye colors including gem-like and vivid shades",
     "total": 46,
     "examples": [
-      "chocolate brown eyes",
-      "brown eyes",
-      "black eyes",
-      "blue eyes",
-      "hazel eyes",
-      "coral eyes"
+      "grey eyes",
+      "ruby eyes",
+      "silver eyes",
+      "purple eyes",
+      "golden-brown eyes",
+      "honey brown eyes"
     ]
   },
   "people.festival": {
@@ -3827,12 +3827,12 @@
     "description": "Major international cultural, religious, and seasonal festivals and holidays",
     "total": 59,
     "examples": [
+      "calgary stampede",
+      "carnival",
+      "sapporo snow festival",
       "san fermin",
-      "white nights festival",
-      "bonfire night",
-      "burning man",
-      "halloween",
-      "independence day"
+      "pride month",
+      "semana santa"
     ]
   },
   "people.group": {
@@ -3841,12 +3841,12 @@
     "description": "Collective nouns and terms for various groups or gatherings of people",
     "total": 71,
     "examples": [
-      "folks",
       "coalition",
-      "group",
-      "assembly",
-      "bystanders",
-      "company"
+      "spectators",
+      "people",
+      "fans",
+      "flock",
+      "customers"
     ]
   },
   "people.hairstyle": {
@@ -3856,10 +3856,10 @@
     "total": 58,
     "examples": [
       "beach waves",
+      "flat top",
       "shag cut",
-      "hime cut",
-      "lob cut",
-      "fringe bangs",
+      "bowl cut",
+      "high and tight",
       "bob cut"
     ]
   },
@@ -3869,12 +3869,12 @@
     "description": "Wide range of creative, physical, and intellectual hobbies and interests",
     "total": 291,
     "examples": [
-      "digital painting",
-      "rc car racing",
-      "disc golf",
-      "crystal healing",
-      "art therapy",
-      "cultural exchange"
+      "card making",
+      "poetry",
+      "collecting coins",
+      "photography",
+      "roller skating",
+      "paper folding"
     ]
   },
   "people.job": {
@@ -3883,12 +3883,12 @@
     "description": "Various professional occupations, roles, and employment titles",
     "total": 612,
     "examples": [
-      "patient",
-      "medical transcriptionist",
-      "economist",
-      "broadcaster",
-      "commander",
-      "computer forensic analyst"
+      "retail clerk",
+      "librarian assistant",
+      "dentist",
+      "cryptographer",
+      "activist",
+      "aircraft maintenance technicians"
     ]
   },
   "people.makeupStyle": {
@@ -3897,12 +3897,12 @@
     "description": "Historical, trendy, and artistic makeup styles and cosmetic techniques",
     "total": 73,
     "examples": [
-      "k-beauty glass skin",
-      "1920s flapper makeup",
-      "bold lip",
-      "feline flick",
-      "emo makeup",
-      "glam makeup"
+      "cat eye makeup",
+      "clown makeup",
+      "fantasy makeup",
+      "festival makeup",
+      "goth makeup",
+      "editorial makeup"
     ]
   },
   "people.posePortrait": {
@@ -3911,12 +3911,12 @@
     "description": "Specific camera angles, body positioning, and framing for portrait photography",
     "total": 45,
     "examples": [
-      "3/4 shot",
-      "environmental portrait",
-      "hand on hip",
-      "looking over one shoulder",
-      "head tilted to the side",
-      "looking down"
+      "arms crossed",
+      "against a wall",
+      "sitting on stairs",
+      "leaning back against a railing",
+      "dramatic close-up",
+      "sitting down with legs crossed"
     ]
   },
   "people.pose": {
@@ -3925,12 +3925,12 @@
     "description": "Dynamic body postures, gestures, and physical actions for characters",
     "total": 201,
     "examples": [
-      "jumping",
-      "looking playful with tongue sticking out or smiling mischievously",
-      "leaning against a nearby object",
-      "looking sad with downturned mouth and eyes",
-      "looking up with hands shielding eyes from the sun",
-      "kneeling with hands on hips"
+      "winking with one eye",
+      "leaning back",
+      "holding an object in one hand, such as a flower or book",
+      "dancing or jumping in mid-air with a joyful expression",
+      "crouching",
+      "lying on back with arms outstretched"
     ]
   },
   "people.profession": {
@@ -3939,12 +3939,12 @@
     "description": "Specific historical, scientific, and specialized professions and trades",
     "total": 60,
     "examples": [
+      "carpenter",
       "barrister",
-      "wheelwright",
-      "archaeologist",
-      "brewer",
-      "librarian",
-      "watchmaker"
+      "stonemason",
+      "silversmith",
+      "lepidopterist",
+      "librarian"
     ]
   },
   "photography.apertureLook": {
@@ -3953,12 +3953,12 @@
     "description": "Photographic effects related to bokeh, depth of field, focus, and lens flares",
     "total": 52,
     "examples": [
-      "selective focus",
+      "f/2.8 look",
       "hyperfocal focus",
-      "infinite focus",
-      "f/16 deep depth of field",
-      "pinhole focus",
-      "swirly bokeh"
+      "deep focus",
+      "shallow depth of field",
+      "f/1.8 look",
+      "anamorphic bokeh"
     ]
   },
   "photography.cameraMovement": {
@@ -3967,12 +3967,12 @@
     "description": "Cinematography terms for dynamic camera movements, rigs, and tracking shots",
     "total": 50,
     "examples": [
-      "360-degree rotation",
-      "camera roll",
-      "snorricam",
-      "bodycam view",
-      "bullet time",
-      "trucking shot"
+      "push in",
+      "panning shot",
+      "shaky cam",
+      "arc shot",
+      "arc",
+      "time-lapse camera movement"
     ]
   },
   "photography.camera": {
@@ -3981,12 +3981,12 @@
     "description": "Specific models of professional cinema cameras, DSLRs, and digital cameras",
     "total": 187,
     "examples": [
-      "nikon f3",
-      "canon eos rebel t7i",
-      "hasselblad 500c/m",
-      "sony a7r ii",
-      "nikon 1 v3",
-      "ricoh gr digital iv"
+      "ricoh gr ii",
+      "blackmagic design pocket cinema camera 4k",
+      "fujifilm gfx 100s",
+      "canon ae-1",
+      "samsung nx200 smart camera",
+      "blackmagic cinema camera 2.5k"
     ]
   },
   "photography.composition": {
@@ -3995,12 +3995,12 @@
     "description": "Visual composition techniques, framing styles, and spatial balance methods",
     "total": 117,
     "examples": [
-      "parallel lines",
-      "low horizon",
-      "l-shape composition",
-      "implied lines",
-      "layered composition",
-      "intersecting lines"
+      "diagonal composition",
+      "u-shape composition",
+      "allover composition",
+      "z-shape composition",
+      "negative space",
+      "left-to-right rule"
     ]
   },
   "photography.filmStock": {
@@ -4009,12 +4009,12 @@
     "description": "Specific brands, models, and ISO speeds of analog photographic film stocks",
     "total": 52,
     "examples": [
-      "cinestill 400d",
-      "fujifilm velvia 50",
-      "ilford delta 400",
-      "ilford sfx 200",
-      "fujicolor c200",
-      "fujifilm superia 400"
+      "agfa vista 400",
+      "cinestill 50d",
+      "fujifilm provia 100f",
+      "kodak ektar 100",
+      "ilford delta 3200",
+      "lomography purple"
     ]
   },
   "photography.film": {
@@ -4023,12 +4023,12 @@
     "description": "Specific analog photography film types, brands, and ISO speeds",
     "total": 102,
     "examples": [
-      "kodak portra 400 film",
-      "ilford delta 100 film",
-      "kodak professional elite chrome extra color 200 film",
-      "lomography xprochrome film",
-      "kodak elite 800s film",
-      "fuji provia 400x rdpiii film"
+      "lomography color negative 400 film",
+      "fujifilm 120 film",
+      "fuji provia 400x rdpiii film",
+      "kodak 126 film",
+      "ilford pan 100 film",
+      "foma fomapan 200 film"
     ]
   },
   "photography.landscapeKeyword": {
@@ -4037,12 +4037,12 @@
     "description": "Broad photography concepts, subjects, and techniques related to outdoor photography",
     "total": 81,
     "examples": [
-      "macro",
-      "viewpoints",
-      "mist",
-      "structures",
-      "trees",
-      "stars"
+      "textures",
+      "exposure",
+      "dunes",
+      "horizons",
+      "churches",
+      "angles"
     ]
   },
   "photography.landscapeSubjectDetailed": {
@@ -4051,12 +4051,12 @@
     "description": "Highly descriptive, full-sentence prompts of vivid nature and landscape scenes",
     "total": 158,
     "examples": [
-      "a colorful desert landscape with towering sandstone formations",
-      "a colorful river canyon with towering walls of rock",
-      "a dense jungle with a variety of primates and other wildlife",
-      "a winding river with rapids and waterfalls",
-      "a secluded cove with a pristine beach",
-      "a rugged desert canyon with narrow passages and towering walls"
+      "a lush, tropical island with palm-fringed beaches",
+      "a rolling hillside covered in vineyards",
+      "a picturesque river gorge with towering cliffs",
+      "a quiet birch forest in winter with a fresh blanket of powdery snow",
+      "a peaceful zen garden with meticulously raked sand around large mossy stones",
+      "a remote wilderness area with snow-covered peaks and alpine meadows"
     ]
   },
   "photography.landscapeSubject": {
@@ -4065,12 +4065,12 @@
     "description": "Various natural and man-made outdoor locations, structures, and landscape features",
     "total": 132,
     "examples": [
-      "wetland",
-      "water tower",
-      "abandoned building",
-      "suspension bridge",
+      "forest",
+      "savannah",
       "badlands",
-      "botanical garden"
+      "water tower",
+      "cave",
+      "alpine meadow"
     ]
   },
   "photography.lensType": {
@@ -4079,12 +4079,12 @@
     "description": "General categories, optical designs, and specialized styles of photographic lenses",
     "total": 52,
     "examples": [
-      "normal lens",
+      "apochromatic lens",
+      "fresnel lens",
       "apochromatic",
-      "disposable camera lens",
-      "tilt-shift",
-      "stereoscopic",
-      "petzval lens"
+      "cine",
+      "ultra-wide-angle",
+      "fisheye"
     ]
   },
   "photography.lens": {
@@ -4093,12 +4093,12 @@
     "description": "Specific focal lengths and exact branded camera lens models",
     "total": 87,
     "examples": [
-      "18mm",
-      "tamron sp 85mm",
-      "panasonic lumix s pro 50mm",
-      "sigma 10-20mm",
-      "sigma 35mm",
-      "sony fe 24-70mm"
+      "canon ef 35mm",
+      "300mm",
+      "nikon z 100-400mm",
+      "sony fe 50mm",
+      "sony fe 16-35mm",
+      "nikon af-s 50mm"
     ]
   },
   "photography.lightSource": {
@@ -4107,12 +4107,12 @@
     "description": "Natural, artificial, and specialized light sources and lighting equipment",
     "total": 64,
     "examples": [
-      "dusk",
-      "fiber optics",
-      "modeling lamp",
-      "skylight",
-      "gaslight",
-      "klieg light"
+      "desk lamp",
+      "bioluminescence",
+      "halogen lamp",
+      "flashlight",
+      "fireplace",
+      "blacklight"
     ]
   },
   "photography.light": {
@@ -4121,12 +4121,12 @@
     "description": "Descriptive lighting styles, natural light conditions, and illumination techniques",
     "total": 136,
     "examples": [
-      "lit by dish reflector",
-      "side light",
-      "key light",
-      "morning blue hour",
-      "horror lighting",
-      "lit by fluorescent lamps"
+      "flat lighting",
+      "dual red and green",
+      "afternoon lighting",
+      "lit by fluorescent tube",
+      "ethereal light",
+      "bright sunlight"
     ]
   },
   "photography.lightingSetup": {
@@ -4135,12 +4135,12 @@
     "description": "Studio lighting techniques, setups, and directional illumination styles",
     "total": 52,
     "examples": [
-      "profile lighting",
-      "background lighting",
-      "loop lighting",
-      "accent lighting",
-      "moody lighting",
-      "ambient lighting"
+      "dramatic lighting",
+      "available lighting",
+      "front lighting",
+      "broad lighting",
+      "checkerboard lighting",
+      "silhouette lighting"
     ]
   },
   "photography.perspective": {
@@ -4149,12 +4149,12 @@
     "description": "Camera angles, viewpoints, and geometric perspective techniques for visual framing",
     "total": 129,
     "examples": [
-      "cabinet perspective",
-      "perceptive perspective",
-      "straight-on view",
-      "three-point perspective",
-      "worm's-eye view",
-      "central perspective"
+      "dutch angle",
+      "anamorphic perspective",
+      "cross-section view",
+      "extreme close-up perspective",
+      "first-person view",
+      "horizon-level view"
     ]
   },
   "photography.photographer": {
@@ -4163,12 +4163,12 @@
     "description": "Names of famous photographers paired with their specific genres or styles",
     "total": 960,
     "examples": [
-      "sergey melnitchenko (documentary photographer)",
-      "berenice abbott (documentary and architectural photographer)",
-      "adriana lestido (documentary photographer)",
-      "madhur dhingra (portrait and fashion photographer)",
-      "eliot elisofon (documentary photographer)",
-      "jacques-henri lartigue (documentary and portrait photographer)"
+      "zaida ben-yusuf (portrait photographer)",
+      "mitch epstein (documentary photographer)",
+      "marc riboud (documentary photographer)",
+      "mariya kozhanova (documentary and portrait photographer)",
+      "max dupain (documentary and commercial photographer)",
+      "zack arias (portrait and editorial photographer)"
     ]
   },
   "photography.portraitPhotographer": {
@@ -4177,12 +4177,12 @@
     "description": "Names of renowned portrait, fine art, and fashion photographers",
     "total": 79,
     "examples": [
-      "joey l",
-      "peter menzel",
-      "ryan mcginley",
-      "man ray",
-      "malick sidibé",
-      "mario testino"
+      "martin schoeller",
+      "bill brandt",
+      "joel meyerowitz",
+      "august sander",
+      "jürgen teller",
+      "bruce gilden"
     ]
   },
   "photography.shotType": {
@@ -4191,11 +4191,11 @@
     "description": "Various camera angles and framing techniques for photography and film",
     "total": 43,
     "examples": [
-      "macro shot",
       "aerial shot",
-      "canted angle",
+      "american shot",
+      "drone shot",
       "cowboy shot",
-      "full shot",
+      "bird's-eye view",
       "close-up"
     ]
   },
@@ -4205,12 +4205,12 @@
     "description": "Idyllic, warm-weather outdoor scenes, landscapes, and summer activities",
     "total": 47,
     "examples": [
-      "a family camping trip in the mountains",
-      "a backyard barbecue with smoke rising under strings of warm cafe lights",
-      "a scenic drive along a winding country road",
+      "a rustic beach shack surrounded by sand dunes and sea grass",
       "a peaceful campsite under a canopy of stars next to a glowing campfire",
-      "a lush forest with a peaceful stream running through it",
-      "a refreshing swimming hole surrounded by smooth river rocks and mossy trees"
+      "a garden filled with butterflies and hummingbirds",
+      "a rolling green hill dotted with grazing sheep",
+      "a mountain lake surrounded by trees",
+      "a terrace overlooking coastal cliffs and the turquoise mediterranean sea"
     ]
   },
   "photography.summerTropicalBeach": {
@@ -4219,12 +4219,12 @@
     "description": "Sensory details and vibrant scenes of a tropical beach vacation",
     "total": 67,
     "examples": [
+      "the gentle sound of water lapping at the shore, like a soothing balm",
       "a collection of brightly colored fishing boats bobbing in the water",
-      "a collection of colorful beach umbrellas providing welcome shade",
-      "a distant island visible on the horizon, like a mirage",
-      "red and orange hibiscus flowers scattered on the white sand",
-      "brightly colored seashells scattered along the beach",
-      "a cold, condensation-ringed glass of coconut water resting on a teak table"
+      "a dazzling display of stars overhead on a clear night",
+      "children splashing in the gentle, warm shallows of a protected lagoon",
+      "a vibrant, colorful reef visible just offshore",
+      "gentle waves rolling in and out, leaving a lacy pattern of foam on the sand"
     ]
   },
   "photojournalism.newsExtreme": {
@@ -4233,12 +4233,12 @@
     "description": "Catastrophic, world-altering, and extreme global news events and disasters",
     "total": 68,
     "examples": [
-      "a powerful solar flare knocks out communications satellites and causes a global internet blackout",
-      "a team of astronauts discovers a new habitable planet",
-      "a sudden, massive sinkhole swallows an entire city block during rush hour",
-      "a new type of energy storage technology is discovered, making renewable energy even more feasible",
-      "a new global disease epidemic threatens the world",
-      "a massive synthetic biology lab leak creates a highly aggressive, invasive plant species that destroys concrete"
+      "a massive data leak exposes the private information of millions",
+      "a massive new environmental law is passed",
+      "a major historical artifact is discovered, rewriting history as we know it",
+      "a global agricultural blight rapidly destroys half of the world's wheat and corn crops",
+      "a new type of food additive is discovered to be causing cancer in humans",
+      "a major new discovery in the world of quantum physics"
     ]
   },
   "photojournalism.newsNormal": {
@@ -4247,12 +4247,12 @@
     "description": "Standard major news headlines covering science, politics, business, and society",
     "total": 57,
     "examples": [
-      "a major political scandal, involving allegations of corruption or abuse of power",
-      "a major development in international relations, such as a new trade deal or a new peace treaty",
+      "a major geopolitical event, such as a peace treaty or a declaration of war",
+      "a high-profile court trial of a corrupt politician begins, attracting massive media crowds",
+      "a major natural disaster, such as a hurricane or earthquake, that leaves thousands of people displaced",
       "a political protest, aimed at overturning a controversial law or policy",
-      "a natural phenomenon, such as a solar eclipse or meteor shower, that captures the world's attention",
-      "a prominent veteran is honored at a moving public ceremony celebrating their lifelong service",
-      "a new public housing project is opened to address rising homelessness in a major metropolis"
+      "a new high-speed rail line is inaugurated, connecting major cities and reducing travel times",
+      "a major international airport suffers a system-wide it failure, grounding hundreds of commercial flights"
     ]
   },
   "photojournalism.newsSpecific": {
@@ -4261,12 +4261,12 @@
     "description": "Highly detailed, specific descriptions of major global news events and crises",
     "total": 38,
     "examples": [
-      "a major political scandal: a top government official is caught in a sexting scandal, leading to calls for his resignation and damaging his political career",
-      "a major climate change summit: leaders from around the world gather in paris to discuss a new global agreement on reducing carbon emissions and slowing the effects of climate change",
-      "a political protest: demonstrators gather outside the white house to protest the government's immigration policies, calling for greater protection for undocumented immigrants and refugees",
-      "a groundbreaking archaeological discovery: researchers in egypt unearth a pristine, undisturbed royal tomb dating back three thousand years",
-      "a major high-tech art heist: armed thieves bypass advanced security systems to steal a famous modern masterpiece from a gallery in paris",
-      "a dramatic urban rescue: firefighters work tirelessly to rescue residents trapped on the upper floors of a burning skyscraper in downtown chicago"
+      "a major civil rights movement: the black lives matter movement gains widespread support and leads to major policy changes, including police reform and the removal of confederate statues",
+      "a critical space rescue: an international crew of astronauts executes a daring spacewalk to repair a damaged life-support system",
+      "a mass protest against police brutality and systemic racism: thousands march through the streets of new york city, demanding justice for victims of police violence and systemic racism in the criminal justice system",
+      "a major sporting event: the world cup is held in qatar, bringing together teams from around the world and drawing massive crowds of enthusiastic fans",
+      "a breakthrough in the fight against cancer: researchers develop a new type of cancer treatment that uses the body's own immune system to target and destroy cancer cells",
+      "a stunning scientific achievement: fusion energy researchers achieve net energy gain for the first time, marking a major milestone for clean power"
     ]
   },
   "photojournalism.styleProtest": {
@@ -4275,12 +4275,12 @@
     "description": "Various photographic styles and techniques used in photojournalism and documentary photography",
     "total": 38,
     "examples": [
-      "analog film photography: using traditional 35mm or medium format film to create a raw, grain-textured aesthetic with natural color tones",
-      "aerial photography: providing a unique and expansive view of the protests and the surrounding environment",
-      "candid photography: capturing the spontaneous moments of protests and the raw emotions of the participants",
-      "cinematic photojournalism: utilizing anamorphic lenses, wide aspect ratios, and dramatic color grading to evoke a movie-like atmosphere",
+      "dramatic silhouette photography: framing protesters against a bright light source, like the setting sun or police headlights, to create powerful dark outlines",
       "action photography: capturing the movement and energy of the protesters in action",
-      "flash photography: using on-camera or off-camera flash to freeze movement and separate subjects from dark or chaotic backgrounds"
+      "intentional camera movement: deliberately moving the camera during a longer exposure to create a dynamic, abstract representation of chaos and action",
+      "street photography: capturing the atmosphere of the protests and the surrounding environment",
+      "documentary photography: providing a historical record of the protests and the people involved",
+      "close-up portraiture: focusing tightly on the expressive faces of individual protesters to highlight intense human emotion and determination"
     ]
   },
   "photojournalism.types": {
@@ -4290,11 +4290,11 @@
     "total": 87,
     "examples": [
       "advocacy photojournalism, documenting specific causes to raise awareness and inspire social change",
-      "investigative reporting on police brutality and misconduct",
-      "climate migration and climate refugees, documenting families forced to relocate due to environmental changes",
-      "gender identity and gender expression",
-      "culture and tradition",
-      "aging and retirement"
+      "entertainment and celebrity culture",
+      "community and neighborhood storytelling, highlighting the everyday lives and challenges of local residents",
+      "religion and spirituality",
+      "transportation and infrastructure",
+      "photojournalistic coverage of the refugee crisis and displacement"
     ]
   },
   "places.home": {
@@ -4303,12 +4303,12 @@
     "description": "Various types of residential dwellings and architectural housing styles",
     "total": 103,
     "examples": [
-      "midcentury modern",
-      "cabin",
-      "fourplex",
-      "manufactured home",
-      "earth sheltered home",
-      "prefab home"
+      "stilt house",
+      "thatched roof home",
+      "solar home",
+      "playhouse",
+      "prefab home",
+      "shipping container home"
     ]
   },
   "places.interiorSpace": {
@@ -4317,12 +4317,12 @@
     "description": "Diverse indoor environments ranging from mundane rooms to specialized workspaces",
     "total": 481,
     "examples": [
-      "pantry",
-      "brewery cellar",
-      "castle keep",
-      "anechoic chamber",
-      "driver's cab",
-      "breakfast nook"
+      "indoor balcony",
+      "cloakroom",
+      "cowshed",
+      "abbey church nave",
+      "arcade hall",
+      "distillery"
     ]
   },
   "places.public": {
@@ -4331,12 +4331,12 @@
     "description": "Common public venues, recreational areas, and civic facilities",
     "total": 94,
     "examples": [
-      "subway station",
-      "government building",
-      "city hall",
-      "fishing pier",
+      "ice rink",
+      "seafront promenade",
+      "observatory",
+      "hiking trail",
       "lighthouse",
-      "boat ramp"
+      "art gallery"
     ]
   },
   "places.roomType": {
@@ -4345,12 +4345,12 @@
     "description": "Specific, often historical or grand interior rooms and specialized chambers",
     "total": 71,
     "examples": [
-      "chapel",
+      "great hall",
+      "vault",
       "root cellar",
-      "atrium",
-      "game room",
-      "armory",
-      "patio"
+      "wine cellar",
+      "scriptorium",
+      "wardrobe"
     ]
   },
   "places.room": {
@@ -4359,12 +4359,12 @@
     "description": "Standard functional rooms and spaces found in typical modern homes",
     "total": 51,
     "examples": [
-      "storage room",
-      "laboratory",
+      "balcony",
+      "conference room",
+      "waiting room",
+      "cellar",
       "conservatory",
-      "cloakroom",
-      "patio",
-      "dining room"
+      "server room"
     ]
   },
   "places.urbanFeature": {
@@ -4373,12 +4373,12 @@
     "description": "Structural elements, fixtures, and infrastructure found in city environments",
     "total": 196,
     "examples": [
-      "e-scooter parking zone",
+      "public restroom",
+      "alleyway",
       "hanging basket",
-      "emergency call box",
-      "skywalk",
-      "dumpster enclosure",
-      "package locker"
+      "jersey barrier",
+      "market stall",
+      "lamppost"
     ]
   },
   "plot.action": {
@@ -4387,12 +4387,12 @@
     "description": "High-stakes, thrilling scenarios involving combat, heists, rescues, and survival",
     "total": 66,
     "examples": [
-      "overcoming personal demons or fears",
-      "participating in a high-speed car chase",
-      "escaping from a hazardous environment or extreme weather",
-      "rescuing a captive from a jungle or wilderness",
-      "rescuing a loved one from danger",
-      "escaping from a collapsed building or tunnel"
+      "infiltrating a high-stakes illegal casino to gather evidence",
+      "rescuing survivors of a natural disaster",
+      "preventing a dangerous weapon from falling into the wrong hands",
+      "stopping a political uprising or revolution",
+      "stopping a rogue government agency or corporation",
+      "stopping a criminal mastermind from enacting their plan"
     ]
   },
   "plot.arthouse": {
@@ -4401,12 +4401,12 @@
     "description": "Introspective narratives focusing on emotional struggles, relationships, and personal crises",
     "total": 66,
     "examples": [
-      "grappling with grief",
-      "battling with a chronic illness",
-      "grappling with the monotony of a repetitive office routine",
-      "searching for connection in a deeply alienated modern metropolis",
-      "struggling with mental health issues",
-      "questioning societal beliefs and values"
+      "dealing with an unwanted pregnancy",
+      "struggling with poverty",
+      "facing discrimination based on race, gender or sexuality",
+      "unraveling the subtle threads of a shared family myth",
+      "navigating the quiet decay of a suburban marriage",
+      "forming a secret society"
     ]
   },
   "plot.fantasy": {
@@ -4415,12 +4415,12 @@
     "description": "Magical and supernatural adventures involving mythical creatures, curses, and epic quests",
     "total": 66,
     "examples": [
-      "navigating through a magical jungle or swamp",
-      "navigating the shifting rules of a court of fae nobility",
-      "dealing with the consequences of using dark magic",
-      "finding a hidden treasure or artifact",
-      "searching for a magical artifact",
-      "overcoming personal demons or fears"
+      "participating in a prophecy or destiny",
+      "closing a rift opening into the elemental plane of fire",
+      "retrieving a stolen treasure",
+      "fighting against an army of undead creatures",
+      "overcoming personal demons or fears",
+      "dealing with the aftermath of a spell gone wrong"
     ]
   },
   "plot.general": {
@@ -4429,12 +4429,12 @@
     "description": "A mix of everyday life events, personal goals, and lighthearted adventures",
     "total": 109,
     "examples": [
-      "attending a music festival",
-      "taking a trip through time",
-      "attending a high school reunion",
-      "dealing with a haunted house",
-      "escaping a cult",
-      "coaching an underdog youth sports team"
+      "going on a holiday",
+      "participating in a scavenger hunt",
+      "renovating a historic but run-down house",
+      "seeking revenge",
+      "participating in a charity walk",
+      "attending a music festival"
     ]
   },
   "plot.horror": {
@@ -4443,12 +4443,12 @@
     "description": "Horror and survival scenarios involving supernatural entities, monsters, and deadly environments",
     "total": 65,
     "examples": [
-      "trapped in a haunted asylum",
-      "fighting against an alien invasion",
-      "fighting against a mysterious entity",
-      "being pursued by an ancient woodland deity after trespassing",
-      "escaping from a mad scientist's laboratory",
-      "fighting against an evil spirit"
+      "battling a supernatural entity",
+      "escaping from a haunted house",
+      "fighting against a cult",
+      "investigating a mysterious ghost town",
+      "investigating a series of bizarre deaths",
+      "being pursued by an ancient woodland deity after trespassing"
     ]
   },
   "plot.musical": {
@@ -4457,12 +4457,12 @@
     "description": "Storylines focused on musical competitions, bands, solo artists, and creative collaborations",
     "total": 66,
     "examples": [
-      "reconciling a classic orchestra with a modern hip-hop group",
-      "staging an unauthorized underground musical",
-      "finding the courage to pursue their musical dreams",
-      "competing in a musical competition",
-      "finding success as a new musical act",
-      "competing in a high-stakes acapella championship"
+      "balancing a secret identity as a rising pop star and a normal student",
+      "competing for a prestigious scholarship at a music conservatory",
+      "finding their own unique sound",
+      "finding inspiration for new music",
+      "finding the courage to perform in public after a personal loss",
+      "finding the courage to experiment with different musical styles"
     ]
   },
   "plot.romance": {
@@ -4471,12 +4471,12 @@
     "description": "Romantic storylines about overcoming personal, social, and communication obstacles to find love",
     "total": 65,
     "examples": [
-      "surviving a test of love",
-      "dealing with jealousy or insecurity",
-      "falling in love despite initial doubts",
-      "falling in love with someone from a different background or culture",
-      "dealing with the stigma of interracial or lgbtq relationships",
-      "dealing with the challenges of a blended family"
+      "coping with infidelity or trust issues",
+      "overcoming communication issues or misunderstandings",
+      "navigating a romance that blooms during a scenic culinary tour",
+      "rekindling love after a period of distance",
+      "finding love despite personal or financial difficulties",
+      "dealing with relationship challenges or obstacles"
     ]
   },
   "plot.scifiCyberpunk": {
@@ -4485,12 +4485,12 @@
     "description": "Cyberpunk scenarios involving hacking, rogue AI, cyborgs, and dystopian corporate espionage",
     "total": 66,
     "examples": [
-      "negotiating with an underground dealer for illegal cybernetic upgrades",
-      "escaping from a virtual reality or simulation",
-      "investigating a cult that worships a rogue artificial intelligence",
+      "escaping from a virtual prison or detention center",
+      "discovering a ghost in the machine within a colossal city-wide mainframe",
+      "investigating a technological cover-up",
       "defending against a powerful ai or rogue program",
-      "escaping from a dangerous virtual game or simulation",
-      "searching for a way to save humanity from technological enslavement"
+      "overcoming addiction to virtual reality or technology",
+      "stealing advanced weapons or military technology"
     ]
   },
   "plot.scifi": {
@@ -4499,12 +4499,12 @@
     "description": "Science fiction scenarios featuring space exploration, alien encounters, and planetary disasters",
     "total": 185,
     "examples": [
-      "negotiating the release of human diplomats from an alien penal colony",
-      "investigating a space-based theft or sabotage",
-      "investigating a temporal anomaly that loops the same day on a spaceship",
-      "preventing a rogue asteroid from colliding with earth",
-      "participating in a space battle",
-      "negotiating a trade agreement with a cautious subterranean alien species"
+      "stopping a rogue ai from destroying humanity",
+      "a group of rebels attempt to overthrow a powerful cyborg empire",
+      "battling against alien races or space monsters",
+      "dealing with the consequences of space travel or time-travel",
+      "a group of survivors try to rebuild society after a massive emp destroys all technology",
+      "dealing with the consequences of a space-based weapon"
     ]
   },
   "plot.war": {
@@ -4513,12 +4513,12 @@
     "description": "Military and tactical operations including covert missions, sieges, and defensive stands",
     "total": 66,
     "examples": [
-      "defending a key position or stronghold",
-      "participating in a siege or assault",
-      "recovering a downed pilot from deep within enemy territory",
-      "stopping a traitor or mole within the group",
-      "negotiating a temporary ceasefire to evacuate wounded non-combatants",
-      "saving civilian lives during conflict"
+      "infiltrating a coastal artillery battery to disable its guns",
+      "securing a remote radio tower to restore allied communications",
+      "overcoming physical challenges in extreme conditions",
+      "surviving behind enemy lines",
+      "participating in a rescue mission",
+      "fighting on the front lines of a battle"
     ]
   },
   "science.astronomy": {
@@ -4527,12 +4527,12 @@
     "description": "Astronomical concepts, phenomena, and celestial structures like black holes and dark matter",
     "total": 54,
     "examples": [
-      "asteroid belt",
-      "galaxy",
-      "pulsar",
-      "kuiper belt",
-      "brown dwarf",
-      "uranus"
+      "mars",
+      "mercury",
+      "white dwarf",
+      "event horizon",
+      "big bang",
+      "cosmic microwave background"
     ]
   },
   "science.chemicalElement": {
@@ -4541,12 +4541,12 @@
     "description": "Various chemical elements from the periodic table",
     "total": 118,
     "examples": [
-      "mendelevium",
-      "argon",
-      "erbium",
-      "gold",
-      "astatine",
-      "francium"
+      "radium",
+      "boron",
+      "holmium",
+      "dubnium",
+      "hassium",
+      "cobalt"
     ]
   },
   "science.constellation": {
@@ -4555,12 +4555,12 @@
     "description": "Names of recognized star constellations in the night sky",
     "total": 88,
     "examples": [
-      "crux",
-      "puppis",
-      "ara",
-      "chamaeleon",
-      "equuleus",
-      "capricornus"
+      "lacerta",
+      "circinus",
+      "columba",
+      "caelum",
+      "auriga",
+      "canis minor"
     ]
   },
   "science.geometry": {
@@ -4569,12 +4569,12 @@
     "description": "Advanced mathematical shapes, fractals, attractors, and geometric concepts",
     "total": 117,
     "examples": [
-      "isometric",
-      "cellular automaton",
-      "cube",
-      "disdyakis dodecahedron",
-      "penrose stairs",
-      "polyhedra"
+      "klein bottle",
+      "strange attractor",
+      "platonic solid",
+      "knot theory",
+      "superellipse",
+      "truncated octahedron"
     ]
   },
   "science.isotope": {
@@ -4583,12 +4583,12 @@
     "description": "Specific radioactive and stable isotopes of various chemical elements",
     "total": 56,
     "examples": [
-      "carbon-13",
-      "barium-133",
-      "fluorine-18",
-      "radon-222",
-      "polonium-210",
-      "uranium-233"
+      "beryllium-10",
+      "sulfur-35",
+      "neptunium-237",
+      "promethium-147",
+      "aluminium-26",
+      "molybdenum-99"
     ]
   },
   "science.medicalImages": {
@@ -4597,12 +4597,12 @@
     "description": "Medical imaging techniques and diagnostic scanning procedures",
     "total": 45,
     "examples": [
-      "thyroid scan",
-      "ultrasound",
+      "4d ultrasound",
+      "3d ultrasound",
       "fmri",
-      "micro-ct",
-      "intraoral photography",
-      "pet-ct"
+      "echocardiography",
+      "ct scan",
+      "oct scan"
     ]
   },
   "science.planetBody": {
@@ -4611,12 +4611,12 @@
     "description": "Specific planets, moons, asteroids, and other named celestial bodies",
     "total": 224,
     "examples": [
-      "biela",
-      "lysithea",
-      "psr b1257+12 b",
-      "priamus",
-      "mimas",
-      "praamzius"
+      "ceres",
+      "carme",
+      "titania",
+      "rhea",
+      "trappist-1c",
+      "neat"
     ]
   },
   "science.robotType": {
@@ -4625,12 +4625,12 @@
     "description": "Various types of industrial, agricultural, and specialized autonomous robots and drones",
     "total": 328,
     "examples": [
-      "cobot",
-      "robotic turret",
-      "industrial robot",
-      "robot bartender",
-      "cryobot",
-      "deep-space probe"
+      "telepresence robot",
+      "edible robot",
+      "gecko-inspired climber",
+      "assistive robot",
+      "autonomous surface vehicle",
+      "lunar rover"
     ]
   },
   "science.scifiTech": {
@@ -4639,12 +4639,12 @@
     "description": "Fictional science fiction technology, gadgets, and futuristic devices",
     "total": 63,
     "examples": [
-      "android",
+      "carbonite chamber",
       "replicator",
-      "quantum computer",
-      "matter replicator",
-      "warp gate",
-      "brain-computer interface"
+      "disintegrator ray",
+      "gauss rifle",
+      "time machine",
+      "cryo-sleep chamber"
     ]
   },
   "set.describeStyle": {
@@ -4653,12 +4653,12 @@
     "description": "Eclectic art styles, hashtags, and artist names used in AI image generation",
     "total": 17756,
     "examples": [
-      "zbrush",
-      "mediterranean landscapes",
-      "petrina hicks",
-      "parmigianino",
-      "neoclassical influences",
-      "norman parkinson"
+      "james nares",
+      "abstracted figurative forms",
+      "dark aquamarine and gray",
+      "bold spray-painted letters",
+      "dark yellow and black",
+      "dark green and orange"
     ]
   },
   "set.describeSubject": {
@@ -4667,12 +4667,12 @@
     "description": "Highly specific, random AI-generated image prompts and surreal subject descriptions",
     "total": 139614,
     "examples": [
-      "an image of a wisteria garden",
-      "a design for a futuristic tower made from glass and steel",
-      "a 3d image of a simple wooden structure and stairs",
-      "a black and white picture of a small building on a beach with chairs around it",
-      "a black knight wearing gold armor with a sword",
-      "a beautiful woman in black gothic makeup and makeup with elaborate make ups"
+      "a young muslim woman stands near a table wearing traditional dress",
+      "a painting showing a hand holding an arrow",
+      "a picture of a valley with mountains and the words ugrave",
+      "a painting shows a couple walking by the seaside together",
+      "a man in a suit with his arms crossed",
+      "a man in a suit and tie is talking"
     ]
   },
   "set.memeDescription": {
@@ -4682,11 +4682,11 @@
     "total": 44,
     "examples": [
       "american chopper argument meme - father and son yelling, throwing chair",
-      "harambe meme - gorilla who was shot, became internet martyr",
-      "expanding brain meme - four panels showing increasingly glowing brains",
       "bernie sanders \"i am once again asking\" meme - bernie asking for financial support",
-      "here comes dat boi meme - same as dat boi",
-      "dolan meme - poorly drawn donald duck with absurd captions"
+      "first world problems meme - woman crying over trivial issues",
+      "disaster girl meme - young girl smirking in front of burning house",
+      "gibby on icarly \"i don't care if you broke your elbow\" meme - gibby responding callously",
+      "galaxy brain meme - increasingly glowing brains with complex ideas"
     ]
   },
   "set.meme": {
@@ -4696,11 +4696,11 @@
     "total": 44,
     "examples": [
       "area 51 raid meme",
-      "gibby on icarly \"i don't care if you broke your elbow\" meme",
-      "i don't always",
-      "cash me outside meme",
-      "bernie sanders \"i am once again asking\" meme",
-      "blinking white guy meme"
+      "ermahgerd meme",
+      "first world problems meme",
+      "felt cute might delete later meme",
+      "blinking white guy meme",
+      "ceiling cat meme"
     ]
   },
   "set.moviegenBench": {
@@ -4709,12 +4709,12 @@
     "description": "MovieGen Video Bench contains 1003 diverse prompts testing various aspects including human activities (motion, emotions), animals, nature/scenery, physics (fluids, gravity, collisions), and unusual subjects/activities. The prompts provide comprehensive coverage across high, medium and low motion scenarios.\n",
     "total": 1003,
     "examples": [
-      "A floating island in the sky with waterfalls cascading into the clouds.",
-      "A bustling ancient marketplace with merchants selling spices and fabrics.",
-      "A tracking shot following a skateboarder performing tricks down a city street, keeping pace with their fluid movements.",
-      "A person playing a grand piano underwater in a crystal-clear lake.",
-      "A person baking bread in an oven powered by dragon fire.",
-      "A thin sheet of ice on a lake cracking and breaking as the sun warms it, creating a mosaic of shifting patterns."
+      "A woman is search her bag trying to find something.",
+      "A man talking animatedly on the phone, his mouth moving rapidly.",
+      "Close-up of a bright blue parrot's feathers glittering in the light, showing its unique plumage and vibrant colors",
+      "A woman applying bright red lipstick in front of a mirror.",
+      "A man is playing the drums under the water",
+      "Top view timelapse video of an artwork being drawn by hand with colored markers, the artwork shows a dragon flying over a castle"
     ]
   },
   "set.parti": {
@@ -4723,12 +4723,12 @@
     "description": "PartiPrompts (P2) is a rich set of over 1600 prompts in English. P2 can be used to measure model capabilities across various categories and challenge aspects.\n",
     "total": 1632,
     "examples": [
-      "a circular brown trash bin in front of a brick wall",
-      "a cup of boba",
-      "the city of London on Mars",
-      "inertia",
-      "a hamster dragon",
-      "A raccoon wearing formal clothes, wearing a tophat and holding a cane. The raccoon is holding a garbage bag. Oil painting in the style of pixel art."
+      "a robot cooking in the kitchen",
+      "the planet Jupiter",
+      "A cat that has black fur bats a red Christmas ornament that has silver sparkles.",
+      "a white pawn attacking a black bishop",
+      "air",
+      "A bare kitchen has wood cabinets and white appliances"
     ]
   },
   "sport.all": {
@@ -4737,12 +4737,12 @@
     "description": "Various athletic sports, gymnastics, and competitive physical activities",
     "total": 470,
     "examples": [
-      "taekwondo",
-      "extreme ironing",
-      "high jump",
-      "endurance riding",
-      "ice cross downhill",
-      "marathon"
+      "air hockey",
+      "bobsleigh",
+      "cross-country running",
+      "croquet",
+      "chess boxing",
+      "canyoning"
     ]
   },
   "thing.adjective": {
@@ -4751,12 +4751,12 @@
     "description": "Adjectives describing physical textures and material conditions",
     "total": 71,
     "examples": [
-      "polished",
-      "shiny",
-      "smooth",
-      "thorny",
-      "flaky",
-      "gauzy"
+      "elastic",
+      "distressed",
+      "gritty",
+      "rusty",
+      "folded",
+      "spongy"
     ]
   },
   "thing.armor": {
@@ -4765,12 +4765,12 @@
     "description": "Historical and modern protective armor, helmets, and tactical vests",
     "total": 171,
     "examples": [
-      "laminar armor",
-      "ballistic helmet",
-      "chainmail armor",
-      "besagew",
-      "splint mail",
-      "bronze armor"
+      "adrian helmet",
+      "sode",
+      "lorica hamata",
+      "pig-faced bascinet",
+      "linothorax",
+      "banded mail"
     ]
   },
   "thing.city": {
@@ -4779,12 +4779,12 @@
     "description": "Urban infrastructure, commercial buildings, and city street elements",
     "total": 216,
     "examples": [
-      "billboard",
-      "fountain",
-      "park",
-      "thrift store",
-      "phone booth",
-      "dry cleaner"
+      "greek restaurant",
+      "street vendor cart",
+      "statue",
+      "skyscraper",
+      "overpass",
+      "sidewalk"
     ]
   },
   "thing.everyday": {
@@ -4793,12 +4793,12 @@
     "description": "Common household objects, appliances, and everyday personal items",
     "total": 243,
     "examples": [
-      "washing up liquid",
-      "harddrive",
-      "air freshener",
-      "dental floss",
-      "can",
-      "boat"
+      "drill",
+      "books",
+      "desk lamp",
+      "tea towel",
+      "shoes",
+      "rags"
     ]
   },
   "thing.fabric": {
@@ -4807,12 +4807,12 @@
     "description": "Various natural and synthetic textiles and fabric materials",
     "total": 56,
     "examples": [
-      "bamboo fabric",
-      "voile",
+      "denim",
+      "duck cloth",
+      "houndstooth",
       "mohair",
-      "damask",
-      "merino wool",
-      "flannel"
+      "rayon",
+      "silk"
     ]
   },
   "thing.fantasy": {
@@ -4821,12 +4821,12 @@
     "description": "Fantasy characters, magical items, and mythical creatures",
     "total": 146,
     "examples": [
-      "figure",
-      "moonbeam",
-      "gargoyle",
-      "dwarf",
-      "king",
-      "defender"
+      "mystic",
+      "defender",
+      "energy",
+      "explosion",
+      "breaking point",
+      "limit"
     ]
   },
   "thing.furniture": {
@@ -4835,12 +4835,12 @@
     "description": "Various types of indoor and outdoor seating and storage furniture",
     "total": 58,
     "examples": [
-      "dining chair",
-      "dresser",
-      "futon",
-      "bunk bed",
+      "chesterfield sofa",
+      "canopy bed",
+      "adirondack chair",
+      "pew",
       "sofa",
-      "couch"
+      "armchair"
     ]
   },
   "thing.gadget": {
@@ -4849,12 +4849,12 @@
     "description": "Electronic devices, musical gadgets, and modern technological equipment",
     "total": 417,
     "examples": [
-      "ct scanner",
-      "electronic leaf area meter",
-      "slide projector",
-      "digital tv antenna",
-      "digital snake (audio)",
-      "cordless phone"
+      "hearing aid",
+      "bluetooth audio receiver",
+      "arcade game machine",
+      "external hard drive",
+      "digital egg incubator",
+      "electronic plant watering system"
     ]
   },
   "thing.gemstone": {
@@ -4863,12 +4863,12 @@
     "description": "Precious and semi-precious gemstones and mineral crystals",
     "total": 59,
     "examples": [
-      "bloodstone",
-      "morganite",
-      "labradorite",
-      "aventurine",
-      "ruby",
-      "tourmaline"
+      "beryl",
+      "sodalite",
+      "hiddenite",
+      "onyx",
+      "garnet",
+      "spinel"
     ]
   },
   "thing.icon": {
@@ -4877,12 +4877,12 @@
     "description": "Common digital interface icons and simple graphic symbols",
     "total": 132,
     "examples": [
-      "newspaper",
-      "folder",
-      "eye",
-      "heart",
-      "snowflake",
-      "upload"
+      "lightbulb",
+      "battery",
+      "envelope",
+      "shopping cart",
+      "phone",
+      "briefcase"
     ]
   },
   "thing.material": {
@@ -4891,12 +4891,12 @@
     "description": "Various raw materials, plastics, stones, and crafting substances",
     "total": 68,
     "examples": [
-      "resin",
       "acrylic",
-      "leather material",
-      "suede material",
-      "plaster material",
-      "obsidian"
+      "acrylic plastic",
+      "marble",
+      "brass",
+      "stucco",
+      "titanium"
     ]
   },
   "thing.metal": {
@@ -4905,12 +4905,12 @@
     "description": "Various metallic elements, alloys, and metal finishes",
     "total": 273,
     "examples": [
-      "copper",
-      "blued steel",
-      "aluminum",
-      "high-speed steel",
-      "matte aluminum",
-      "anodized titanium"
+      "iridescent metal",
+      "anodized aluminum",
+      "ruthenium",
+      "mischmetal",
+      "oxidized bronze",
+      "mirror-polished steel"
     ]
   },
   "thing.office": {
@@ -4919,12 +4919,12 @@
     "description": "Financial tools, office supplies, and business-related items",
     "total": 68,
     "examples": [
-      "protractor",
-      "laminator",
-      "business card",
+      "clipboard",
+      "stock chart",
+      "magnifying glass",
       "abacus",
-      "tape dispenser",
-      "file cabinet"
+      "protective gloves",
+      "adding machine"
     ]
   },
   "thing.pattern": {
@@ -4933,12 +4933,12 @@
     "description": "Decorative geometric, textile, and camouflage visual patterns",
     "total": 115,
     "examples": [
-      "calico",
-      "arabesque",
-      "regimental stripe",
-      "fleur-de-lis",
-      "floral",
-      "buffalo check"
+      "awning stripe",
+      "gingham",
+      "sashiko",
+      "jacquard",
+      "suzani",
+      "dogtooth"
     ]
   },
   "thing.scary": {
@@ -4947,12 +4947,12 @@
     "description": "Creepy locations, paranormal entities, and horror-themed concepts",
     "total": 211,
     "examples": [
+      "possessed vehicles",
       "boogeyman",
-      "undead armies",
-      "eerie silence",
-      "banshee",
-      "bewitched places",
-      "blood sacrifices"
+      "flickering lights",
+      "ghostly apparitions in photographs",
+      "dark tunnels",
+      "grim reaper"
     ]
   },
   "thing.sciFi": {
@@ -4961,12 +4961,12 @@
     "description": "Futuristic technology, AI systems, and science fiction transportation",
     "total": 204,
     "examples": [
-      "autonomous deep-sea exploration vehicle",
-      "service robot",
-      "teleportation network hub",
-      "holographic display",
-      "ai building construction system",
-      "3d printing"
+      "force field generator",
+      "space rescue pod",
+      "ai construction machine",
+      "cybernetic implant",
+      "disaster response robot",
+      "human augmentation device"
     ]
   },
   "thing.space": {
@@ -4975,12 +4975,12 @@
     "description": "Celestial bodies, nebulae, moons, stars, and cosmic phenomena",
     "total": 158,
     "examples": [
-      "supermassive black hole",
-      "gamma-ray burst",
-      "ledaxa",
-      "gravitational wave",
-      "iocaste",
-      "red giant"
+      "millisecond pulsar",
+      "soft gamma repeater",
+      "chaldene",
+      "molecular cloud",
+      "orthosie",
+      "harpalyke"
     ]
   },
   "thing.summer": {
@@ -4989,12 +4989,12 @@
     "description": "Summer recreation items, beach gear, and outdoor accessories",
     "total": 70,
     "examples": [
-      "cotton candy",
-      "beach towel",
-      "cooler",
+      "shorts",
+      "tanning lotion",
+      "picnic blanket",
       "paddleboard",
-      "pool noodle",
-      "lawn chair"
+      "sandals",
+      "s'mores"
     ]
   },
   "thing.surfaceFinish": {
@@ -5003,12 +5003,12 @@
     "description": "Material surface treatments, textures, and manufacturing finishes",
     "total": 164,
     "examples": [
-      "crackle-glazed",
-      "soft-touch",
-      "calendered",
-      "hard-coat-anodized",
-      "vapor-polished",
-      "flaked"
+      "distressed",
+      "combed",
+      "aqueous-coated",
+      "board-marked",
+      "eggshell",
+      "honed"
     ]
   },
   "thing.weapon": {
@@ -5017,12 +5017,12 @@
     "description": "Historical melee, ranged, and medieval combat weapons",
     "total": 55,
     "examples": [
+      "tomahawk",
+      "greataxe",
+      "mace weapon",
       "quarterstaff",
-      "bearded axe",
-      "spatha",
-      "spear",
-      "dirk",
-      "trident"
+      "scimitar",
+      "halberd"
     ]
   },
   "thing.woodType": {
@@ -5031,12 +5031,12 @@
     "description": "Various tree species and types of woodworking lumber",
     "total": 150,
     "examples": [
-      "sakura wood",
-      "poplar",
-      "mango wood",
-      "pecan",
-      "gidgee",
-      "acacia"
+      "pearwood",
+      "butternut",
+      "lyptus",
+      "curly maple",
+      "greenheart",
+      "ziricote"
     ]
   },
   "time.century": {
@@ -5045,12 +5045,12 @@
     "description": "Specific centuries spanning BC and AD historical timelines",
     "total": 37,
     "examples": [
-      "7th century",
-      "24th century",
-      "3rd century",
-      "20th century",
-      "6th century",
-      "12th century bc"
+      "11th century",
+      "1st century",
+      "2nd century",
+      "4th century",
+      "19th century",
+      "3rd century"
     ]
   },
   "time.dayOfYear": {
@@ -5059,12 +5059,12 @@
     "description": "Specific calendar dates and notable days of the year",
     "total": 387,
     "examples": [
-      "june 6",
-      "august 3",
-      "july 17",
-      "august 7",
-      "april 6",
-      "easter sunday"
+      "november 23",
+      "june 22",
+      "may 16",
+      "may 25",
+      "may 3",
+      "may 29"
     ]
   },
   "time.decade": {
@@ -5073,12 +5073,12 @@
     "description": "Specific decades ranging from the 1800s to the 2050s",
     "total": 35,
     "examples": [
-      "20s",
-      "1820s",
-      "1930s",
-      "1940s",
-      "1990s",
-      "50s"
+      "40s",
+      "70s",
+      "1860s",
+      "1800s",
+      "1890s",
+      "1930s"
     ]
   },
   "time.era": {
@@ -5087,12 +5087,12 @@
     "description": "Historical periods, cultural eras, and specific global conflicts",
     "total": 118,
     "examples": [
-      "inca empire",
-      "age of exploration",
-      "war of the spanish succession",
-      "russo-japanese war",
-      "naturalism",
-      "balkan wars"
+      "early christianity",
+      "dark ages",
+      "mesolithic era",
+      "edo period",
+      "tanzimat era in ottoman empire",
+      "aztec empire"
     ]
   },
   "time.festival": {
@@ -5101,12 +5101,12 @@
     "description": "Global cultural, religious, and film festivals and holidays",
     "total": 196,
     "examples": [
-      "fete des lumieres",
-      "saint lucia's day",
-      "beltane",
-      "cologne carnival",
-      "all saints' day",
-      "bonnaroo"
+      "ratha yatra",
+      "new year's eve",
+      "obon",
+      "nebuta matsuri",
+      "ugadi",
+      "thingyan"
     ]
   },
   "time.historicalEra": {
@@ -5115,12 +5115,12 @@
     "description": "Historical empires, dynasties, and major technological or cultural ages",
     "total": 148,
     "examples": [
-      "elizabethan era",
-      "late antiquity",
-      "post-cold war era",
-      "parthian empire",
-      "cold war era",
-      "old kingdom of egypt"
+      "digital age",
+      "regency era",
+      "reconstruction era",
+      "nara period",
+      "ancient rome",
+      "abbasid caliphate"
     ]
   },
   "time.season": {
@@ -5129,12 +5129,12 @@
     "description": "Astronomical, cultural, commercial, agricultural, and natural seasons",
     "total": 241,
     "examples": [
-      "fog season",
-      "st. luke's little summer",
-      "birak",
-      "firefly season",
-      "freeze-up season",
-      "flood season"
+      "berry season",
+      "mid-winter",
+      "pollen season",
+      "post-monsoon season",
+      "shearing season",
+      "tick season"
     ]
   },
   "time.timeOfDay": {
@@ -5143,12 +5143,12 @@
     "description": "Specific times of day and associated lighting or atmospheric conditions",
     "total": 201,
     "examples": [
-      "afternoon heat",
-      "midday heat",
-      "anticrepuscular rays",
-      "dead of night",
-      "late morning",
-      "early hours"
+      "broad daylight",
+      "sunset light",
+      "morning fog",
+      "morning frost",
+      "mid-afternoon",
+      "nightfall"
     ]
   },
   "time.year": {
@@ -5157,12 +5157,12 @@
     "description": "Specific individual years spanning the 19th to 21st centuries",
     "total": 251,
     "examples": [
-      "1966",
-      "2050",
+      "1934",
+      "1971",
+      "1952",
+      "1960",
       "1853",
-      "1906",
-      "1908",
-      "1865"
+      "1850"
     ]
   },
   "typography.feature": {
@@ -5171,12 +5171,12 @@
     "description": "Typographic design features, spacing, and specific letterform characteristics",
     "total": 69,
     "examples": [
-      "contextual shaping",
-      "hanging figures",
-      "extended width",
-      "single-story g",
-      "balanced letterforms",
-      "distinctive alternates"
+      "monolinear strokes",
+      "graceful curves",
+      "tall ascenders",
+      "irregular letterforms",
+      "optical sizing",
+      "tabular figures"
     ]
   },
   "typography.fontType": {
@@ -5185,12 +5185,12 @@
     "description": "Typographic design movements and historical font classifications",
     "total": 62,
     "examples": [
-      "decorative typography",
-      "art deco typography",
-      "rotunda typography",
-      "art nouveau typography",
-      "lombardic typography",
-      "graffiti typography"
+      "blackletter typography",
+      "old style typography",
+      "transitional typography",
+      "gothic sans typography",
+      "fraktur typography",
+      "glitch typography"
     ]
   },
   "typography.font": {
@@ -5199,12 +5199,12 @@
     "description": "Specific named typefaces and popular font families",
     "total": 89,
     "examples": [
-      "minion font",
-      "pt sans font",
-      "roboto condensed font",
-      "source code pro font",
-      "space mono font",
-      "raleway font"
+      "copperplate font",
+      "ubuntu font",
+      "pacifico font",
+      "garamond font",
+      "univers font",
+      "fira code font"
     ]
   },
   "typography.style": {
@@ -5213,12 +5213,12 @@
     "description": "Font weights, widths, and specific stylistic typeface variations",
     "total": 76,
     "examples": [
-      "textured style font",
-      "all caps style font",
-      "backslanted style font",
-      "compressed style font",
-      "debossed style font",
-      "expanded bold style font"
+      "display style font",
+      "black style font",
+      "medium italic style font",
+      "light italic style font",
+      "distressed style font",
+      "backslanted style font"
     ]
   },
   "typography.typefaceStyle": {
@@ -5227,12 +5227,12 @@
     "description": "Various font styles, historical typefaces, and typographic classifications",
     "total": 69,
     "examples": [
-      "bastarda",
-      "neo-grotesque",
-      "modern serif",
-      "art nouveau font",
-      "condensed",
-      "transitional serif"
+      "3d lettering font",
+      "art deco",
+      "humanist serif",
+      "expanded",
+      "inline",
+      "grotesque"
     ]
   },
   "typography.wordArt": {
@@ -5241,12 +5241,12 @@
     "description": "Textures, materials, and visual effects applied to text and typography",
     "total": 137,
     "examples": [
-      "shadowed text",
-      "frayed text",
-      "anaglyph 3d text",
-      "denim text",
-      "argyle text",
-      "brushstroke text"
+      "rotated text",
+      "holographic foil text",
+      "jigsaw text",
+      "burning text",
+      "brushstroke text",
+      "embossed text"
     ]
   },
   "vehicle.aircraft": {
@@ -5255,12 +5255,12 @@
     "description": "Various types of airplanes, helicopters, and specialized aerial vehicles",
     "total": 126,
     "examples": [
-      "rocket",
-      "skycar",
-      "maritime patrol aircraft",
-      "water bomber",
-      "jet fighter",
-      "utility helicopter"
+      "tiltwing",
+      "unmanned combat aerial vehicle",
+      "trainer aircraft",
+      "hoverbike",
+      "bush plane",
+      "passenger plane"
     ]
   },
   "vehicle.car": {
@@ -5269,12 +5269,12 @@
     "description": "Specific modern car makes and models from various automotive manufacturers",
     "total": 329,
     "examples": [
-      "chevrolet camaro",
-      "subaru crosstrek",
-      "jaguar xj",
-      "fiat panda",
-      "acura rdx",
-      "acura nsx"
+      "chevrolet tahoe",
+      "kia sorento",
+      "acura nsx",
+      "chevrolet bolt",
+      "cadillac xt4",
+      "bmw i4"
     ]
   },
   "vehicle.classicCar": {
@@ -5283,12 +5283,12 @@
     "description": "Specific vintage, antique, and classic car models with their production years",
     "total": 161,
     "examples": [
-      "1982 porsche 956",
-      "1924 bentley 3 litre",
-      "1918 ford model t",
-      "1923 mercer series 6 raceabout",
-      "1922 studebaker special six",
-      "1917 chevrolet model d"
+      "1933 auburn 12-165 speedster",
+      "1904 rolls-royce 10 hp",
+      "1914 buick model b-24",
+      "1916 cadillac type 53",
+      "1929 cadillac series 341a",
+      "1929 duesenberg model j"
     ]
   },
   "vehicle.famousCar": {
@@ -5297,12 +5297,12 @@
     "description": "Iconic cars and fictional vehicles from popular movies and film franchises",
     "total": 50,
     "examples": [
-      "the audi r8 from iron man",
+      "the ecto-1 from ghostbusters",
+      "the volkswagen beetle from herbie goes to monte carlo",
+      "kitt from knight rider",
       "bumblebee from transformers",
-      "the delorean from back to the future part ii",
-      "finn mcmissile from cars 2",
-      "the ecto-1 from ghostbusters (2016)",
-      "pursuit special from mad max"
+      "the 1994 toyota supra from the fast and the furious",
+      "the a-team van from the a-team"
     ]
   },
   "vehicle.fastCar": {
@@ -5311,12 +5311,12 @@
     "description": "Specific models of high-performance sports cars, supercars, and luxury vehicles",
     "total": 98,
     "examples": [
-      "porsche carrera gt",
-      "aston martin db11",
-      "audi rs7",
-      "bentley mulsanne",
-      "ferrari fxx evoluzione",
-      "ferrari gtc4lusso"
+      "aston martin vantage",
+      "mclaren 650s",
+      "rolls-royce ghost",
+      "aston martin db7",
+      "bugatti bolide",
+      "koenigsegg cc850"
     ]
   },
   "vehicle.motorcycle": {
@@ -5325,12 +5325,12 @@
     "description": "Various styles, classes, and specialized types of motorcycles and motorbikes",
     "total": 121,
     "examples": [
-      "classic motorcycle",
-      "dresser",
-      "touring motorcycle",
-      "vespa",
-      "sidecar rig",
-      "flat tracker"
+      "scooter sidecar",
+      "track-only bike",
+      "utility motorcycle",
+      "street tracker",
+      "retro motorcycle",
+      "touring motorcycle"
     ]
   },
   "vehicle.spacecraft": {
@@ -5339,12 +5339,12 @@
     "description": "Sci-fi spacecraft, starships, and specialized futuristic space vehicles",
     "total": 56,
     "examples": [
-      "explorer vessel",
-      "cruiser spacecraft",
-      "rover",
-      "deep-space telescope",
-      "jump ship",
-      "scout ship"
+      "cruiser",
+      "seed ship",
+      "cargo hauler",
+      "ufo",
+      "stealth ship",
+      "mining barge"
     ]
   },
   "vehicle.type": {
@@ -5353,12 +5353,12 @@
     "description": "Broad categories of land, air, and water transportation vehicles",
     "total": 116,
     "examples": [
-      "train",
-      "cable car",
+      "paraglider",
+      "front-end loader",
       "amphibious vehicle",
-      "funicular",
-      "suv",
-      "moon buggy"
+      "helicopter",
+      "camper",
+      "garbage truck"
     ]
   },
   "vehicle.watercraft": {
@@ -5367,12 +5367,12 @@
     "description": "Various types of boats, ships, and marine vessels",
     "total": 188,
     "examples": [
-      "kayak",
-      "ocean liner",
-      "cog",
-      "baidarka",
-      "yawl",
-      "pocket battleship"
+      "balsa raft",
+      "aircraft carrier",
+      "tall ship",
+      "scow",
+      "corvette",
+      "luxury yacht"
     ]
   },
   "videoGame.action": {
@@ -5381,12 +5381,12 @@
     "description": "In-game character actions, abilities, and mechanics in video games",
     "total": 314,
     "examples": [
-      "pushing and pulling boxes",
-      "lock-on targeting",
-      "astral projection",
-      "building",
-      "checking inventory",
-      "parachuting"
+      "levitating",
+      "meditating for mana regeneration",
+      "performing a super sprint",
+      "practicing wand movements",
+      "scaling walls",
+      "playing a mini-game"
     ]
   },
   "videoGame.designer": {
@@ -5395,12 +5395,12 @@
     "description": "Names of prominent real-world video game designers and directors",
     "total": 68,
     "examples": [
-      "suda51",
-      "alex rigopulos",
-      "jordan mechner",
-      "chris roberts",
-      "eiji aonuma",
-      "eric chahi"
+      "lucas pope",
+      "peter mcconnell",
+      "tetsuya mizuguchi",
+      "keiji inafune",
+      "ken levine",
+      "satoshi tajiri"
     ]
   },
   "videoGame.engine": {
@@ -5409,12 +5409,12 @@
     "description": "Software frameworks and game engines used for developing video games",
     "total": 68,
     "examples": [
-      "fox engine",
-      "aurora engine",
-      "eclipse engine",
-      "vision engine",
-      "dunia engine",
-      "amazon lumberyard"
+      "monogame",
+      "build engine",
+      "lithtech engine",
+      "gamebryo",
+      "anvilnext",
+      "love2d"
     ]
   },
   "videoGame.game": {
@@ -5423,12 +5423,12 @@
     "description": "Titles of popular video game franchises and specific game releases",
     "total": 319,
     "examples": [
-      "portal",
-      "metro: exodus",
-      "mortal kombat 3",
-      "terraria",
-      "nhl",
-      "mortal kombat ii"
+      "just cause",
+      "earthbound",
+      "the legend of zelda",
+      "need for speed",
+      "sayonara wild hearts",
+      "nioh"
     ]
   },
   "videoGame.region": {
@@ -5437,12 +5437,12 @@
     "description": "Fictional environments, biomes, and level themes found in video games",
     "total": 118,
     "examples": [
-      "solar kingdom",
-      "candy kingdom",
-      "mushroom city",
-      "aerial region",
-      "industrial kingdom",
-      "vineyard kingdom"
+      "ancient forest",
+      "alpine region",
+      "atlantis region",
+      "mystic forest",
+      "coral kingdom",
+      "ninja region"
     ]
   },
   "word.adjective": {
@@ -5451,12 +5451,12 @@
     "description": "Various descriptive adjectives ranging from anatomical to behavioral",
     "total": 4980,
     "examples": [
-      "malposed",
-      "naval",
-      "gloomy",
-      "auxiliary",
-      "aristotelian",
-      "agrarian"
+      "eminent",
+      "diverse",
+      "divine",
+      "coercive",
+      "deaf",
+      "dramatic"
     ]
   },
   "word.adverb": {
@@ -5465,12 +5465,12 @@
     "description": "Assorted adverbs modifying actions, states, or qualities",
     "total": 1798,
     "examples": [
-      "overboard",
-      "responsibly",
-      "reliably",
-      "now",
-      "plainly",
-      "personally"
+      "aft",
+      "ceaselessly",
+      "chemically",
+      "equitably",
+      "elaborately",
+      "inordinately"
     ]
   },
   "word.noun": {
@@ -5479,12 +5479,12 @@
     "description": "A diverse mix of concrete objects, animals, and abstract conceptual nouns",
     "total": 24389,
     "examples": [
-      "admire",
-      "astilbe",
-      "chirping",
-      "imp",
-      "grass",
-      "roadbed"
+      "four",
+      "subcompact",
+      "city",
+      "chlorpyrifos",
+      "evolutionist",
+      "colossus"
     ]
   },
   "word.onomatopoeia": {
@@ -5493,12 +5493,12 @@
     "description": "Sound-imitating words including animal noises, human vocalizations, and impact sounds",
     "total": 159,
     "examples": [
-      "coo",
       "gurgle",
-      "bonk",
-      "flap",
-      "flutter",
-      "bash"
+      "ribbit",
+      "clang",
+      "jangle",
+      "boohoo",
+      "crackle"
     ]
   },
   "word.verb": {
@@ -5507,12 +5507,12 @@
     "description": "Action words and verb forms across various tenses including past and gerunds",
     "total": 9950,
     "examples": [
-      "waver",
-      "haying",
-      "dive",
-      "flatter",
-      "eaten",
-      "immersed"
+      "grabbed",
+      "planned",
+      "abhorred",
+      "dying",
+      "bag",
+      "barge"
     ]
   }
 }

--- a/lists/fiction/alien-predator.yml
+++ b/lists/fiction/alien-predator.yml
@@ -3,60 +3,150 @@ title: Alien and Predator names
 category: fiction
 description: "Places, species, factions, creatures, ships, and artifacts from Alien and Predator fiction"
 ---
+85
 acheron
 alien queen
 amanda ripley
+apone
+ash
 berserker predator
+bg-386
+bio-mask
 bioweapon division
+bishop
+black liquid
+brett
 bug hunt
+burke
+call
+ceremonial dagger
+charlie holloway
 chestburster
+christie
 city hunter
 clan ship
+cllemens
 cloaking device
 colonial administration
 colonial marines
 combistick
+cuchillo
+dallas
+daniels
+danny boyer
+david 8
 deacon
 derelict ship
+dillon
+dr. wren
 drone xenomorph
+elgyn
+elizabeth shaw
 ellen ripley
+empress
 engineer
+engineer juggernaut
 engineer temple
+engineers
 facehugger
+fiorina 'fury' 161
 fiorina 161
 fury 161
+garber
+gorman
 hadley's hope
+hammerpede
+hanzo
+harrigan
+hicks
+hish-qu-ten
 hive
+hudson
 hunter's moon
+isabelle
 isolation
+janek
+jerry lambert
+johan
 jungle hunter
+kane
 katanga
+keyes
+lambert
+leona cantrell
+lope
 lv-223
 lv-426
+m240 incinerator unit
+m41a pulse rifle
+m577 apc
 mars base
+medicomp
+meredith vickers
+mombassa
+motion tracker
+naru
 neomorph
 netgun
+newt
+nikolai
 nostromo
+oram
+origae-6
 ovomorph
+parker
+pathogen
+peter weyland
+plasma caster
+power loader
 praetorian
 predalien
 predator
 prometheus
+protomorph
 queen alien
 queen mother
+rebecca jorden
+royce
+ryushi
+scimitar blade
 seegson
+seegson corporation
+seegson sevastopol
+self-destruct device
+sevastopol station
+shoulder cannon
+smart disc
 smartgun
 space jockey
+space jockeys
+stans
 sulaco
 synthetic
+taabe
+tennesse
+the black ooze
 the company
+three world empire
+trilobite
+united americas
 uscss covenant
 uscss nostromo
 uscss prometheus
+uss sulaco
+uss veracruz
+vasquez
+vriess
+walter
+wey-yu
 weyland corporation
 weyland industries
 weyland-yutani
+weyland-yutani corporation
+wrist gauntlet
 xenomorph
 xenomorph hive
+xenomorph xx121
 yautja
 yautja prime
+zeta ii reticuli

--- a/lists/fiction/amber.yml
+++ b/lists/fiction/amber.yml
@@ -3,10 +3,15 @@ title: Amber names
 category: fiction
 description: "Places, powers, factions, and concepts from Roger Zelazny's Chronicles of Amber"
 ---
+abyss
 amber
+arden
+arthur
 avernus
 bayle
 benedict
+bill roth
+black road
 black zone
 bleys
 brand
@@ -18,11 +23,15 @@ castle amber
 chaos
 coral
 corwin
+courts of chaos
 dalt
 dara
 deirdre
 delwin
+delwin and sand
 dworkin
+dworkin barimen
+dybele
 eric
 faiella-bionin
 fiona
@@ -31,26 +40,38 @@ frakir
 ganelon
 gerard
 ghostwheel
+grayswandir
 hellrides
+hug hug
 jasra
+jewel of judgment
+jopin
 julia barnes
 julian
 kashfa
 keep of the four worlds
 lancelot
+lewilla
+logrus
 lorraine
 luke
+luke raynard
 mandor
 martin
 mauve zone
+merle corey
 merlin
+moire
 nayda
 oberon
 pattern
 patternfall
+primal pattern
 random
 rebma
+reinal
 rinaldo
+sand
 shadow
 shadow earth
 spikard
@@ -59,6 +80,7 @@ the abyss
 the black road
 the courts of chaos
 the jewel of judgment
+the logrus
 the pattern
 the primal pattern
 the serpent
@@ -66,5 +88,9 @@ the trumps
 the unicorn
 tir-na nog'th
 trump gate
+unicorn
+vialle
 werewindle
+ygg
 ysabel
+zanth

--- a/lists/fiction/asoiaf.yml
+++ b/lists/fiction/asoiaf.yml
@@ -4,124 +4,239 @@ category: fiction
 description: "Places, houses, peoples, and creatures from A Song of Ice and Fire"
 ---
 acorn hall
+amberly
+antlers
+ar noy
+ashemark
 ashford
 asshai
 astapor
 aurochs
+bandallon
+banefort
+barrowton
 basilisk
+basilisk isles
 bear island
 bitterbridge
+blackcrown
 blackhaven
 blackwater bay
+blackwater rush
+blue fork
 braavos
+brennan
 brightwater keep
+brindlewood
+broken arm
+brownhill
+cape wrath
+castamere
 casterly rock
 castle black
 cave lion
 children of the forest
+chroyane
 cider hall
+claw isle
+cornfield
+crackclaw point
+crag
 crakehall
 craster's keep
+cravenhall
+crow's nest
+darry
 deep den
 deepwood motte
 direwolf
 direwolf pup
+doom of valyria
 dorne
 dragon
+dragonmont
 dragonstone
+dreadfort
+driftmark
+durran's defiance
 duskendale
+dyre den
 eastwatch-by-the-sea
 elk
 evenfall hall
+fair isle
+faircastle
+feastfires
+fever river
 firewyrm
+fist of the first men
 flea bottom
+flint's finger
+frostfangs
+gallowstown
+ghaston grey
 ghost grass
+ghoyan drohe
 giant
 godsgrace
+gogossos
+golden tooth
+goldengrove
+goldroad
+grassy vale
+great sept of baelor
+green fork
+greenstone
+greygallows
 greywater watch
 griffin's roost
 grindylow
 grumkin
+gulf of grief
 gulltown
 hardhome
 harpy
 harrenhal
+haunted forest
+hayford
+hellholt
 high heart
+high tide
 highgarden
+hightower
+honeyholt
+honeywine
 horn hill
 hornvale
 house allyrion
 house arryn
+house ashford
 house baelish
 house banefort
+house bar emmon
 house baratheon
+house beesbury
 house belmore
 house blackmont
+house blackmyre
 house blacktyde
 house blackwood
+house boggs
 house bolton
+house borrell
 house botley
 house bracken
+house brax
+house bulwer
 house caron
+house caswell
 house celtigar
 house cerwyn
 house clegane
+house clyay
 house codd
+house coldwater
 house connington
 house corbray
 house crakehall
+house crane
+house cray
+house crowl
+house cuy
 house dalt
 house darry
 house dayne
 house dondarrion
 house drumm
 house dustin
+house errol
 house estermont
+house farman
 house farwynd
+house fenn
+house flint
 house florent
+house footly
 house fossoway
 house fowler
 house frey
+house gargalen
 house glover
 house goodbrother
 house grafton
+house grandison
+house greengood
 house greyjoy
+house harclay
 house harlaw
+house herston
+house hersy
 house hightower
 house hornwood
 house hunter
+house jordayne
 house karstark
+house kenning
 house lannister
 house lefford
+house liddle
+house locke
+house lonmouth
+house lydden
+house magnar
 house mallister
 house manderly
+house manwoody
 house marbrand
+house marsh
 house martell
+house massey
+house melcolm
 house merlyn
+house merryweather
 house mooton
 house mormont
 house mullendore
+house myre
+house norrey
 house oakheart
 house payne
+house peat
+house penrose
 house piper
+house plumm
+house prester
+house qorgyle
+house quagg
 house rambton
 house redfort
 house redwyne
 house reed
+house reyne
 house rowan
 house royce
+house ryger
 house ryswell
+house r联
+house r聯
 house saltcliffe
 house santagar
 house seaworth
 house selmy
+house serrett
+house slate
+house smallwood
 house sparr
+house stane
 house stark
 house stonehouse
+house sunderland
 house sunglass
 house swann
 house swyft
+house swygert
 house tallhart
+house tarbeck
 house targaryen
 house tarly
 house tarth
@@ -133,9 +248,16 @@ house uller
 house umber
 house vance
 house velaryon
+house volmark
+house waxley
 house waynwood
+house went
 house westerling
 house whent
+house wode
+house woolfield
+house wull
+house wylde
 house wynch
 house yronwood
 hrakkar
@@ -143,9 +265,14 @@ ibben
 ice dragon
 ice spider
 karhold
+kayce
 king's landing
+kingsroad
 kraken
 lannisport
+last hearth
+lemonwood
+lhazar
 lizard-lion
 longtable
 lorath
@@ -153,6 +280,7 @@ lys
 maidenpool
 mammoth
 manticore
+massey's hook
 meereen
 merling
 mistwood
@@ -160,38 +288,80 @@ moat cailin
 mole's town
 myr
 naath
+new ghis
 nightsong
 norvos
+ny sar
 old valyria
+oldcastle
 oldtown
 oxcross
+parchments
 pentos
+pinkmaiden
+planky town
+port yorween
 pyke
 qarth
 qohor
+queenscrown
 rain house
+rainwood
+ramsgate
 raven
 raventree hall
+raventry hall
+red fork
+red lake
+red waste
+riverroad
 riverrun
+rook's rest
+rosby
+roseroad
 runestone
 saltpans
+salty town
+sandstone
+sar mell
+sarsfield
+sea dragon point
+sea dragon tower
 seagard
+searoad
 shadow
 shadowcat
+sharp point
+shipbreaker bay
+silverhill
 skagos
 slaver's bay
 snark
 snow bear
+sothoryos
+sow's horn
 sphinx
+spicetown
 squisher
 starfall
+starry sept
+stepstones
+stokeworth
+stone drum
 stone hedge
 stone men
 stone mill
 stonehelm
+stony shore
 storm's end
+strait of tarth
+stygai
+summer islands
 summerhall
+sun house
 sunspear
+sweetport sound
+tarbeck hall
 tarth
 the arbor
 the bloody gate
@@ -200,6 +370,7 @@ the crag
 the crossroads inn
 the crownlands
 the dothraki sea
+the dragonpit
 the dreadfort
 the eyrie
 the fingers
@@ -211,12 +382,15 @@ the house of black and white
 the iron islands
 the isle of faces
 the kingsroad
+the mander
 the neck
+the nightfort
 the others
 the paps
 the quiet isle
 the reach
 the red keep
+the rills
 the riverlands
 the ruby ford
 the shadow lands
@@ -235,19 +409,45 @@ the wall
 the water gardens
 the westerlands
 the whispering wood
+the whispers
+thenn
+three towers
 three-eyed raven
+tor
+torrhen's square
 tumbleton
+twins
 tyrosh
+ulthos
 unicorn of skagos
+uplands
+vaes athzhari
+vaes dordi
 vaes dothrak
+vaes efe
+vaes graddakh
+vaes jin
+vaes khewo
+vaes mejhah
+vaes shier
+vaes tolorro
+vaith
+valyria
+valyrian peninsula
 valyrian sphinx
 volantis
+wayfarer's rest
 weirwood
+whispering wood
 white harbor
 white walker
+widow's watch
 wight
+windwyrm
 winterfell
+wyl
 wyvern
+yeen
 yi ti
 yronwood
 yunkai

--- a/lists/fiction/avatar.yml
+++ b/lists/fiction/avatar.yml
@@ -3,16 +3,19 @@ title: "Avatar: The Last Airbender names"
 category: fiction
 description: "Places, peoples, spirits, bending arts, and factions from Avatar: The Last Airbender and The Legend of Korra"
 ---
+aang
 agni kai
 air acolytes
 air nomads
 air temple island
 airbending
+ammon
 appa
 asami sato
 avatar kyoshi
 avatar roku
 avatar state
+avatar stateglider
 avatar wan
 azula
 ba sing se
@@ -35,44 +38,58 @@ dragon dance
 earth kingdom
 earth kingdom colonies
 earthbending
+eastern air temple
 ember island
 ember island players
 energybending
 equalists
 fire ferret
+fire ferrets
 fire nation
+fire nation capital
 fire nation colonies
 fire nation royal palace
 fire sages
 firebending
 firelord ozai
+foggy swamp
 foggy swamp tribe
+ghazan
 gyatso
 hama
 harmonic convergence
+haru
 hei bai
+ikki
 iroh
 jeong jeong
 jett
+jinora
 kai
 katara
+koh the face stealer
 koizilla
 korra
 kuruk
 kuvira
 kuvira's empire
+kya
 kyoshi island
 lake laogai
 lava bending
+lavabending
 lightning bending
 lightning direction
 lightning redirection
+lin beifong
 lion turtle
 long feng
 mai
 mako
 mechanist
+meelo
 metalbending
+ming-hua
 misty palms oasis
 moon spirit
 naga
@@ -82,27 +99,37 @@ ocean spirit
 omashu
 opal
 ozai
+p'li
 pabu
 paku
+pemma
 piandao
 platinum mecha
 polar bear dog
 pro-bending
 pro-bending arena
+raava
 red lotus
 republic city
 republic council
+rohan
 roku
 sandbenders
+sandbending
 secret tunnel
+senna
 serpent's pass
 shyu
+si wong desert
+sokka
 southern air temple
 southern water tribe
 sozin
 sozin's comet
 spirit oasis
 spirit world
+suki
+suyin beifong
 swampbenders
 tarrlok
 tenzin
@@ -114,11 +141,15 @@ the white lotus
 the world tree
 tofh
 tofh beifong
+tonraq
+tree of time
 tui and la
 ty lee
 unalaq
 unalaq's empire
+united forces
 ursa
+vaatu
 varrick
 wan
 wan shi tong
@@ -128,6 +159,7 @@ waterbending
 western air temple
 white lotus
 yakone
+yangchen
 yu dao
 yue
 zaheer

--- a/lists/fiction/avatar.yml
+++ b/lists/fiction/avatar.yml
@@ -9,9 +9,11 @@ air nomads
 air temple island
 airbending
 appa
+asami sato
 avatar kyoshi
 avatar roku
 avatar state
+avatar wan
 azula
 ba sing se
 ba sing se lower ring
@@ -19,13 +21,16 @@ ba sing se upper ring
 badgermole
 bending
 bloodbending
+bofeng
 boiling rock
 boiling rock prison
+bolin
 bumi
 cabbage merchant
 chi blocking
 combustion man
 combustionbending
+dai li
 dragon dance
 earth kingdom
 earth kingdom colonies
@@ -42,15 +47,30 @@ fire sages
 firebending
 firelord ozai
 foggy swamp tribe
+gyatso
+hama
 harmonic convergence
 hei bai
+iroh
+jeong jeong
+jett
+kai
+katara
 koizilla
+korra
+kuruk
+kuvira
 kuvira's empire
 kyoshi island
 lake laogai
 lava bending
+lightning bending
+lightning direction
 lightning redirection
 lion turtle
+long feng
+mai
+mako
 mechanist
 metalbending
 misty palms oasis
@@ -58,7 +78,13 @@ moon spirit
 naga
 northern air temple
 northern water tribe
+ocean spirit
 omashu
+opal
+ozai
+pabu
+paku
+piandao
 platinum mecha
 polar bear dog
 pro-bending
@@ -66,27 +92,45 @@ pro-bending arena
 red lotus
 republic city
 republic council
+roku
 sandbenders
 secret tunnel
 serpent's pass
+shyu
 southern air temple
 southern water tribe
+sozin
 sozin's comet
 spirit oasis
 spirit world
 swampbenders
+tarrlok
+tenzin
 the avatar
 the dai li
 the fire lord
 the red lotus
 the white lotus
 the world tree
+tofh
+tofh beifong
 tui and la
+ty lee
+unalaq
+unalaq's empire
+ursa
+varrick
 wan
 wan shi tong
 wan shi tong's library
 water tribe
 waterbending
 western air temple
+white lotus
+yakone
 yu dao
+yue
+zaheer
 zaofu
+zuko
+zuko's dragon

--- a/lists/fiction/barsoom.yml
+++ b/lists/fiction/barsoom.yml
@@ -7,15 +7,18 @@ airships
 apt
 apt-man
 apt-men
+atmosphere plant
 banth
 banths
 barsoom
+barsoomian
 black martians
 black pirates
 blue men
 bork
 calot
 calots
+carrion caves
 carter
 carthoris
 city of helium
@@ -24,18 +27,25 @@ dead sea bottoms
 dejah thoris
 dor
 dwar
+eighth ray
 first born
 frowning mountains
 gars
 gathol
+ghek
 great thoat
 great white apes
+greater helium
 green martians
 gulliver jones
+gur tullas
 guthrie
 helium
+hills of tsing
 holy therns
+hormad
 horz
+ice barrier
 iss
 iss valley
 issus
@@ -43,12 +53,16 @@ jed
 jeddak
 jeddak of jeddaks
 john carter
+kantor dahl
 kaol
 kaor
+kar komak
 korad
 lator
+lesser helium
 lesser thern
 llana of gathol
+lost sea of korus
 lothar
 malagor
 manator
@@ -58,37 +72,53 @@ martian flier
 martian sword
 martian warship
 masena
+mor tulas
+mountains of otz
+nine rays
 oath of issus
 ocar
 odwar
+okar
 ool
+orluk
 orovar
 otar
 padwar
 panthan
+phadar
+phor tak
 plant men
 pompée
 ptarth
 radium rifle
+ras thavas
 red martians
 river iss
 sarkoja
+sea of korus
 shakor
 silian
+sith
+solan
 synthetic men
 tan hadron
 tara of helium
 tars tarkas
+temple of the sun
 thark
 tharkian hordes
 tharks
 therns
 thoat
+thoat saddle
 thoats
 thuvia
 thuvia of ptarth
+turjun
 u-gor
+ul vas
 ulsio
+vadan kole
 valley dor
 warhoon
 warhoons

--- a/lists/fiction/barsoom.yml
+++ b/lists/fiction/barsoom.yml
@@ -5,32 +5,43 @@ description: "Places, peoples, creatures, titles, and artifacts from Edgar Rice 
 ---
 airships
 apt
+apt-man
+apt-men
 banth
 banths
 barsoom
+black martians
 black pirates
 blue men
+bork
 calot
+calots
 carter
 carthoris
 city of helium
+daffy
 dead sea bottoms
 dejah thoris
 dor
 dwar
 first born
+frowning mountains
 gars
+gathol
 great thoat
 great white apes
 green martians
 gulliver jones
+guthrie
 helium
 holy therns
 horz
 iss
 iss valley
 issus
+jed
 jeddak
+jeddak of jeddaks
 john carter
 kaol
 kaor
@@ -38,8 +49,14 @@ korad
 lator
 lesser thern
 llana of gathol
+lothar
 malagor
 manator
+martian
+martian canals
+martian flier
+martian sword
+martian warship
 masena
 oath of issus
 ocar
@@ -50,12 +67,17 @@ otar
 padwar
 panthan
 plant men
+pompée
 ptarth
+radium rifle
 red martians
 river iss
 sarkoja
+shakor
+silian
 synthetic men
 tan hadron
+tara of helium
 tars tarkas
 thark
 tharkian hordes
@@ -63,6 +85,8 @@ tharks
 therns
 thoat
 thoats
+thuvia
+thuvia of ptarth
 u-gor
 ulsio
 valley dor
@@ -71,4 +95,6 @@ warhoons
 white apes
 xavarian
 xodar
+yellow martians
 zodanga
+zythes

--- a/lists/fiction/bas-lag.yml
+++ b/lists/fiction/bas-lag.yml
@@ -5,79 +5,146 @@ description: "Places, peoples, creatures, factions, and concepts from China Miev
 ---
 anophelii
 armada
+badside
 bas-lag
+bellis coldwine
+benthic
 bohemie
 bonetown
+broken dome
 cactacae
 cadnebar
+charlie
 chimer
 chob
 clench
+coalhole
 construct council
 cray
+creekside
 crobuzon
 crobuzoner
+cutter
 dagger moth
+der grimnebulin
 derkhan blued
 dusthouse
 faber
+faro
+fennec
 fly-spitter
+flyside
 garuda
 gengris
+ghoul
+glasshouse
 golemetry
+grimy
 grindylow
 griss twist
+grub
 gutter
+handlingers
+hedrigall
+high cromlech
 iron council
+isaac dan der grimnebulin
 jabber
 jabberwock
 jack half-a-prayer
+jacre
 judah low
+judas
+kar'uchai
 khepri
+kinken
 lin
+lin energy
 lin loving
 lovecraftian
+low
 malachite
 marrowers
+mayor rudgutter
 mercantile armada
 militia towers
+monstrous
 motley
+mr motley
 mr. motley
 new crobuzon
 nomads
 oriel
+orihuela
 parliament
 parliamentary militia
+perdido
 perdido street station
 possibility engine
 possibility mining
 railsea
 remade
+rhyol
+ribs
 rudgutter
+rust
 rustheap
+salacus fields
+scabmettlers
+scald
 scar
 scuttles
 shadrach
+sheeler
+shining boy
+silas fennec
 slake moth
+slake-moth
+smogspire
+sobt
 solomon gold
+somnambulism
 south badlands
 spatters
+spit hearth
 suzerain
+tanner
 tar
 tarmac
+tarry
+teafortwo
+tesserae
 thaumaturge
+the advance
 the avanc
 the cacotopic stain
+the cactus
 the cactus people
+the collective
+the construct
+the ghost
 the glasshouse
+the grand easterly
 the grand khepri
+the iron council
 the khepri
+the lovers
 the militia
+the ribs
 the scabbler
+the scar
+the sough
+the spike
+the tarry
 the vodyanoi
+thrax
 tinkermen
+toro
 torque
 uffing
+uvan
+uver
+vanc
 vodyanoi
 weaver
 wyrmen

--- a/lists/fiction/bas-lag.yml
+++ b/lists/fiction/bas-lag.yml
@@ -11,12 +11,17 @@ bonetown
 cactacae
 cadnebar
 chimer
+chob
+clench
 construct council
 cray
+crobuzon
 crobuzoner
 dagger moth
+derkhan blued
 dusthouse
 faber
+fly-spitter
 garuda
 gengris
 golemetry
@@ -30,6 +35,8 @@ jack half-a-prayer
 judah low
 khepri
 lin
+lin loving
+lovecraftian
 malachite
 marrowers
 mercantile armada
@@ -38,29 +45,41 @@ motley
 mr. motley
 new crobuzon
 nomads
+oriel
 parliament
 parliamentary militia
 perdido street station
+possibility engine
 possibility mining
 railsea
 remade
 rudgutter
 rustheap
 scar
+scuttles
 shadrach
 slake moth
+solomon gold
 south badlands
 spatters
+suzerain
+tar
+tarmac
 thaumaturge
 the avanc
 the cacotopic stain
 the cactus people
 the glasshouse
+the grand khepri
 the khepri
 the militia
+the scabbler
 the vodyanoi
 tinkermen
 torque
+uffing
 vodyanoi
 weaver
 wyrmen
+yagharek
+yare

--- a/lists/fiction/conan.yml
+++ b/lists/fiction/conan.yml
@@ -5,13 +5,19 @@ description: "Places, peoples, creatures, gods, and factions from Robert E. Howa
 ---
 acheron
 akbitana
+altaro
 amazon
+amool
 aquilonia
+aquilonian knight
 argos
 argossean
 asgard
+asura
 atali
+ayodhya
 baracha isles
+bel
 belit
 black circle
 black coast
@@ -20,10 +26,15 @@ black kingdoms
 black lotus
 black ring
 black seers
+black seers of yimsha
+bomongus
+bori
 bossonia
 bossonian
+bossonian archer
 bossonian marches
 brule
+brule the spear-slayer
 brythunia
 cimmeria
 cimmerians
@@ -34,18 +45,28 @@ conan
 conan the barbarian
 conan the destroyer
 corsairs
+corsairs of tula
 crom
 darfar
 dark valley
 demons of the dark
 devil in iron
 el-ron
+erlik
+frost giants
+ghouls of yoth
+grey lotus
 gunderland
+gunderland pikeman
+hanuman
 haunted pyramids
+heart of ahriman
+hyborian
 hyborian age
 hyperborea
 hyrcania
 hyrcanians
+iranistan
 iron shadows
 ishtar
 jemsha
@@ -53,6 +74,7 @@ keshan
 khawarizm
 khitai
 khoraja
+king conan
 kordava
 kosala
 koth
@@ -61,39 +83,61 @@ kull
 kull of atlantis
 kush
 kushites
+lemuria
 lost valley
+luxur
+messantia
+mitra
 nemedia
 nemedian
+numalia
+olgerd vladislav
 ophir
 ophirean
 pictish wilderness
 picts
 pirate isles
 poitain
+publius
+punt
+purple lotus
 red brotherhood
 red nails
+red sonja
 salome
 scarlet citadel
 serpent men
+serpent ring of set
 set
+shadizar
 shan-e-sorkh
 shem
 shemites
 shumballa
 siptah
+star of khorala
 stigia
 stigian
 stygia
 stygian
 stygian priests
 stygian serpent
+stygian tomb
+subotai
+sutri
+taramis
+tarantia
 the black ring
 the tower of the elephant
 the tree of death
 thog
 thoth-amon
+thutothmes
+tortage
+tsotha-lanti
 turan
 turanian
+valeria
 valusia
 valusian
 vendhya
@@ -101,12 +145,18 @@ vendhyan
 vilayet sea
 western ocean
 xuthal
+yag-kosha
 yamatai
 yanath
+yara
+yasmina
+yellow lotus
 yeti
 yg
 zamora
 zamorian
+zamorian thief
+zembabwei
 zingara
 zingaran
 zula

--- a/lists/fiction/conan.yml
+++ b/lists/fiction/conan.yml
@@ -7,32 +7,47 @@ acheron
 akbitana
 amazon
 aquilonia
+argos
 argossean
 asgard
 atali
+baracha isles
 belit
 black circle
 black coast
 black colossus
+black kingdoms
 black lotus
+black ring
 black seers
+bossonia
 bossonian
+bossonian marches
 brule
+brythunia
 cimmeria
 cimmerians
+city of brass
 city of skulls
 conajohara
 conan
+conan the barbarian
+conan the destroyer
 corsairs
 crom
 darfar
 dark valley
+demons of the dark
 devil in iron
+el-ron
 gunderland
 haunted pyramids
 hyborian age
 hyperborea
+hyrcania
+hyrcanians
 iron shadows
+ishtar
 jemsha
 keshan
 khawarizm
@@ -41,11 +56,17 @@ khoraja
 kordava
 kosala
 koth
+kothian
 kull
+kull of atlantis
 kush
+kushites
 lost valley
 nemedia
+nemedian
 ophir
+ophirean
+pictish wilderness
 picts
 pirate isles
 poitain
@@ -56,21 +77,36 @@ scarlet citadel
 serpent men
 set
 shan-e-sorkh
+shem
 shemites
 shumballa
 siptah
 stigia
+stigian
+stygia
+stygian
+stygian priests
+stygian serpent
 the black ring
 the tower of the elephant
 the tree of death
+thog
 thoth-amon
 turan
+turanian
 valusia
+valusian
 vendhya
+vendhyan
 vilayet sea
+western ocean
 xuthal
 yamatai
 yanath
+yeti
 yg
 zamora
+zamorian
 zingara
+zingaran
+zula

--- a/lists/fiction/cthulhu-mythos.yml
+++ b/lists/fiction/cthulhu-mythos.yml
@@ -5,89 +5,238 @@ description: "Unique names from Cthulhu Mythos — places, peoples, creatures, f
 ---
 abbith
 abhoth
+adirondacks
 agartha
+albany
+albertson
+amagansett
+amityville
 ammutseba
+annapolis royal
+annisquam
+anticosti
+antigonish
 aphom-zhah
+aqubogue
 arkham
+arkham sanitarium
 arwassa
+asylum hill
 atlach-nacha
+atlantic beach
 atlantis
+avalon peninsula
 aylesbury
 ayyiig
 azathoth
 b'gnu-thun
+baal-zephon
+babylon
 baharna
+baldwin
+bangor
 baoht z'uqqa-mogg
+bar harbor
 basatan
+bast
+bath
+bay of fundy
+bay view
+bayshore
+bayville
 bel yarnak
+belfast
+bellerose
+bellmore
+bellport
+benefit street
+berkshires
+bethpage
+beverly
 bhole
+biddeford
+blackstone river
+blackwood mountain
+blayne
 bnazic desert
 bokrug
 bolton
+boothbay
+boston
+brenton's point
+brentwood
 brichester
 brichester university
+bridgehampton
+bridgeport
+brunswick
 bugg-shash
+buzzards bay
 byakhee
 byatis
+cabot strait
+calverton
+camden
 camoense
+campobello
+cape ann
+cape breton
+cape cod
+cape elizabeth
+cape sable
 carcosa
+casco bay
+castine
+castle hill
+castle island
+castle neck
+catskills
+cedarhurst
 celaeno
+celephais
 celephaïs
 cerngoth
+charnel ruins
+chatham
 chaugnar faugn
+chebacco lake
 chthonian
 city of the old ones
 clotton
+coasters harbor
+coatlicue
+cohasset
+cold harbor
+college hill
+commack
 commoriom
+conanicut
+connecticut river
+constellation street
+copiague
+crane's beach
+cranston
 cthugha
 cthulhu
 cthylla
+cutchogue
+cuttyhunk
 cxaxukluth
-cyäegha
 cykranosh
+cynothoglys
+cyäegha
 dagon
 daoloth
 dark young
+dartmouth
+dean's corner
 deep one
+deer island
+deer isle
+deer park
 delta green
 demhe
 denizen of k'n-yan
+despair island
 devil reef
+devil's reef
 dhole
+digby
 dimensional shambler
+dreamlands
 dunwich
+duxbury
+dyer island
 dylath-leen
+east meadow
+east rockaway
+eastern point
+eastham
+easthampton
+eastport
 eihort
 elder thing
+elizabeth islands
+elmont
+essex
 exham priory
 falcon point
+falmouth
+farmingdale
+father dagon
+federal hill
 fire vampire
+floral park
 flying polyp
 formless spawn
+fortune bay
+franklin square
+freeport
+frenchman bay
 g'harne
+gallops island
+gallows hill
+garden city
+gardiners island
+gaspe
+gaspee point
+georges island
 ghadamon
 ghast
 ghatanothoa
 ghoul
 ghroth
 gla'aki
+glace bay
+glen cove
+gloon
+gloucester
+gloucester harbor
 glyu-vho
 gnoph-keh
+goat island
 goatswood
 gol-goroth
+gorgon's head
+gould island
+governors island
+grand manan
 great race of yith
+green mountains
+greenport
 groth-golka
 gru sv-8
 gug
+gulf of st. lawrence
 hali
+halibut point
+halifax
+halsey street
+hampton
+hampton bays
+hangmans hill
+harpswell
+hartford
 hastur
 hatheg
 hatheg-kla
+hauppauge
+hempstead
+hermitage bay
+hewlett
+hicksville
+hingham
 hlanith
+hodgkins cove
+hope island
 hound of tindalos
+hudson river
+hull
 hunting horror
 hyperborea
+hypnos
 hziulquoigmnzhah
+iatha
 ib
 idh-yaa
 ignarh
@@ -96,94 +245,297 @@ inhabitant of l'gy'hx
 innsmouth
 inqua
 insect from shaggai
+inwood
+ipswich
+ipswich river
 iqqua
 irem
+island park
+islip
 ithaqua
+jamesport
+jones river
+jonesport
 k'n-yan
 kadath
+karakal
 kassogtha
+kathanyy
+kennebec river
+kennebunk
+kennebunkport
+kings park
 kingsport
 kiran
+kittery
 kled
 kthanid
 ktynga
+kuranes
 kythanil
 l'gy'hx
+lake champlain
+lake george
 lake of hali
+lakeview
+lanesville
+laurel
+lawrence
 lemuria
 leng
 lerion
+levittown
+lido beach
+lindenhurst
+little compton
 lloigor
+lobby
+lobster cove
+locust valley
 lomar
+long beach
+long island
+long island sound
+louisbourg
+lovells island
+lunenburg
+lynbrook
+lynn
+m'nagalah
+m'zoor
+machias
 majestic-12
+malverne
+manchester
+manorville
+manuxet river
+marblehead
 march technologies
+marshfield
+martha's vineyard
 martin's beach
+massapequa
+mattituck
+meadow hill
+merrick
+merrimack river
 mhu thulan
 mi-go
+middletown
+mill river
+miller place
+mineola
+miquelon
 miri nigri
 miskatonic university
+miskatonic valley
+mlandoth
 mnar
 mnomquah
+mohawk river
+mohorg
+monhegan
+monomoy point
+montauk point
+montreal
 moon-beast
 mordiggian
+moriches
 mother hydra
+mount desert island
+mount hope
+mount sinai
 mount voormithadreth
 mountains of madness
 mu
 n'kai
+nag and yeb
+nahant
+namquit point
+nantucket
+napeague
+narragansett bay
+nashawena
+nathanorth
+naushon
 nctolhu
 nctosa
+new bedford
+new haven
+new hyde park
+newburyport
+newfoundland
+newport
 ngranek
 ngyr-korath
 night-gaunt
 nir
+noddles island
 nodens
+nonamesset
+nova scotia
+nyaghoggua
 nyarlathotep
+nyctelios
 nyogtha
+oceanside
+ogunquit
+olney court
 oorn
 ooth-nargai
 oriab
+orient point
+orleans
+orxy
+oryx
+othuyeg
 oukranos
 ouraq
+oyster bay
+paddler's cove
 parg
+parker river
 partridgeville
+pasque
+passamaquoddy bay
+patchogue
+patience island
+pawtuxet
+pawtuxet cove
 peaks of thok
+peconic
+peconic bay
+peddocks island
+pemaquid
+penikese
+penobscot bay
+penobscot river
+ph'rnum
 pharol
 phenomen-x
+pictou
+pigeon cove
 pisces
+placentia bay
+plainview
+plateau of leng
 plateau of tsang
+plum cove
+plum island
+plum island sound
+plymouth
 pnakotus
+point lookout
+port jefferson
+portland
+portsmouth
+portsmouth harbor
+providence
+provincetown
+prudence island
+qn'tth
 quachil uttaus
+quebec
+quincy
+quogue
+r'lim shaikorth
 r'lyeh
 rat-thing
+red hook
+revere
 rhan-tegoth
+riverhead
 rlim shaikorth
+rockland
+rockport
+rockville centre
+rocky point
+roosevelt
+rose island
+roslyn
+rowley
+rowley river
+rye
+s'ytry
+saaitii
+sable island
+saco
+sag harbor
+saguenay
+sakonnet river
+salem
+salem harbor
+salisbury
+salisbury beach
 sand-dweller
 sarkomand
 sarnath
 saucerwatch
+sayville
+scarborough
+schenectady
+schoodic peninsula
+scituate
+sea cliff
+seabrook
+seaford
 sefton
+sefton asylum
 sentinel hill
 serpent man
+setauket
 severn valley
 shaggai
+shaktaj
 shamballah
 shantak
 shathak
 shaurash-ho
+shelburne
+shelter island
+shgjou
+shinnecock hills
 shoggoth
 shonhi
+shoreham
+shterot
 shub-niggurath
 shudde m'ell
 skai
+smithtown
+southampton
+southold
 space-eater
 spawn of yog-sothoth
+spectacle island
+springfield
+squam river
+sstros
+st. andrews
+st. croix river
+st. james
+st. john
+st. john's
+st. john's eve
+st. lawrence river
+st. pierre
+stamford
 star vampire
 star-spawn
+stonington
+stony brook
 sung
+swampscott
+sydney
+syosset
+taconic mountains
+tamash
 tcho-tcho
 temphill
+temple of dagon
+temple of the blind ape
 thalarion
+thasaidon
 the arkham historical society
 the bholes
 the black brotherhood
@@ -287,11 +639,20 @@ the wamps
 the wilmarth foundation
 the worshippers of the black goat
 the zoogs
+thog
+thompson island
+thurvath
 thuum'ha
 tiger transit
+tiverton
+tlophan
 tomb-herd
 tond
+trinity bay
+troy
 tru'nembra
+trugg
+truro
 tsath
 tsathoggua
 tulzscha
@@ -299,24 +660,65 @@ ubb
 ubbo-sathla
 ulthar
 umr at-tawil
+uncatena
+under-gulf
+uniondale
+uwan
 uzuldaroum
+vale of pnath
 vale of pnoth
+valley stream
 valusia
+vhalon
 vhoorl
+vishim
 voonith
 voormis
+vorvadoss
+vthyarilops
 vulthoom
+wading river
+wainscott
 wamp
+wantagh
+warwick
+water mill
+weepecket
+wellfleet
+wells
+west hempstead
+westbury
+westhampton
+westport
+weymouth
+white mountains
+williston park
+windsor
+winthrop
+witch house
+woodbury
+woodmere
+woods hole
+wyandanch
+xada-gla
+xalox
+xeethra
 xexanoth
 xiclotl
+xingg
 xoth
 xothian
+xursh
 y'golonac
 y'ha-nthlei
+y'lla
 y'quaa
 yaddith
 yaddithian
 yaksh
+yanyar
+yarmouth
+yarnak
 ycnagnnisssz
 yegg-ha
 yekub
@@ -325,23 +727,36 @@ yhoundeh
 yhtill
 yian-ho
 yibb-tstll
+yidhra
 yig
+yirgh
 yith
 yithian
 yog-sothoth
 yoh-vombis
+yomagn'tho
+york
 yoth
+yoth-gla
 ythogtha
+yug-goth
 yuggoth
 yuggs
+z'toth-komm
 zak
 zaoth
 zathog
 zhar
+zhar and lloigor
 zin
+zindarak
+zo-kalar
 zobna
 zoog
 zoth-ommog
+zoth-syra
+zothique
+zoxla
 zstylzhemghi
 zura
 zushakon

--- a/lists/fiction/cthulhu-mythos.yml
+++ b/lists/fiction/cthulhu-mythos.yml
@@ -122,9 +122,9 @@ cthylla
 cutchogue
 cuttyhunk
 cxaxukluth
+cyäegha
 cykranosh
 cynothoglys
-cyäegha
 dagon
 daoloth
 dark young

--- a/lists/fiction/culture.yml
+++ b/lists/fiction/culture.yml
@@ -63,7 +63,7 @@ flere-imsaho
 flexible demeanor
 fou
 frank exchange of views
-funny, it worked last time...
+funny, it worked last time
 gcv
 gellon
 get off my lawn
@@ -112,7 +112,7 @@ masaq' orbital
 mawhrin-skel
 mcu
 melancholia enshrines all triumph
-mistake not...
+mistake not
 morthanveld
 morthanveld world
 murphy's legal representation

--- a/lists/fiction/culture.yml
+++ b/lists/fiction/culture.yml
@@ -3,30 +3,51 @@ title: Culture series
 category: fiction
 description: "Starship names, orbitals, planets, systems, species, and factions from Iain M. Banks' Culture series"
 ---
+a series of unlikely explanations
+a ship with a view
+ablation
 aerle
+ahforgetit tendency
+all through with this niceness and negotiation stuff
+another fine product from the nonsense factory
 anticipation of a new lover's arrival, the
 appeal to reason
 arbitrary
+arrested development
 attitude adjuster
+avatar (culture)
 bad for business
 beast shall rise, the
+big sexy beast
 boisterous frame of mind, a
+boo!
 bravado
+byr genar-hofoen
 cantankerous
+cargo cult
 casualty of cause
+chaman
 charitable view, a
+chelgrians
+cheradenine zakalwe
+chiark
 chiark orbital
 clear air turbulence
 coercion theory
 compromised integrity
+contact
 creeble
 crublu
 cutting edge
+davu
 death and gravity
+demi-mind
 demise
 different tan, a
 disposable asset
+diziet sma
 dramatic exit, a
+elvens
 empiricist
 ends of invention, the
 escape velocity
@@ -35,37 +56,84 @@ esperi
 ethics gradient
 experiencing a significant gravitas shortfall
 falling outside the normal moral constraints
+fate amenable to change
 fate amenably amuck
+fine, be that way
+flere-imsaho
 flexible demeanor
+fou
 frank exchange of views
+funny, it worked last time...
+gcv
 gellon
+get off my lawn
+glandular system
+good fences
+gou
+gravitas
 grey area
+gsv
 gunboat diplomat
+gzilt
 gzilt homeworld
 hands, eyes
+helpless in the face of your beauty
+homomda
 honest mistake, an
+hou
+hub mind
+i blame my mother
+i said, i've got a big stick
 i thought he was with you
+i'll just be over here blinking incredulously
 ididir
 idir
+idirans
+inappropriate response
 it's character-building
+jandraligano
+jernau morat gurgeh
+jerry-built
 just read the instructions
+just testing
 killing time
 lasting damage
+lcv
+lightly seared on the reality grill
 limitation school, the
 liveware problem
+lou
+lsf
+lucid dreamer
+luisidians
 m masaq' orbital
+masaq'
 masaq' orbital
+mawhrin-skel
+mcu
+melancholia enshrines all triumph
+mistake not...
+morthanveld
 morthanveld world
+murphy's legal representation
 namues
+nariscene
+nasanier
 nestworld
+neural lace
+no more mister nice guy
 no more mr nice guy
 not invented here
+not you again
+oct
 of course i still love you
+oh bugger, the ship is on fire
 olthre
 only slightly bent
 passing by reference
 pataal
 patience, gravity
+peace faction
 peacemaker, the
 phlebas
 pittyl
@@ -74,38 +142,62 @@ pure big mad boat man
 questionable ethics
 ravished by the battle's fury
 reaper, the
+reasonable anachronism
 reasonable excuse, a
+rou
 sadik orbital
+sanctioned parts list
 sansei orbital
+scanthian
 schar's world
 shubiol
+significant emotional event
 sinon
 size isn't everything
 sleeper service
+so much for subtlety
+so that's what that means
 sori
 space charter
+special circumstances
 state of mind
 stent
+sub-mind
+sublimed
 sursamen
 sweet and rachel
+sweet and simple
+synchronize your dogmas
 tactical grace
 tempestuous
+terminal drug
 thank you and goodnight
+the culture
+this might cause discomfort
 total recall
+tou
 touch me i'm dickish
 trade surplus
 truth-bearer, the
 tsungic arch
+ulterior
+unacceptable behaviour
 unfortunate conflict of interest
 use lances
+vavatch
 vavatch orbital
 very little gravitas indeed
+vfp
 wavering attitude, a
+what are the civilian applications?
+wisdom like silence
 wisely dragooned
 xenophobe
 yawning angel
+yes, that happened
 you lier
 you'll regret that
 youthful indiscretion
 zandronum
 zero gravitas
+zetetic elench

--- a/lists/fiction/dark-tower.yml
+++ b/lists/fiction/dark-tower.yml
@@ -3,65 +3,130 @@ title: Dark Tower names
 category: fiction
 description: "Places, peoples, creatures, factions, and powers from Stephen King's Dark Tower fiction"
 ---
+aaron deepneau
+alain johns
 algul siento
 all-world
+andolini
 arthur eld
+atropos
+balazar
 big coffin hunters
 blaine the mono
+blue heaven
+booth
+brick dust row
+brown
 calla bryn sturgis
+calla sench
 can ka no rey
 can-toi
+cardiac hill
 charlie the choo-choo
 charyou tree
+chevin of the cloot
+clootie
+coos
+coral thorin
+cort
 crimson king
 cuthbert allgood
+cynthia smith
+dandelo
 dark tower
 dark tower rose
+david the hawk
 devar-tete
 devar-toi
+dis
 dixie pig
+donald callahan
 doorway cave
+dusty
 eddie dean
+elden weems
+eldred jonas
+elria
+eluria
+emmanuelle devar
 eyebolt canyon
+fargson
 farson
 father callahan
-gan
+fedoras
 gilead
+giles farnum
+gran-pere
 guns of eld
 gunslinger
 hax
+hummingbird
+in-world
 jake chambers
 jericho hill
+john cullum
+john farson
+joseph r. robert
 ka
+ka-shume
 ka-tet
+kansas
+keystone earth
+lamerk industries
+laverne
+left-handed cartwright
+lindy
+lippy
 lobstrosities
 low men
 lud
 maerlyn
 maerlyn's grapefruit
+mandy
 manni
 mejis
 mid-world
+mofet
 mohaine desert
 mordred
 mordred deschain
+moses carver
+mustang
+north central positronics
+old mother
+old people
+old star
+otish
+outer-world
 oy
 patricia
+peerless
 prim
+pubcast
 rainbow bends
 rhea of the coos
 roland deschain
+rose
 rose madder
+roy depape
+russel baldwin
+sayre
 shardik
 sheemie
+shiklah
+snitch
 song of susannah
+stuttering bill
 susannah dean
 taheen
+tandy
+tet corporation
 the beam
 the big combination
 the breakers
 the calla
 the clearing at the end of the path
+the crimson king
 the dogan
 the gunslingers
 the man in black
@@ -72,8 +137,12 @@ the turtle
 the wolves
 thunderclap
 todash darkness
+tolly
 tower road
 tull
+turtle maturin
+vance
 walter o'dim
 wizard's glass
 wolves of the calla
+zoltán

--- a/lists/fiction/dc.yml
+++ b/lists/fiction/dc.yml
@@ -3,81 +3,236 @@ title: DC Universe names
 category: fiction
 description: "Places, teams, species, artifacts, cosmic powers, and factions from DC fiction"
 ---
+achilles' courage
 amanda waller
 amazon
+amulet of anubis
 anti-monitor
+antimatter universe
 apokolips
+aquaman
+ares
+argus
 arkham asylum
 arkham knight
 atlantis
+atlas' stamina
+bane
 bat-signal
+batarang
 batcave
+batgirl
+batman
+batmobile
+batwing
+beast boy
+belle reve
+birds of prey
+bizarro
 bizarro world
+black adam
+black canary
 black lantern corps
+black manta
+blackgate penitentiary
+blackhawks
+bloodsport
+bludhaven
+blue beetle
 blue beetle scarab
+blue lantern corps
 boomtube
+booster gold
+bracelets of submission
 brainiac
+calendar man
+captain boomerang
+captain cold
+catwoman
 central city
+challengers of the unknown
+checkmate
+cheetah
+circe
+clayface
+cloak of destiny
 coast city
+cosmic treadmill
+crazy jane
 crime alley
+crisis on infinite earths
+cyborg
 daily planet
+dark multiverse
 darkseid
+deadshot
 deathstroke
+desaad
+destiny's garden
+deus
+dinosaur island
 doom patrol
+doomsday
+doomsday clock
+dr. sivana
+el diablo
+elasti-girl
+enchantress
 fawcett city
+female furies
+final crisis
+firestorm
+forever people
 fortress of solitude
 gcpd
+general zod
+giganta
+golden glider
+gorilla city
+gorilla grodd
 gotham city
+granny goodness
 green arrow
+green lantern
 green lantern battery
 green lantern corps
+green lantern ring
+h-dial
+h.i.v.e
 hall of doom
 hall of justice
+happy harbor
+harley quinn
+hawkgirl
 hawkman
+heat wave
+helmet of fate
+hercules' strength
 house of mystery
 house of secrets
+hush
+indigo tribe
+infinite crisis
+injustice league
 intergang
+john constantine
 joker venom
 justice league
+justice league dark
 justice league of america
 justice society of america
+kalibak
 kandor
+keystone city
 khandaq
+killer croc
+killer frost
+king shark
+kobra cult
+korugar
 krypton
 kryptonite
 lantern rings
+lasso of truth
 league of assassins
 legion of doom
 legion of super-heroes
+lex luthor
 lexcorp
+lobo
+man-bat
 mars
+martian manhunter
+marvel family
+mastro's book
+mercury's speed
 metahuman
+metal men
+metallo
 metropolis
+midway city
+miracle machine
+miraclo
+mirror master
+mobius chair
+mogo
 monitor
 mother box
+mr. freeze
 mr. mxyzptlk
+nanda parbat
+negative man
 new genesis
 nightwing
+nok
 nth metal
 nth world
 oa
+ocean master
+omega beams
+oracle
+outsiders
 parademon
+paradise island
+parasite
+peacemaker
+penguin
 phantom zone
+plastic man
+poison ivy
+power battery
+power girl
+professor pyg
+qward
+ra's al ghul
+ranx
+raven
+rebirth
 red hood
 red lantern corps
+reverse-flash
+riddler
 robin
+robotman
+rock of eternity
+ryut
+s.t.a.r. labs
+scarecrow
+secret society of super villains
+shadowspire
+shazam
+shazam family
+sinestro
+sinestro corps
+skartaris
+smallville
+solomon grundy
+solomon's wisdom
 star city
 star labs
+star sapphires
+starfire
+starro
+steppenwolf
 suicide squad
 superboy
+supergirl
+superman
+supertown
+swamp thing
+talia al ghul
+talon
+task force x
 teen titans
 the anti-life equation
 the bat-family
 the black mercy
 the court of owls
 the endless
+the flash
 the flashpoint
 the green
+the joker
 the joker toxin
 the lantern corps
 the lazarus pit
@@ -91,10 +246,30 @@ the source
 the source wall
 the speed force
 themyscira
+trench
+trickster
+trident of neptune
 trigon
+two-face
+utility belt
+vandal savage
+venom
+victor zasz
+vixen
 watchtower
 wayne enterprises
 wayne manor
+weather wizard
 white lantern corps
+white lantern ring
+wonder woman
+world's orchard
 yellow lantern corps
 yj
+young justice
+ysmault
+zamaron
+zatanna
+zero hour
+zeus' power
+zoom

--- a/lists/fiction/dc.yml
+++ b/lists/fiction/dc.yml
@@ -18,6 +18,7 @@ blue beetle scarab
 boomtube
 brainiac
 central city
+coast city
 crime alley
 daily planet
 darkseid
@@ -30,11 +31,16 @@ gotham city
 green arrow
 green lantern battery
 green lantern corps
+hall of doom
 hall of justice
 hawkman
+house of mystery
+house of secrets
 intergang
 joker venom
 justice league
+justice league of america
+justice society of america
 kandor
 khandaq
 krypton
@@ -42,7 +48,7 @@ kryptonite
 lantern rings
 league of assassins
 legion of doom
-legion of superheroes
+legion of super-heroes
 lexcorp
 mars
 metahuman
@@ -81,10 +87,14 @@ the parliament of trees
 the question
 the red
 the rogues
+the source
+the source wall
 the speed force
 themyscira
 trigon
 watchtower
 wayne enterprises
 wayne manor
+white lantern corps
+yellow lantern corps
 yj

--- a/lists/fiction/discworld.yml
+++ b/lists/fiction/discworld.yml
@@ -4,15 +4,21 @@ category: fiction
 description: "Places, peoples, creatures, and groups from Terry Pratchett's Discworld"
 ---
 al khali
+albert
+alchemists' guild
 ambiguous puzuma
 ankh-morpork
+ankh-morpork city watch
+assassins' guild
 bad ass
 banshees
 basilisk
+beggars' guild
 berilia
 bes pelargic
 bhangbhangduc
 big cabbage
+binky
 bogeymen
 bonk
 borogravia
@@ -20,10 +26,16 @@ brindisi
 broad way
 brownies
 bugarup
+butchers' guild
 cable street
+cable street watch house
+canting crew
 chelys galactica
 chimera
+chirm
 circle sea
+clacks
+clacks association
 clacks tower gargoyle
 copperhead
 cori celesti
@@ -31,8 +43,11 @@ curious squid
 curse-of-the-mummy scarab
 death of rats
 death's domain
+deathtrap
+decius duellum
 dijabringabeeralong
 dimwell
+dinky
 dis-organizer imp
 djelibeybi
 dolly sisters
@@ -41,9 +56,11 @@ dryads
 dunmanifestin
 dwarfs
 elves
+embalmers' guild
 ephebe
 errand imp
 escrow
+fools' guild
 fourecks
 gargoyles
 genua
@@ -51,8 +68,11 @@ gnolls
 gnomes
 goblins
 golems
+grand trunk clacks company
 great a'tuin
 great t'phon
+grimm
+grimoire
 hergen
 hermit elephant
 hiho dwarfs
@@ -60,6 +80,8 @@ history monks
 hivers
 holy wood
 howondaland
+hubland
+hubward
 hunchbroad
 hunghung
 igors
@@ -72,22 +94,34 @@ koom valley
 krull
 lancre
 lancre town
+lawyers' guild
 leshp
 liches
 llamedos
 luggages
 mad stoat
+magic
+medusa
 medusae
+merchants' guild
+moldavia
+mort
 muntab
+musicians' guild
 nac mac feegle
 naiads
 noble dragon
 nothingfjord
+octarine
+ogre
 ohulan cutash
 omnia
 orcs
+patrician's palace
 pictsies
 pixies
+plumbers' guild
+point-of-view bird
 pointless albatross
 pseudopolis
 pseudopolis yard
@@ -96,24 +130,35 @@ quirm
 razorback
 re-annual grape
 reannual plant
+rimward
 salamander
 sapient pearwood
 sator square
 scrote
 sea troll
+seamstresses' guild
 short street
 skund forest
 slice
+small gods
+sourcerer
 sto helit
 sto kerrig
 sto lat
+sto plains
+susan
 swamp dragon
+temple of small gods
+thaum
 the agatean empire
+the ankh-morpork times
 the auditors
+the broken drum
 the brown islands
 the carrack mountains
 the chalk
 the counterweight continent
+the crawl
 the dancers
 the dungeon dimensions
 the gnarly ground
@@ -122,25 +167,30 @@ the isle of gods
 the long man
 the luggage
 the mended drum
+the octavo
 the ramtops
 the rim
 the shades
 the sto plains
 the tump
 the wyrmberg
+thieves' guild
 ting ling
 tooth fairies
 treacle mine road
 trolls
 tsort
 tubul
+turnwise
 twoshirts
 überwald
 unseen university
 vampires
 vermine
+watchmen
 wee free men
 werewolves
+widdershins
 yetis
 zemphis
 zlobenia

--- a/lists/fiction/dragon-ball.yml
+++ b/lists/fiction/dragon-ball.yml
@@ -6,69 +6,134 @@ description: "Places, species, transformations, artifacts, and powers from Drago
 android 16
 android 17
 android 18
+android 19
+android 20
+android 21
 androids
+babidi
+bardock
 beerus
+broly
 bulma
 capsule corp
 capsule corporation
 capsule house
 cell
 cell games
+cell junior
 cell juniors
+chaozu
+chi-chi
+chichi
+cooler
+dabura
+dende
 destroyer god
+destructo disc
+dodoria
+dr gero
+dr slump
+dragon ball
+dragon ball gt
+dragon ball super
+dragon ball z
 dragon balls
 dragon radar
 earthlings
+frieza
 frieza force
 fusion dance
 fusion reborn
+future trunks
 galactic patrol
 galick gun
+garlic jr
 ginyu force
 gohan
 goku
+goku black
+goten
 gotenks
+grand minister
 great ape
+great saiyaman
+guru
+hercule
+hit
 hyperbolic time chamber
+jiren
 kaio-ken
+kaioken
 kaioshin
 kame house
 kamehameha
+kami
 kami's lookout
+kamis lookout
+kefla
+kid buu
+king cold
+king kai
 king kai's planet
+king piccolo
 kinton
 korin tower
 krillin
+launch
 majin
 majin buu
+majin vegeta
+maron
 master roshi
+mercenary tao
+moro
+mr popo
+mr satan
 mr. satan
 namek
 namekian dragon balls
 namekians
+nappa
+nimbus
 nimbus cloud
+oolong
 oozaru
 other world
+pan
+patroller
 piccolo
 piccolo jr
 pilaf gang
+pinnacle
+planet namek
 planet vegeta
 porunga
 potara
+power pole
 pride troopers
+puar
+puiar
 raditz
 red ribbon army
+ribrianne
+saibamen
 saiyans
+satan city
 shenlong
 shenron
+spirit bomb
 super buu
 super dragon balls
 super saiyan
 super saiyan blue
 super saiyan god
+super saiyan rose
 supreme kai
 the lookout
+tien
+tien shinhan
 time patrol
+toppo
 tournament of power
 trunks
 trunks' time machine
@@ -76,7 +141,15 @@ ultra instinct
 universe 6
 universe 7
 vegeta
+vegetto
+vegito
 west city
+whis
 world martial arts tournament
+yaji
+yajirobe
+yamcha
 yardrat
+zamasu
+zen-oh
 zeno

--- a/lists/fiction/dragonlance.yml
+++ b/lists/fiction/dragonlance.yml
@@ -3,12 +3,26 @@ title: Dragonlance names
 category: fiction
 description: "Places, peoples, factions, creatures, deities, and artifacts from Dragonlance"
 ---
+abanasinia
+alhana starbreeze
 ansalon
+ariakas
+astinus
+aurak draconian
+baaz draconian
 balifor
+black dragonarmy
 blue dragonarmy
+bozak draconian
+bupu
+caramon majere
 chromatic dragons
+chrystania
 citadel of light
 clerist's tower
+conclave of wizards
+dallamar the dark
+dargaard keep
 dark queen
 draconians
 dragon highlords
@@ -16,27 +30,79 @@ dragon orb
 dragonarmies
 dragonlance
 ergoth
+estwilde
+feal-thas
+fewmaster toede
+fizban
 flint fireforge
+gasshan
+gilean
+gilthanas kanan
+goldmoon
+goodlund
+graygem of gargath
+great library of palanthas
+green dragonarmy
 gully dwarves
+huma dragonbane
 hylo
+icewall
+inn of the last home
 istari
+justinius
+kapak draconian
 kender
 kharolis
+khur
+kitiara uth matar
+knight of the crown
+knight of the rose
+knight of the sword
 knights of neraka
 knights of solamnia
+kothas
 krynn
+laurana kanan
+lord soth
+lunitari
+magius
 mithas
 mount nevermind
 neraka
+nightlund
+nordmaar
+nuitari
+order of high sorcery
+paladine
+palanthas
+par-salian
+pax tharkas
 qualinesti
+qualinost
 raistlin
+raistlin majere
+red dragonarmy
 red robes
+reorx
+riverwind
+salah-khan
 sancrist
+sanctuary
+shoikan grove
 silvanesti
+silvanost
+silvara
+sivak draconian
 solace
 solamnia
+solamnic knights
+solinari
+sturm brightblade
 takhasis
+takhisis
+tanis half-elf
 tarsis
+tasslehoff burrfoot
 the abyss
 the conclave of wizards
 the gods of balance
@@ -51,6 +117,17 @@ the staff of magius
 the tower of high sorcery
 the vallenwood
 the war of the lance
+theros ironfeld
+thoradin
+thorbardin
 tika waylan
+tika waylan majere
+tower of high sorcery at palanthas
+tower of high sorcery at wayreth
+vale of kurn
+verminaard
+wayreth
+white dragonarmy
 white robes
 xythar
+zakhal

--- a/lists/fiction/dragonlance.yml
+++ b/lists/fiction/dragonlance.yml
@@ -12,10 +12,13 @@ aurak draconian
 baaz draconian
 balifor
 black dragonarmy
+black robes
+blue crystal staff
 blue dragonarmy
 bozak draconian
 bupu
 caramon majere
+cataclysm
 chromatic dragons
 chrystania
 citadel of light
@@ -24,6 +27,7 @@ conclave of wizards
 dallamar the dark
 dargaard keep
 dark queen
+disks of mishakal
 draconians
 dragon highlords
 dragon orb
@@ -34,6 +38,7 @@ estwilde
 feal-thas
 fewmaster toede
 fizban
+fizban the fabulous
 flint fireforge
 gasshan
 gilean
@@ -44,6 +49,7 @@ graygem of gargath
 great library of palanthas
 green dragonarmy
 gully dwarves
+hill dwarves
 huma dragonbane
 hylo
 icewall
@@ -66,8 +72,10 @@ laurana kanan
 lord soth
 lunitari
 magius
+metallic dragons
 mithas
 mount nevermind
+mountain dwarves
 neraka
 nightlund
 nordmaar
@@ -77,7 +85,9 @@ paladine
 palanthas
 par-salian
 pax tharkas
+port of tarsis
 qualinesti
+qualinesti elves
 qualinost
 raistlin
 raistlin majere
@@ -88,8 +98,10 @@ riverwind
 salah-khan
 sancrist
 sanctuary
+sanctum of neraka
 shoikan grove
 silvanesti
+silvanesti elves
 silvanost
 silvara
 sivak draconian
@@ -97,6 +109,7 @@ solace
 solamnia
 solamnic knights
 solinari
+spellbook of magius
 sturm brightblade
 takhasis
 takhisis
@@ -129,5 +142,7 @@ verminaard
 wayreth
 white dragonarmy
 white robes
+wild elves
+xak tsaroth
 xythar
 zakhal

--- a/lists/fiction/dune.yml
+++ b/lists/fiction/dune.yml
@@ -3,45 +3,160 @@ title: Dune series
 category: fiction
 description: "Planets, cities, factions, houses, and political groups from Frank Herbert's Dune universe"
 ---
+abomination
 al-dhanab
+al-lat
+alia atreides
 arrakeen
 arrakis
 atrides
+axlotl tank
+baliset
 bene gesserit
 bene tleilax
+bren
+burseg
+butlerian jihad
 caladan
 carthag
+chakobsa
+chani
+chaumas
+chaumurky
 choam
+cielago
+cone of silence
+coom
+crawler
+crysknife
+darwi odrade
+deep desert
+duncan idaho
 ecaz
+erg
+farad'n corrino
+faufreluches
+fedaykin
+fenring
+feyd-rautha
+fish speakers
+foldspace
 fremen
+ghanima
+ghola
 giedi prime
+glosser rabban
+golden path
+gom jabbar
+gom jabbar test
+graben
 grumman
 guild navigators
+gundishapur
+gurney halleck
 hagal
+harah
 harkonnen
+harvester
+heighliner
+highliner
+holtzman effect
+holtzman shield
+honored matres
 house atreides
 house corrino
+house ecaz
+house fenring
+house ginaz
+house grumman
+house hagal
 house harkonnen
+house lankiveil
 house moritani
+house richese
 house vernius
+hwi naree
+irulan
 ix
 ixians
+jamis
 kaitain
+kanly
+kwisatz haderach
+lady jessica
 landsraad
 lankiveil
+lasgun
+let atreides
+leto atreides ii
+liet-kynes
+lisan al-gaib
+lucilla
+mahdi
+maker hooks
+margot fenring
+melange
+mentat
 mentats
+miles teg
+missionaria protectiva
+mohiam
+moneo atreides
+muad'dib
+murbella
+ornithopter
+pan
+paul atreides
+piter de vries
+plasteel
+poison snooper
+polar sink
 poritrin
+pre-born
+reverend mother
 richese
 salusa secundus
+sand snorkel
+sandworm
 sardaukar
+scytale
 selusa secundus
+shaddam corrino
+shadout mapes
+shai-hulud
+sheeana
+shield generator
+shield wall
+shigawire
+shuloch
 siedch tabr
+sietch jacurutu
 sietch tabr
+sink
 smugglers
+solari
 spacing guild
+spice agony
+spice melange
+stilgar
+stillsuit
+stilltent
 suk doctors
+swordmasters of ginaz
+thopter
+thufir hawat
+thumper
 tleilax
 tleilaxu
+truthsayer
 tupile
 tupile sanctuary
+tutelage
+usul
+vladimir harkonnen
 wallach ix
+water discipline
+water of life
+weirding way
+wellington yueh
+wensicia

--- a/lists/fiction/elder-scrolls.yml
+++ b/lists/fiction/elder-scrolls.yml
@@ -5,99 +5,338 @@ description: "Places, peoples, factions, creatures, artifacts, and deities from 
 ---
 aedra
 akatosh
+akavir
+ald'ruhn
 aldmer
 aldmeri dominion
+aldmeris
 alduin
+alessia
+alinor
+alit
+almalexia
 altmer
+amulet of kings
 an-xileel
+ancano
 anvil
+apocrypha
+archon
 argonian
 arkay
+arngeir
+ash hopper
 ashlander
+ashpit
+astrid
+atmora
+atronach
+attribution's share
 auriel
+auriel's bow
+auriel's shield
 azura
+azura's star
+baan dar
 balmora
+baurus
+become ethereal
 black marsh
+black star
 blackreach
 blade
+bloodskal blade
 boethiah
 bosmer
+bravil
 breton
 bruma
+brynjolf
+caius cosades
+camlorn
+chaurus
 cheydinhal
 chim
 chorrol
+clannfear
+cliff racer
 cllavicus vile
+cloudrest
 coldharbour
+college of whispers
+college of winterhold
+colored rooms
+corinthe
 cyrodiil
 daedra
 daedric armor
+daedroth
+daggerfall
+dagoth ur
 dark brotherhood
+dark seducer
+dawnguard
+dawnguard rune shield
+dawnstar
+deadlands
+death hound
+delphine
 dibella
+divayth fyr
 dovahkiin
+dragon priest
+dragonborn
+dragonrend
 dremora
+dreugh
+dune
+dusk
 dwemer
+ebonheart
 ebonheart pact
+ebony blade
+ebony mail
+elden root
+elinhir
+elisif the fair
 elsweyr
+empress alessia
+esbern
+evergloam
+evermore
+falinesti
 falkreath
+fields of regret
 fighters guild
+fire breath
+firsthold
+flame atronach
 forsworn
+frost atronach
+frost breath
+frost troll
+frostbite spider
+gargoyle
+gelebor
+general tullius
+gideon
+gilane
 glass armor
+gnisis
+goldbrand
+golden saint
 gray fox
+greenheart
+greybeards
+guar
+hagraven
+hammerfell
+harkon
+hasphat antabolis
+haven
+heart of lorkhan
+hegathe
+helstrom
 hermaeus mora
 high hrothgar
+high rock
 hircine
+house dagoth
+house dres
+house hlaalu
+house indoril
+house redoran
+house telvanni
+hunting grounds
 imperial city
+imperial legion
 imperials
+indoril nerevar
 isgarmor
+isran
+jagar tharn
 jarl
+jarl balgruuf
 julianos
+jyggalag
+ka po' tun
+kagouti
+kamal
+karliah
+keening
 khajiit
 knights of the nine
+kodlak whitemane
+kvatch
+kwama
 kynareth
 leylawiin
+lillandril
+lorkhan
+lorkhan's heart
+lucian lachance
+lurker
+m'aiq the liar
+mace of molag bal
 mage's guild
+magnus
 malacath
+mannimarco
+mara
+marbruk
 markarth
+martin septim
+masque of clavicus vile
 mehrunes dagon
+mehrunes' razor
+mephala
+mercer frey
 meridia
+miraak
 molag bal
+morag tong
+morihaus
 morrowind
 morthal
+mournhold
+mudcrab
+myriad basins
+mythic dawn
 namira
+neloth
+nerevar
 nerevarine
+netch
 nibenay
+nocturnal
 nord
 oblivion
+ocato
+ohghma infinium
+order of the black worm
 ordinator
+oreyn bearclaw
+orisinium
 orsimer
 paarthurnax
+pelagiad
+pelinal whitestrake
+penitus oculatus
+peryite
+phynaster
+potema
+pyandonea
+quagmire
+rajiin
 red mountain
 redguard
+reman cyrodiil
+rhad
+riddle'thar
 riften
+rimmen
+ring of khajiiti
+ring of namira
+riverhold
+ruin's edge
+sadrith mora
+sanguine
+sanguine rose
+savior's hide
+savos aren
+scamp
+scuttling void
+seeker
+senchal
+sentinel
 septim empire
+serana
+seyda neen
 sheogorath
+shimmerene
 shivering isles
+shornhelm
+shout
+silt strider
+silvenar
+silver hand
+skaal
+skeever
+skeleton key
+skingrad
+skull of corruption
+sky haven temple
 skyrim
+slaughterfish
+slow time
 solitude
 solstheim
+sotha sil
 soul cairn
+soulrest
+spellbreaker
+spiral skein
+spriggan
+staff of magnus
+staff of sheogorath
 stendarr
+storm atronach
+storm call
+stormhold
+sul-matuul
+summerset isles
+sunder
+sunhold
+synod
+syrabane
 talos
 tamriel
+taneth
+tang mo
 thalmor
 the blades
 the companions
 the elder scrolls
+the pits
 the tribunal
 thieves guild
+throat of the world
+thu'um
+tiber septim
+tolfdir
+torval
+tribunal temple
+trinimac
+troll
 tsaesci
+ulfric stormcloak
+unrelenting force
+urag gro-shub
+uriel septim
+vaermina
 valenwood
+valerica
 vampire lord
+vicente valtieri
+vigilants of stendarr
 vivec
+vivec city
+volendrung
+volkihar clan
+vyrthur
+wabbajack
+wayrest
+whirlwind sprint
 whiterun
 windhelm
+wingless twilight
 winterhold
+wolf queen
+woodhearth
+wraithguard
+xivilai
+yagrum bagarn
 yffre
 yokuda
+ysmir
 zenithar

--- a/lists/fiction/elder-scrolls.yml
+++ b/lists/fiction/elder-scrolls.yml
@@ -10,6 +10,7 @@ aldmeri dominion
 alduin
 altmer
 an-xileel
+anvil
 argonian
 arkay
 ashlander
@@ -19,13 +20,18 @@ balmora
 black marsh
 blackreach
 blade
+boethiah
 bosmer
 breton
 bruma
 cheydinhal
+chim
 chorrol
+cllavicus vile
+coldharbour
 cyrodiil
 daedra
+daedric armor
 dark brotherhood
 dibella
 dovahkiin
@@ -40,12 +46,16 @@ glass armor
 gray fox
 hermaeus mora
 high hrothgar
+hircine
 imperial city
 imperials
+isgarmor
 jarl
+julianos
 khajiit
 knights of the nine
 kynareth
+leylawiin
 mage's guild
 malacath
 markarth
@@ -67,10 +77,14 @@ redguard
 riften
 septim empire
 sheogorath
+shivering isles
 skyrim
 solitude
 solstheim
 soul cairn
+stendarr
+talos
+tamriel
 thalmor
 the blades
 the companions
@@ -84,4 +98,6 @@ vivec
 whiterun
 windhelm
 winterhold
+yffre
 yokuda
+zenithar

--- a/lists/fiction/expanse.yml
+++ b/lists/fiction/expanse.yml
@@ -3,61 +3,129 @@ title: Expanse names
 category: fiction
 description: "Places, factions, ships, peoples, and technologies from The Expanse"
 ---
+adolphus murtry
+adrastea
+alex kamal
+amos burton
+anderson dawes
 anderson station
+antony dresden
 anubis
 auberon
+bara gaon
 behemoth
 belters
+bull
+bullet
+callisto
+camina drummer
 canterbury
+carlos 'bull' de baca
 ceres
+chrisjen avarasala
 churn
+clarissa mao
+cotyar ghazi
 donnager
 draper station
+duarte
+earth
 earth-mars coalition
+elvi okoye
 epstein drive
+eros
 eros station
+europa
+eye of the typhoon
+fayez sarkis
+filip inaros
+focus drug
+fred johnson
 free navy
+freehold
 ganymede
+gate builders
 gathering storm
 goliath armor
+goliath power armor
+goths
+heart of the tempest
 holden
+hygiea
+iapetus
 ilus
 inazami
+io
+james holden
+james josephus miller
 jimenez
+josephus
+josephus miller
+juice
+jules-pierre mao
 julie mao
 jupiter system
+klaes ashford
 laconia
 laconian empire
 leonidas
 luna
+magnetic catapult
+marco inaros
+mars
 mars congressional republic
 mcrn
 mcrn donnager
+mcrn scipio africanus
 mcrn tachi
 medina station
+mei meng
+melba koh
+michio pa
 miller
 naomi nagata
 nauvoo
 new terra
 opa
+outer planets alliance
+pallas
+paulo cortazar
 pella
+phoebe
 phoebe station
+praxidike meng
 protomolecule
+ring builders
+ring entities
 ring gate
 ring network
 ring space
 ring station
+roberta 'bobbie' draper
 rocinante
+roman empire
+sadavir errinwright
+san esteban
 slow zone
 sol gate
 sol system
+solomon epstein
+teardrop
+teresa duarte
 the belt
 the churn
 the tempest
 thoth station
+titan
 transport union
 tycho station
 underground
 united nations
+unn
+unn agatha king
+unn thomas prince
+unshubby
 venus incident
+vesta
 vesta blockade
+winston duarte

--- a/lists/fiction/forgotten-realms.yml
+++ b/lists/fiction/forgotten-realms.yml
@@ -4,67 +4,275 @@ category: fiction
 description: "Places, peoples, factions, creatures, deities, and artifacts from the Forgotten Realms"
 ---
 abeir-toril
+aglarond
+alustriel silverhand
 amn
 anauroch
+anchorome
 ankheg
+ao
+arabel
 arcane brotherhood
+archendale
+arkhan the cruel
+artemis entreri
 asmodeus
+astarion
 athkatla
 auril
+axe of the dwarvish lords
+baenre
+bahamut
 baldur's gate
 bane
+battledale
+beholder
+berdusk
+bezantur
 bhaal
+blackstaff
 blackstaff tower
+blingdenstone
+bodhi
+bogel
+boo
+book of keeping
+brown dragon
+bruenor battlehammer
+cadderly bonaduce
+calimport
 calimshan
 candlekeep
+catti-brie
+chauntea
+ched nasad
+chitine
+choker
+choldrith
 chult
+cloakwood
+coldwood
+corellon larethian
+cormanthor
 cormyr
+crown of horns
 cyric
+daggerdale
 dalelands
+dambrath
 darkhold
+deep dragon
 deep gnome
+demilich
 demogorgon
+demonomicon of iggwilv
+displacer beast
+dove falconhand
+dracolich
+dreadwood
+drider
 drizzt
 drizzt do'urden
+drow
 duergar
+durpar
+earthspur mountains
+edwin odesseiron
 elminster
+elminster aumar
+elmwood
+eltabbar
 elturel
+estagund
+ettercap
 evermeet
+eye of vecna
 faerun
+fang dragon
+featherdale
+finder wyvernspur
+flumph
+forest of tethyr
+forest of wyrms
+fzoul chembryl
 gale
 gale dekarios
+galena mountains
+garagos
+gargauth
+garl glittergold
+gazer
+gelatinous cube
+githyanki
+githzerai
 gond
+gortash
+gracklsth
+great rift
+grick
+gromph baenre
+gruumsh
+guenhwyvar
+halaster blackcloak
 halruaa
+halruaan airship
+halsin
+hand of vecna
 harpers
+harrowdale
+helm
+high forest
+high moor
+hillsfar
+hoar
+hook horror
+huzuz
 icewind dale
 illithid
+ilmater
+immilmar
+imoen
+intellect devourer
+iron throne
+jaheira
+jarlaxle baenre
+jergal
+jon irenicus
+kara-tur
+karlach
+katashaka
+kelemvor
+ketheric thorm
 kezef
+khalid
+khelben arunsun
+knights of the shield
+kozakura
+kraken society
+lae'zel
+laeral silverhand
+lake of steam
+lantan
+lathander
+lich
 lloth
 lolth
+luiren
 luskan
 luskan hosts
+malara
+malatra
+manshoon
+many-arrows
+marsember
+marsh of chelimber
+maztica
+meazel
 menzoberranzan
+mezro
+mielikki
+milil
+mimic
+mind flayer
+minsc
+minthara
+mistledale
+misty forest
 mithral hall
+monks of the yellow rose
 moonshae isles
+moonwood
+moradin
+mulhorand
+mulmaster
+mulsantir
 myrkul
+mystra
 myth drannor
 mythallar
+netherese
 netheril
 neverwinter
+night masks
+nimbral
 nine hells
+nothic
 oakhaven
+obould many-arrows
+oghma
 orb of dragonkind
+ordulin
+orin the red
+owlbear
 phaerimm
+port nyanzaru
+portal
+proskur
+purple worm
+pwent
+qilue veladorn
+quenthel baenre
+raphael
+rashemen
+red knight
 red wizards
 red wizards of thay
+redcap
+regis
+ring of winter
+ruathym
+runeshapers
+rust monster
+saerloon
+sarevok
+sarevok anchev
+savage frontier
+savras
+scardale
+scornubel
 sea of fallen stars
+selgaunt
 selune
+semobia
+serpent hills
+shadovar
+shadow dragon
+shadow mastiff
+shadow thieves
+shadow weave
 shadowdale
+shadowheart
 shar
+sharess
+sharn
+shiallia
+shou lung
+siamorphe
+silent shroud
+silvanus
+silver fire
+silver marches
 silverymoon
+skuld
+skullport
+song dragon
+spectator
+spelljammer
 spellplague
 spine of the world
+starwood
+stone of golorr
+storm horns
+storm silverhand
+surthay
+suzail
+svirfneblin
+sword coast
+sword of kas
+sylune silverhand
 szass tam
+tabot
+talos
 tarrasque
 tempus
 tethyr
@@ -76,15 +284,53 @@ the flaming fist
 the lords' alliance
 the order of the gauntlet
 the underdark
+the weave
 the zhentarim
+thesk
+thibbledorf pwent
+thunder peaks
 tiamat
+tilverton
+tomb of annihilation
+tomb tapper
 torm
+triel baenre
+trollclaws
+tu pean
+twisted rune
 tymora
+tyr
+tyraturos
+ubtao
+umber hulk
+umberlee
 underdark
 undermountain
+unther
+valkur
+vampire spawn
+var the golden
+velprintalar
+velsharoon
+viconia de'vir
+volo
+volothamp geddarm
+wa
+wand of orcus
+wasat
 waterdeep
+welkwood
 westgate
+withers
+wood of sharp teeth
+wulfgar
+wyll
 wyrmshadow
+wyrmskull throne
 ymeen
+yochlol
+yondalla
+zakhara
+zaknafein baenre
 zhentil keep
 zygor

--- a/lists/fiction/forgotten-realms.yml
+++ b/lists/fiction/forgotten-realms.yml
@@ -9,6 +9,8 @@ anauroch
 ankheg
 arcane brotherhood
 asmodeus
+athkatla
+auril
 baldur's gate
 bane
 bhaal
@@ -17,20 +19,30 @@ calimshan
 candlekeep
 chult
 cormyr
+cyric
 dalelands
 darkhold
 deep gnome
 demogorgon
 drizzt
+drizzt do'urden
 duergar
 elminster
 elturel
 evermeet
 faerun
+gale
+gale dekarios
+gond
+halruaa
 harpers
 icewind dale
 illithid
+kezef
+lloth
+lolth
 luskan
+luskan hosts
 menzoberranzan
 mithral hall
 moonshae isles
@@ -40,17 +52,21 @@ mythallar
 netheril
 neverwinter
 nine hells
+oakhaven
 orb of dragonkind
 phaerimm
 red wizards
+red wizards of thay
 sea of fallen stars
 selune
 shadowdale
 shar
 silverymoon
+spellplague
 spine of the world
 szass tam
 tarrasque
+tempus
 tethyr
 thay
 the abyss
@@ -63,8 +79,12 @@ the underdark
 the zhentarim
 tiamat
 torm
+tymora
+underdark
 undermountain
 waterdeep
 westgate
 wyrmshadow
+ymeen
 zhentil keep
+zygor

--- a/lists/fiction/foundation.yml
+++ b/lists/fiction/foundation.yml
@@ -6,26 +6,38 @@ description: "Places, planets, factions, and groups from Isaac Asimov's Foundati
 61 cygni
 achilles
 alpha centauri
+amaryl
 anacreon
+arcadia darell
 arcturus
 arkady darell
 askone
 association of independent trading worlds
+atomic power
 aurora
 baleyworld
 bayta darell
+bel riose
 bonde
 cleon
+cleon i
+cleon ii
 comporellon
 daribow
 demerzel
 derowd
+ducem barr
+dusem barr
 earth
 echegaray
 eldest
+emperor cleon
+encyclopedia galactica
 encyclopedists
+ethel duar
 euterpe
 first foundation
+first speaker
 florina
 foundation
 gaia
@@ -36,25 +48,35 @@ gamma andromeda
 gleiar
 golan trevize
 gornnet
+gravitic ship
 hari seldon
+harla branno
 helicon
 hesperos
+hober mallow
 horleggor
 hoyle
 ifni
 indburs
 independents
+janov pelorat
+jorane sutt
 kalgan
 kalganian union
 konom
 korell
 kyrt
 lagash
+lasenby
 leporis
+lewis pirenne
 libair
+licia
 lingane
+lord dorwin
 loris
 lyrane
+manella dubanqua
 mayors of terminus
 melpomenia
 mentalics
@@ -63,10 +85,14 @@ mnemon
 mule
 neotrantor
 nexon
+nucleics
 orsha ii
 pallas
+poly verisof
+preem palver
 psychohistory
 r. daneel olivaw
+r. giskard reventlov
 raych seldon
 rhodia
 rossem
@@ -75,17 +101,24 @@ santanni
 sark
 sayshell
 second foundation
+seldon crisis
+seldon vault
 sirius sector
 siwenna
 smitheus
 smyrno
 solaria
+space-warp drive
 speakers
+stettin i
+synaptic amplifier
 synnax
+tazenda
 terminus
 terminus traders
 the fifty
 the mule
+the mule's empire
 tithonus
 toran darell
 trantor
@@ -94,4 +127,7 @@ tyrann
 union of worlds
 vega
 vincetori
+visi-sonor
 wanda seldon
+yugo amaryl
+zoranel

--- a/lists/fiction/foundation.yml
+++ b/lists/fiction/foundation.yml
@@ -8,15 +8,21 @@ achilles
 alpha centauri
 anacreon
 arcturus
+arkady darell
 askone
 association of independent trading worlds
 aurora
 baleyworld
+bayta darell
 bonde
+cleon
 comporellon
 daribow
+demerzel
 derowd
 earth
+echegaray
+eldest
 encyclopedists
 euterpe
 first foundation
@@ -28,9 +34,13 @@ galactic imperial navy
 galaxy
 gamma andromeda
 gleiar
+golan trevize
+gornnet
+hari seldon
 helicon
 hesperos
 horleggor
+hoyle
 ifni
 indburs
 independents
@@ -50,12 +60,17 @@ melpomenia
 mentalics
 merchant princes
 mnemon
+mule
 neotrantor
 nexon
 orsha ii
 pallas
+psychohistory
+r. daneel olivaw
+raych seldon
 rhodia
 rossem
+salvor hardin
 santanni
 sark
 sayshell
@@ -70,10 +85,13 @@ synnax
 terminus
 terminus traders
 the fifty
+the mule
 tithonus
+toran darell
 trantor
 trantorian empire
 tyrann
 union of worlds
 vega
 vincetori
+wanda seldon

--- a/lists/fiction/gethen.yml
+++ b/lists/fiction/gethen.yml
@@ -3,23 +3,158 @@ title: Gethen and Hainish Cycle
 category: fiction
 description: "Planets, countries, towns, cultures, and organizations from Ursula K. Le Guin's Hainish Cycle and Earthsea"
 ---
+agern
+altas
 anarres
+ansible
+argaven xv
+arren
 athshe
 athshea
+atoll
+atuan
+awabath
+bedap
+benderesk
 cetia
+cetians
+chawry
+chumen
+cob
+diem
+don davidson
+dothe
 earthsea
+ebor
+ekumen
+eorviny
 erhenrang
+esbren
+esker faxe
+farsor
+fastness
+foretelling
+gadan
+gaer
+ged
+genly ai
+gensher
+gethen
+ghete
+gide
 gont
+gontish wilderness
 gorakse
+guthe
+hagget
 hain
+haka
+handdara
+hare
+havnor
+heim
+hilfs
+hollow mountain
+hort town
+investigator
+iskel
+jasper
+kalessin
+karg
+kargad empire
 karhide
+kemmer
+kemmering
+keng
+keth
+koppish
+kossil
+kurremkarmerruk
+lebanhnen
+lorbanery
+mave
+mesk
+minds
+miser
 mishnory
+nafal
+narveden
+o-tokne
+obsle
+ogion
 olleroo
 orgoreyn
+orgyen
+orm embar
+othokhad
+pae
+paln
+peln
+pemmry
+penthe
+perregal
 persea
+pervert
+plegath
+port aubry
+rahan
+raj lyubov
+re albi
+remur
 rer
+rogue
+rokanan
+roke
+sabul
+sadik
+seggris
+selidor
+selver
+sentinel
+serret
+shath
+shevek
+shifgrethor
 shing
+shusgis
 sini
+solaria
+solea
+sopli
+sove
+sparrowhawk
+stabilizer
+steth
+stravag
+taka
+takver
+tehanu
+ten aldi
+tenar
+thar
+tharn
+therem harth rem ir estraven
+therru
+tibe
+tirarin
+torheven
+tovath
+tsun
+uldrish
 urras
+vadan
+ve
+veffq
+venway
+vetch
+wathort
+way
+welland
 werel
+winter
+yegey
 yeowe
+yevaud
+yomesh
+zama
+zentil

--- a/lists/fiction/halo.yml
+++ b/lists/fiction/halo.yml
@@ -3,55 +3,146 @@ title: Halo names
 category: fiction
 description: "Places, factions, species, artifacts, ships, and installations from Halo"
 ---
+05-032 mendicant bias
+2401 penultimate tangent
+343 guilty spark
 alpha halo
 arbiter
+arcadia
+atriox
+avery johnson
 banished
 battle of reach
+binary rifle
+boltshot
+broadsword
 brutes
+buck
+carter-259
+cas-class assault carrier
+catherine halsey
+ccs-class battlecruiser
 charum hakkor
+cleveland
 combat evolved
+composer
+constructor
 cortana
 covenant
+delta halo
 didact
+doisac
 domain
+earth
+edward buck
 elites
+emile-239
+energy sword
+eridanus ii
+escharum
 flood
 forerunners
 forward unto dawn
+gamma halo
+geas
+genesis
 glassing
 gravemind
+gravity hammer
 great journey
+greater ark
 grunts
+halberd
 halo array
+harvest
 high charity
+incineration cannon
 infinity
 installation 00
+installation 03
 installation 04
 installation 05
+installation 07
 jackals
+jacob keyes
+jameson locke
+jega 'rdonnm
+john-117
+jorge-052
+jun-266
+kat-320
 keyship
+lesser ark
+librarian
+lightrifle
+longsword
+maethrillian
 mantle of responsibility
+marathon-class
 master chief
+mauler
 maw
+miranda keyes
+mjolnir armor
+mount kili
+needler
 new mombasa
+noble six
 odst
+offensive bias
 onyx
+orion project
+pegasi delta
+pelican
 pillar of autumn
+plasma rifle
 precursors
 prometheans
 reach
 reclaimer
+requiem
+retriever sentinel
 ringworld
+rraas 'vadam
 sangheili
+sanghelios
+sarah palmer
 scarab
+scorpion tank
+sdv-class heavy corvette
+seeker
+sentinel
+sentinel beam
+shaw-fujikawa drive
+shield world 006
+shield world 111
+shock rifle
 silent cartographer
+skewer
+slipspace
 spartan-ii
 spartan-iii
+spartan-iv
+spiker
+suppressor
+swords of sanghelios
+tartarus
 the ark
 the flood
 the librarian
 the monitor
+the weapon
+thel 'vadam
+thomas lasky
+tribute
 unggoy
 unsc
+unsc forward unto dawn
+unsc infinity
+unsc pillar of autumn
+unsc spirit of fire
+ursula
+voi
 war sphinx
+warthog
 zeta halo

--- a/lists/fiction/harry-potter.yml
+++ b/lists/fiction/harry-potter.yml
@@ -3,96 +3,307 @@ title: Wizarding World names
 category: fiction
 description: "Places, schools, houses, creatures, objects, and groups from the Harry Potter and Wizarding World fiction"
 ---
+aberforth dumbledore
+accio
 acromantula
+aguamenti
+alastor moody
 albania
+albus dumbledore
+alohomora
+amortentia
+animagus
+apparition
+aragog
+argus filch
+arnold
+avada kedavra
 azkaban
+bane
 beauxbatons
+beauxbatons academy
 beedle the bard
+bellatrix lestrange
 bezoar
 black lake
+blood pact
 bludger
+boggart
+bogrod
+bombarda
 borgin and burkes
+bowtruckle
 buckbeak
 butterbeer
+castelobruxo
+cedric diggory
 chamber of secrets
+cho chang
 chudley cannons
+cleansweep
 cockroach cluster
+comet
+confundo
+cornelius fudge
 cornish pixie
+credence barebone
+crookshanks
+crucio
+cursed necklace
+daily prophet office
 death eaters
 deathly hallows
+deluminator
 dementor
 demiguise
+dervish and banges
 diagon alley
+diffindo
+dobby
+dolores umbridge
+double-eight loop
+draco malfoy
+draught of living death
+draught of peace
 durmstrang
+durmstrang institute
+eeylops owl emporium
 elder wand
+elixir of life
+episkey
 erised
+erumpent
+essence of murtlap
 expecto patronum
+expelliarmus
+fang
 fawkes
+felix felicis
 fidelius charm
+filius flitwick
 firebolt
+firenze
 fizzing whizzbee
+fleur delacour
 flo powder
 flobberworm
+floo network
+flourish and blotts
+fluffy
+foe-glass
 forbidden forest
+fred weasley
 galleon
+gellert grindelwald
+george weasley
 ghoul
+giant
+gilderoy lockhart
 gillyweed
+ginny weasley
+gladrags wizardwear
 goblet of fire
+godric gryffindor
 godric's hollow
 golden snitch
+grawp
 grimmauld place
+grindylow
 gringotts
+griphook
 gryffindor
+gryffindor tower
+gryffindor's sword
+hagrid's hut
+hand of glory
+hawksworth pinch
+hedwig
+helga hufflepuff
+hermione granger
+hinkypunk
+hippogriff
 hogsmeade
+hogsmeade station
 hogwarts
 hogwarts express
 hogwarts houses
+hokey
+honeydukes
 horcrux
+house-elf
+howler
 hufflepuff
+hufflepuff basement
+hufflepuff's cup
+ilvermorny
+imperio
 imperius curse
 invisibility cloak
+jacob kowalski
+kelpie
+kingsley shacklebolt
 knight bus
 knockturn alley
+koldovstoretz
+kreacher
 leaky cauldron
+legilimency
+legilimens
 little whinging
+lord voldemort
+lucius malfoy
+lumos
+luna lovegood
+macusa
+mad-eye moody
+madam puddifoot's
+magical menagerie
+magorian
+mahoutokoro
+malfoy manor
 mandrake
+manticore
 marauder's map
+marvolo gaunt's ring
 merpeople
+minerva mcgonagall
 ministry of magic
 mokeskin pouch
+monster book of monsters
+muffliato
 muggle
 nagini
+neville longbottom
+newt scamander
+nicholas flamel
 niffler
+nimbus two thousand
+nimbus two thousand and one
+norbert
+nox
+nurmengard
+nymphadora tonks
+obliviate
+obscurial
+obscurus
+occamy
+occlumency
 ollivanders
+omnioculars
+opal necklace
 order of merlin
 order of the phoenix
+parselmouth
 parseltongue
 patronus
 pensieve
+pepperup potion
+petrificus totalus
+philosopher's stone
+phineas nigellus
+pigwidgeon
 platform nine and three quarters
+plumpton pass
 polyjuice potion
+pomona sprout
+porskoff ploy
 portkey
+prior incantato
 privet drive
+protego
+put-out
 quaffle
+quality quidditch supplies
+queenie goldstein
 quidditch
+quirinus quirrell
+ragnok
 ravenclaw
+ravenclaw tower
+ravenclaw's diadem
+red cap
+reducto
+regulus black
+remembrall
+remus lupin
+resurrection stone
+reverse pass
+riddikulus
+rita skeeter
+ron weasley
+ronan
 room of requirement
+rowena ravenclaw
+rubeus hagrid
+rufus scrimgeour
+salazar slytherin
 salem witches' institute
 scabbers
+scrivenshaft's quill shop
+secrecy sensor
+sectumsempra
+seraphina picquery
+severus snape
+shell cottage
+shooting star
+sirius black
+skele-gro
+sleeping draught
+slug and jiggers apothecary
 slytherin
+slytherin dungeon
+slytherin's locket
+sneakoscope
+sorcerer's stone
 sorting hat
 spellotape
+spinners end
+splinch
+squib
 st mungo's
+starfish and stick
+stupefy
+swooping evil
+sybill trelawney
+the astronomy tower
 the burrow
 the daily prophet
+the dungeons
+the great hall
+the greenhouse
+the hog's head
+the owlery
+the prefects' bathroom
+the quidditch pitch
+the shrieking shack
 the three broomsticks
+the trophy room
 thestral
+thunderbird
 time-turner
+tina goldstein
+tom riddle's diary
+transylvanian tackle
+trevor
 triwizard tournament
+twilfitt and tatting's
+uagadou
+unbreakable vow
 unforgivable curses
+vanishing cabinet
 vault 713
 veela
+veritaserum
+viktor krum
+weasleys' wizard wheezes
+werewolf
 whomping willow
+wingardium leviosa
+winky
 wizarding world
 wizengamot
+wolfsbane potion
+wool's orphanage
+woollongong shimmy
+xenophilius lovegood
 zonko's joke shop

--- a/lists/fiction/his-dark-materials.yml
+++ b/lists/fiction/his-dark-materials.yml
@@ -4,37 +4,111 @@ category: fiction
 description: "Places, peoples, creatures, and concepts from Philip Pullman's His Dark Materials"
 ---
 adamant tower
+alethiometer
+amber spyglass
+anbaric
 angels
+archangel
 armored bears
+balthamos
+baruch
+berlin
+billy costa
+bodley's library
 bolvangar
 brytain
+cazimi
+chevalier tialys
+chicago
 cittagazze
 cliff-ghasts
+cloud-pine
+consistorial court of discipline
 daemons
+dark matter
+dust
+farder coram
+father coram
 fen country
 gallivespians
 geneva
 ghosts
 gyptians
 harpies
+hester
 himalaya
+iorek byrnison
+jerry
+john fane
+john parry
 jordan college
+kaisa
+kirjava
+lady salmakia
 lake enara
 land of the dead
 lapland
+lee scoresby
 london
+lord asriel
+lord boke
+lyra belacqua
+lyra silvertongue
+ma costa
 magisterium
+marisa coulter
+mary malone
+metatron
+moscow
 mulefa
+mulefa wheels
 mulefa world
 night-ghasts
+no-name land
+novaya zemlya
+oblation board
 oxford
+oxford university
+palazzo
 panserbjorne
+pantalaimon
+photochemistry
 republic of heaven
+roger parsglow
+rome
+rusakov particles
+ruta skadi
+salcilia
+sariel
+sayan
+seed-pods
+serafina pekkala
+shadows
+shanghai
+sofia pekkala
 spectres
+stanislaus grumman
+stelimanjer
+subtle knife
+subtle knife rift
 svalbard
+svalbard fortress
+the abyss
+the authority
+the golden monkey
+the magisterium
+the world of the dead
+thorold
+tony costa
+torre degli angeli
 trollesund
+trollesund harbor
 tualapi
+underworld
+ural mountains
+will parry
 witch clans
 witches
 world of the dead
+xaphania
 yenisei

--- a/lists/fiction/his-dark-materials.yml
+++ b/lists/fiction/his-dark-materials.yml
@@ -7,6 +7,7 @@ adamant tower
 alethiometer
 amber spyglass
 anbaric
+anbaric light
 angels
 archangel
 armored bears
@@ -18,6 +19,7 @@ bodley's library
 bolvangar
 brytain
 cazimi
+charles latrom
 chevalier tialys
 chicago
 cittagazze
@@ -26,7 +28,9 @@ cloud-pine
 consistorial court of discipline
 daemons
 dark matter
+dr. mary malone
 dust
+esohedral tower
 farder coram
 father coram
 fen country
@@ -52,6 +56,7 @@ lee scoresby
 london
 lord asriel
 lord boke
+lord boreal
 lyra belacqua
 lyra silvertongue
 ma costa
@@ -60,6 +65,7 @@ marisa coulter
 mary malone
 metatron
 moscow
+mrs. coulter
 mulefa
 mulefa wheels
 mulefa world
@@ -81,6 +87,7 @@ ruta skadi
 salcilia
 sariel
 sayan
+seed-pod wheels
 seed-pods
 serafina pekkala
 shadows

--- a/lists/fiction/hitchhikers.yml
+++ b/lists/fiction/hitchhikers.yml
@@ -3,6 +3,8 @@ title: Hitchhiker's Guide names
 category: fiction
 description: "Places, species, spacecraft, and groups from The Hitchhiker's Guide to the Galaxy"
 ---
+agda
+agrajag
 algol
 algolians
 allosimanius syneca
@@ -10,68 +12,251 @@ alpha centauri
 arcturan mega-elephants
 arcturan megadonkeys
 argabuthon
+ark b
 arkintoofle minor
+arthur dent
+asgard
+babel fish
+bablefish
+badgells
+bar
 bartledan
 bartledanians
+beeb
+beeblebrox
+beetle
+bernard
 beta ursae minor
 billion year bunker
+bistro
 bistromath
+bistromathic drive
+bistromathics
+blabul
 blagulon kappa
 blagulon kappa policecraft
 blagulon kappans
+blart
+blaster
+boring
+branston
 brontitall
+bugblatter beast of traal
 business end
+cabs
+catastrophic
+clon
+cloud
+colchester
+colin
+constant
+cricket
+cricketer
+crosstown
+daisy
 damogran
+daphne
+dent
+dentrassi
 dentrassis
+depressed robot
+disaster area
 disaster area stunt ship
+dolmans
 dolphins
+domain
+don't panic
+dong
+dont panic
+door
 earth
+eccentrica gallumbits
+eddie the computer
+elvis
+emperor
+encyclopedia
+epraim
 eroticon vi
+esther
+fenny
+filippo
+finkelstein
+ford prefect
+fotheringay
 frogstar world b
 g'gugvuntts
+gag halfrunt
+gargravarr
+gellish
 giant silver suncruiser
+gla
+gog
+gold
+golden
+golden ratio
 golgafrincham
 golgafrinchan ark fleet ship b
 golgafrinchans
+grand central
+gratuitous
+great green arkleseizure
 grebulon reconnaissance ship
 grebulons
+green
+guide
+hactar
 haggunenon admiral ship
 haggunenons
+half
+halfrunt
+han
 han wavel
+har
 heart of gold
+heavens
+hector
+hooligan
 hooloovoo
+hotblack desiato
 hotblack desiato's limoship
 hrung
 humans
+humma kavula
+improbability
+infinite improbability drive
+islington
+jagger
 jaglan beta
+jallg
+jart
 jatravartids
+jeltz
+jillian
+juju
+kab
 kakrafoon kappa
+kavula
 krikkit
 krikkit one
 krikkiters
+lall
 lamuella
+lean
+life the universe and everything
+ligr
+lintilla
 lintillas
 little star trolley
+lonely
+loofward
+lord
+lunkwill
 magrathea
+magratheans
+marvin
+marvin the paranoid android
+max
 mice
 milliways
+mogr
+murray
 nowwhat
+number 42
+nutrimatic
+nutrimatic drinks dispenser
+oglar
+oog
+oracle
+order
+orion
+pan galactic gargle blaster
+pangalactic gargle blaster
+paranoid android
+perfect
+petunia
 pikka birds
+pluto
 pluton
+pogon
+poo
+pook
+prefect
 prehistoric earth
+prosser
+prostetnic vogon jeltz
+questular
+questular rontok
+rain god
+random dent
+rat
 ravenous bugblatter beast of traal
+rest of the universe
+restaurant at the end of the universe
+rob mckenna
+rontok
+roosta
+rupert
 santraginus v
+sausage
+savlas
+sector
+sector zz9 plural z alpha
+shalt
 silastic armorfiends of striterax
 sirians
+sirius
+sirius cybernetics corporation
+slartibartfast
+smash
+so long and thanks for all the fish
+space
+squib
 squornshellous mattresses
 squornshellous zeta
 stavromula beta
 strenuous garfighters of stug
+strider
+sub-ether
+sub-ether sens-o-matic
+supercomputer
+tachy
 tangerine star buggy
+tea
+teabag
+the book
+the guide
+the total perspective vortex
+thor
+thought
+towel
 traal
+tricia mcmillan
+trillian
+ursa minor
 ursa minor beta
+viltvodle
 viltvodle vi
 viltvodles
 vl'hurgs
 vod sphere
+vogan
+vogon
+vogon poetry
 vogons
+vran
+vroomfondel
+war
+whale
+wilt
+wonko
+wonko the sane
+worst poetry
+xa
+xan
+xaphod
+yooden
+yooden vranx
+zaphod beeblebrox
+zarniwoop
+zarquon
+zem

--- a/lists/fiction/lotr.yml
+++ b/lists/fiction/lotr.yml
@@ -3,163 +3,467 @@ title: Lord of the Rings
 category: fiction
 description: "Places, races, creatures, and unique names from J.R.R. Tolkien's Middle-earth"
 ---
+adorn river
+aglarond
 ainur
+alatar
 aldburg
 amon hen
 amon lhaw
+amon sul
 amon sûl
+amras
+amrod
+ancalagon
+andrast
+anduril
 anfalas
+angainor
 angband
+anglachel
 angmar
+annuminas
 annúminas
 anorien
 anvil of rog
+aragorn
 aragost
 archenland
+archet
 argonath
+arkenstein
 arnor
+arundel
+arwen
+aule
+avallone
 avallónë
+azog
 bag end
+balin
 balrog
+barad-dur
+baranduin
+bard the bowman
 barrow-downs
 barrow-wight
+barrow-wights
+battle of bywater
+battle of dagorlad
+battle of helm's deep
+battle of pelennor fields
+battle of sudden flame
+battle of the five armies
+battle of the hornburg
+battle of unnumbered tears
+battle under stars
+beleriand
 belfalas
+beorn
 beorn's house
 beornings
+beren
+bifur
+bilbo baggins
+bill the pony
+black riders
+blue mountains
+bofur
+bolg
+bombur
+book of mazarbul
+boromir
+brandywine river
 bree
+bree-hill
 breeland
+bruinen
 buckland
 cair andros
 calas galadhon
 caradhras
+caranthir
 caras galadhon
+carn dum
+cave-trolls
 celebdil
+celeborn
+celebrian
+celegorm
+cerin amroth
 cirith ungol
+combe
 cracks of doom
+cram
 crebain
+curufin
+dagor bragollach
+dagor-nuin-giliath
 dale
 dead marshes
+denethor
+destruction of numenor
 dimrill dale
+disaster of the gladden fields
 dol amroth
 dol guldur
+dori
+doriath
 dorwinion
 dragons
+drowning of numenor
+druedain
 dunedain
-dúnharg
 dunharrow
 dunland
+durin
+durin's bane
+durin's folk
+dwalin
 dwarves
 dwimorberg
+dúnharg
 eagle of manwë
+earendil
 easterlings
 edoras
 eguias
 eithel sirion
+elendil
+elendilmir
 elostirion
+elrond
 elves
+elwing
 emyn muil
 ennyn durin
+ent-draught
 ents
+entwash
+eomer
+eorl the young
+eowyn
+ephel duath
 erebor
+ered lithui
 eregion
+eriador
 esgaroth
+este
 ethril
 ettendales
 ettenmoors
+fallohides
+fangorn
 fangorn forest
 fanuidhol
+far harad
+faramir
+feanor
 fell beast
+fell beasts
+field of celebrant
+fili
+fingolfin
+finrod
+first battle of beleriand
+flame of the west
+fords of isen
 forlond
 fornost
+forochel
 framsburg
+frodo baggins
+galadriel
+galenas
+gandalf
+gap of rohan
 giant spiders
+gil-galad
+gildor
+gimli
+glamdring
+glaurung
+glittering caves
+gloin
+glorfindel
 goblins
+goldberry
+gollum
 gondolin
 gondor
+gorbag
 gorgoroth
+gothmog
 great eagles
+great plague
+great river
 great spiders
 grey havens
 grey mountains
+greyflood
+grima wormtongue
+grishnakh
+grond
+gurthang
+guthwine
+gwaihir
+gwathlo
+hadhafang
+haldir
 half-elves
 half-orcs
+hammer of the underworld
+harad
 haradrim
+harfoots
 harlond
+hasufel
+havens of umbar
 hegues
+helm hammerhand
 helm's deep
+helms deep
+henneth annun
 henneth annûn
+herugrim
 himring
+hoarwell
 hobbiton
 hobbits
+hornburg
+huor
 huorn
+huorns
+hurin
+ice-bay of forochel
+imladris
+iron hills
+isen river
 isengard
+isildur
 ithilien
+khand
+khazad-dum
 khazad-dûm
 kibil-nâla
+kili
+kin-strife
+lake nenuial
 lake-town
-lórien
+lamedon
+landroval
+last alliance of elves and men
+laurelin
+lefgui
+legolas
+lembas
+limlight
+lithlad
+lonely mountain
+long winter
+longbottom leaf
+lorien (valar)
+lossarnach
 lossoth
+lothlorien
 lothlórien
+loudwater
 lune
 luthany
+luthien
+lórien
+maedhros
+maglor
 maiar
+mandos
+manwe
 marish
 mearas
+meduseld
+melian
+melkor
 men
+menegroth
+meneldor
+meriadoc brandybuck
 michel delving
+mim
+minas anor
+minas ithil
 minas morgul
 minas tirith
 mirkwood
+miruvor
+misty mountains
+mitheithel
+mithlond
+mithril
+mithril-coat
 mordor
+morgoth
+morgul pass
 moria
+morwen
 mount doom
 mount gundabad
+mountain-trolls
+mountains of ash
+mountains of shadow
+mouth of sauron
 mûmakil
 nargothrond
+narsil
+narya
+naulagamir
+nazgul
 nazgûl
+near harad
 nenuial
+nenya
+nienna
+nine rings
+nirnaeth arnoediad
+noldor
+nori
+numenor
+numenoreans
 nurn
+old forest
+old toby
 oliphaunt
+oliphaunts
+olorig-hai
+one ring
+ooin
+orcrist
 orcs
+ori
+orodruin
+orome
 orthanc
 osgiliath
+palantir
+palantiri
+pallando
+paths of the dead
 pelargir
 pelennor fields
+peregrin took
 periannath
+phial of galadriel
+pillars of the kings
+pipe-weed
+quickbeam
+radagast
+radbug
 radost
+rangers of ithilien
+rangers of the north
 rangers' camp
 rauros
+red book of westmarch
+rhovanion
 rhudaur
+rhun
 rhûn
+ring of barahir
+ringwraiths
 rivendell
+river anduin
 rohan
+roheryn
 rohirrim
+ruling ring
 sammath naur
+samwise gamgee
 sarn ford
+saruman
+sauron
+scatha
+sceptre of annuminas
+scouring of the shire
+seeing-stone
+seven rings
+shadowfax
+shagrat
 sharon
 shelob
+shelob's lair
 shire
+siege of barad-dur
+silmaril
+silmarils
+silvan elves
+sindar
+smaug
+smeagol
+snaga
 staddle
+star of elendil
+star-glass
+sting
 stone-giants
+stone-trolls
+stoors
+teleri
+telperion
 thangorodrim
+the shire
 the watcher in the water
+theoden
+thingol
+thorin oakenshield
+thorondor
+thranduil
+three rings
 tol brandir
+tol eressea
 tol eressëa
+tom bombadil
+tower hills
+treebeard
 trolls
 tuckborough
+tulkas
+tuor
+turgon
+turin turambar
+two trees of valinor
+ugluk
+ulmo
 umbar
 undying lands
+ungoliant
 uruk-hai
+uruks
 utumno
 valar
 valinor
 vampires
+vanyar
+varda
+variags
+vilya
+vingilot
 vinyamar
+vire
+war of the ring
+war of wrath
 wargs
+watcher in the water
+weather hills
 weathertop
 werewolves
 westfold
+white mountains
+white tree of gondor
+white tree of minas tirith
+wilderland
+witch-king of angmar
 withered heath
 withywindle
+woodland realm
 woses
+yavanna
 zarak-dûm

--- a/lists/fiction/lotr.yml
+++ b/lists/fiction/lotr.yml
@@ -114,6 +114,7 @@ dragons
 drowning of numenor
 druedain
 dunedain
+dúnharg
 dunharrow
 dunland
 durin
@@ -122,7 +123,6 @@ durin's folk
 dwalin
 dwarves
 dwimorberg
-dúnharg
 eagle of manwë
 earendil
 easterlings
@@ -263,6 +263,7 @@ lithlad
 lonely mountain
 long winter
 longbottom leaf
+lórien
 lorien (valar)
 lossarnach
 lossoth
@@ -272,7 +273,6 @@ loudwater
 lune
 luthany
 luthien
-lórien
 maedhros
 maglor
 maiar

--- a/lists/fiction/magic-multiverse.yml
+++ b/lists/fiction/magic-multiverse.yml
@@ -3,62 +3,139 @@ title: Magic multiverse names
 category: fiction
 description: "Planes, peoples, factions, creatures, and artifacts from Magic: The Gathering fiction"
 ---
+abzan
+ajani goldmane
 alara
 amonkhet
 angel
 arcavios
 artificer
+ashiok
+atarka
+avacyn
 azorius senate
 baloth
 bant
+belenon
 boros legion
+bruna
+cabal
 capenna
+chandra nalaar
 coalition
+conclave
+consulate
+daretti
+dimir
 dominaria
+domri rade
 dragonlord atarka
 dragonlord dromoka
 dragonlord kolaghan
 dragonlord ojutai
 dragonlord silumgar
+drana
+dromoka
+eldraine
 eldrazi
+elspeth tirel
 esper
 fblthp
+fiora
 firja
+freyalise
 garruk
+garruk wildspeaker
+gatewatch
+gideon jura
+gisela
 goblin
 golgari swarm
+griselbrand
+grixis
 gruul clans
+house dimir
+ikoria
+innistrad
+ixalan
 izzet league
 jace beleren
+jaya ballard
+jeskai
 jund
+kaladesh
 kaldheim
 kamigawa
 karn
 kaya
 keld
+kephalai
 khalni
 kiora
 kithkin
+kolaghan
+koth
 liliana vess
 lorwyn
+lukka
+mardu
+mercadia
 mirrodin
+mishra
 multani
+muraganda
+nahiri
+naya
+new capenna
+new phyrexia
 nicol bolas
 nissa revane
+ob nixilis
+ojutai
+olivia voldaren
+order of the ebon hand
+orzhov syndicate
 phyrexia
 phyrexian
 planeswalker
+rabiah
 rakdos cult
+ral zarek
+rath
 ravnica
+regatha
+rowan kenrith
+sarkhan vol
+segovia
 selesnya conclave
 serra's realm
+shadowmoor
 shandalar
+sigarda
+silumgar
 simic combine
+sorin markov
+squee
 strixhaven
+sultai
+tamiyo
 tarkir
+tazri
+teferi
+temur
+tezzeret
+thalia
 theros
+ugin
+ulgrotha
 urza
 vampire nocturnus
 vedalken
+venser
+vivien reid
+vraska
 vryn
+wilds of eldraine
+will kenrith
+yawgmoth
 zendikar

--- a/lists/fiction/malazan.yml
+++ b/lists/fiction/malazan.yml
@@ -3,6 +3,7 @@ title: Malazan names
 category: fiction
 description: "Places, peoples, creatures, and groups from the Malazan Book of the Fallen"
 ---
+anomander rake
 aptorian
 aren
 artorallah
@@ -13,66 +14,123 @@ bastion
 bhoka'ral
 black coral
 blackdog swamp
+bonehunters
+bridgeburners
+burn
+caladan brood
 capustan
+chaos warren
+claw
 coral
+cotillion
+crimson guard
 d'ivers
+d'riss
+dancer
 darujhistan
+dassem ultor
 deadhouse
+deck of dragons
 demons of aral gamelon
+denul
+destnant
 dragnipur
+duiker
 ehrlitan
 eleint
 eres'al
+falah
+falari
+fatid
 fenn
+fidler
+first sword
 forkrul assail
 forulkan
 g'danisban
+ganoes paran
 genabackis
 great ravens
+grey swords
+high house chains
+high house dark
+high house death
+high house life
+high house light
+high house shadow
+high house war
 hissar
+hold
+hound of darkness
+hound of light
+hound of shadow
 imass
 jacuruku
 jaghut
 jheck
 k'chain che'malle
 k'chain nah'ruk
+kalam
 kartool
+kellenved
 kenryll'ah
 kolanse
 korel
 kurald emurlahn
 kurald galain
 kurald thyrllan
+laseen
 lest
 lether
 letheras
 li heng
 malaz city
 malaz island
+master of the deck
 maurik
+meanas
 meckros
+mockra
 moon's spawn
 moranth
+mortal sword
 mott wood
 nacht
+napan
 omtose phellack
 one eye cat
+onos t'oolan
+otataral
+otataral sword
 pale
 pan'potsun
+quickben
 quon tali
+rashan
+ruse
+scabandari bloodeye
+sela
 setta
 seven cities
 shadowkeep
+shadowthrone
 shake
+shield anvil
+silchas ruin
 soletaken
 starvald demelain
 stormriders
 stratem
 t'lan imass
+talas
+talon
 tartheno toblakai
+tavore paran
 teblor
 tellann
+tennes
 the azath house
+the crippled god
 the crippled god's realm
 the deragoth caves
 the first throne
@@ -92,12 +150,19 @@ the wastelands
 the whirlwind
 theft
 thelomen toblakai
+thyr
+tile
 tiste
 tiste andii
 tiste edur
 tiste liosan
+tool
 trell
 tremorlor
 ubaryd
+unaligned
 unta
+warren of shadow
+whiskeyjack
+wickan
 y'ghatan

--- a/lists/fiction/malazan.yml
+++ b/lists/fiction/malazan.yml
@@ -3,27 +3,51 @@ title: Malazan names
 category: fiction
 description: "Places, peoples, creatures, and groups from the Malazan Book of the Fallen"
 ---
+abyss
+anaster
 anomander rake
+apsalar
 aptorian
+aral gallyan
 aren
+artanthos
 artorallah
 assail
+azath
+azath house
 azathanai
+banoes
 barghast
+baruk
 bastion
+baudin
+beast hold
+beru
 bhoka'ral
+bidithal
 black coral
+blackdog forest
 blackdog swamp
+bluerose
+boil
+bole brothers
 bonehunters
+bottle
 bridgeburners
+brys beddict
+bugg
 burn
+caddis
 caladan brood
 capustan
 chaos warren
 claw
+coll
+corabb bhim lalan
 coral
 cotillion
 crimson guard
+crokus younghand
 d'ivers
 d'riss
 dancer
@@ -33,25 +57,46 @@ deadhouse
 deck of dragons
 demons of aral gamelon
 denul
+desert of raraku
 destnant
+detoran
 dragnipur
+dragon hold
+drift avalii
 duiker
+dujek onearm
 ehrlitan
 eleint
+elient
 eres'al
 falah
 falari
+fanday
 fatid
+fear sengar
+feather witch
+felisin paran
+fener
 fenn
 fidler
 first sword
+fist
 forkrul assail
 forulkan
 g'danisban
 ganoes paran
 genabackis
+gesler
+gothos' folly
+great raven
 great ravens
 grey swords
+greychar
+gruntle
+hannesta
+heboric
+hebric lighttouch
+hedge
 high house chains
 high house dark
 high house death
@@ -61,73 +106,133 @@ high house shadow
 high house war
 hissar
 hold
+holds
+hood
 hound of darkness
 hound of light
 hound of shadow
+hull beddict
+icarium
+ice hold
 imass
+imperum
+itko kan
+itkovian
 jacuruku
 jaghut
 jheck
 k'chain che'malle
 k'chain nah'ruk
 kalam
+kalam mekhar
+kaminsod
+karakarang
+karsa orlong
 kartool
 kellenved
 kenryll'ah
+kilava
+kindly
 kolanse
+korbolo dom
 korel
+korelri
+korlat
+kruppe
 kurald emurlahn
 kurald galain
+kurald liosan
 kurald thyrllan
+l'oric
+lady envy
 laseen
+leoman of the flails
 lest
 lether
 letheras
 li heng
+maelan
 malaz city
 malaz island
+malazan empire
+mallet
+mappo runt
 master of the deck
 maurik
 meanas
 meckros
+minala
 mockra
 moon's spawn
+moons' spawn
 moranth
+moranth mountains
 mortal sword
 mott wood
+murillio
 nacht
 napan
+omhanas
 omtose phellack
 one eye cat
 onos t'oolan
+onrack the broken
+oppon
+ornfawn
 otataral
 otataral sword
 pale
 pan'potsun
+pannion seer
+pores
+quick ben
 quickben
 quon tali
+raest
+raraku
 rashan
+rhulad sengar
+rulas
 ruse
+ryland
+saneb
 scabandari bloodeye
+scillara
+seguleh
 sela
 setta
 seven cities
+sha'ik
 shadowkeep
 shadowthrone
 shake
+shal-morzinn
 shield anvil
+shurq elalle
 silchas ruin
+silgar
+skulldeath
+smiley
 soletaken
+soltiel
+sorry
+spindle
+spite
 starvald demelain
 stormriders
+stormy
 stratem
 t'lan imass
 talas
 talon
 tartheno toblakai
 tavore paran
+tayschrenn
 teblor
+tehol beddict
+telas
 tellann
+tempest
 tennes
 the azath house
 the crippled god
@@ -155,14 +260,28 @@ tile
 tiste
 tiste andii
 tiste edur
+tiste edur lands
 tiste liosan
+toc the younger
+toggh
 tool
+trake
+treach
 trell
 tremorlor
+trotts
+trow
+trull sengar
+truth
 ubaryd
+udinaas
 unaligned
 unta
+uun
+warren of dark
+warren of light
 warren of shadow
 whiskeyjack
 wickan
+wickans
 y'ghatan

--- a/lists/fiction/marvel.yml
+++ b/lists/fiction/marvel.yml
@@ -4,9 +4,12 @@ category: fiction
 description: "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction"
 ---
 a-force
+abomination
 acolytes
+adam warlock
 adamantium
 advanced idea mechanics
+aether
 aim
 alchemax
 alfheim
@@ -14,102 +17,192 @@ all-black
 all-black the necrosword
 alpha flight
 annihilus
+ant-man
+apocalypse
+arc reactor
+arcade
 asgard
 asteroid m
 astral plane
 attilan
 avengers
 avengers mansion
+avengers tower
+bafomet
+baron zemo
 battleworld
 baxter building
+beast
+beyonder
+bishop
 black order
 black panther
+black widow
 blackbird
+blade
 blue area of the moon
 book of the vishanti
 brood
 brotherhood of mutants
+bullseye
+cabal
+cable
 cancerverse
+captain america
+captain marvel
 captain universe
 carbonadium
+carnage
 casket of ancient winters
+cassandra nova
 celestials
+cerebro
 champions
 chandilar
+chitauri
+chitauri sanctuary
+clea
+collector
+colossus
 contest of champions
 cosmic cube
 counter-earth
 crimson gem of cyttorak
 cross technological enterprises
+crossbones
+cyclops
 daily bugle
 damage control
 danger room
+daredevil
 dark dimension
 darkhold
+deadpool
 death
+defenders
 deviant
 doctor doom
+doctor octopus
 doctor strange
 dora milaje
+dormammu
+drax
 ego
 ego the living planet
+electro
+elektra
+emma frost
 eternals
 eternity
 evil eye
 excalibur
+eye of agamotto
+falcon
 fantastic four
+frigga
+frightful four
 galactus
+gambit
+gamora
 generation x
 genosha
+ghost rider
 goblin serum
+godslayer
+grandmaster
 graymalkin
 great lakes avengers
+green goblin
+groot
 guardians of the galaxy
 gungnir
+h-copter
+h.y.d.r.a
 hala
 hammer industries
+hand
 hatut zeraze
+hawkeye
+heimdall
 hel
+hela
 helicarrier
 hellfire club
 howling commandos
 hulk
+human torch
 hydra
+iceman
+immortus
 in-betweener
 infinity
 infinity gauntlet
 infinity gems
 infinity stones
 inhumans
+inner circle
 invaders
+invisible woman
+iron fist
 iron man
+iron man armor
+jean grey
+jessica jones
 jotunheim
+juggernaut
 k'un-lun
 kamar-taj
+kang the conqueror
+kingpin
+kitty pryde
 klyntar
 knowhere
 krakoa
+kraven the hunter
 kree
 latveria
+leader
 legacy virus
 limbo
 living tribunal
+lizard
+loki
 lord chaos
+luke cage
+m-day
+m.o.d.o.k
 madripoor
+magneto
+malekith
+mandarin
 mandarin rings
+mansion
+mantis
 marauders
 master order
 masters of evil
+mephisto
 microverse
 midgard
 midnight sons
 mind stone
+mister fantastic
+mjolnir
+mojo
+moon knight
 morlocks
 mount wundagore
+mr. sinister
+ms. marvel
 muir island
 muspelheim
 mutants
+mysterio
+mystique
+namor
+nebula
 necrosha
+necrosword
 negative zone
 negative zone portal
 new avengers
@@ -117,53 +210,91 @@ new mutants
 new warriors
 nexus of all realities
 nidavellir
+niflheim
+nightcrawler
 norn stones
+nova
 nova corps
+novas
 oblivion
+odin
 odinforce
+okoye
+one above all
+onslaught
+orb
 oscorp
+phalanx
 pleasant hill
 power stone
+professor x
 promethium
+punisher
 purifiers
 pym particles
 quantum realm
+quicksilver
 quinjets
 rand enterprises
 ravagers
 reality stone
 reavers
 red room
+red skull
+rocket raccoon
+rogue
 roxxon
 runaways
+s.h.i.e.l.d
+sabretooth
 sanctum sanctorum
+sandman
 savage land
+scarlet witch
+scepter
+sebastian shaw
 secret empire
 secret wars
+sentinel
+sentinel robot
 sentinels
+shang-chi
+she-hulk
+shi'ar
 shield
+shield of captain america
+shuri
 silver surfer
 sinister six
 skrull
 skrullos
+skrulls
 sokovia
 sorcerer supreme
 soul stone
 space stone
+spider-buggy
 spider-man
 spider-verse
+star-lord
 stark industries
+stark tech
 stark tower
+storm
 stormbreaker
 super-soldier serum
+surtur
 svartalfheim
 sword
 symbiote
 symkaria
 ta lo
+taskmaster
 techno-organic virus
 ten rings
 terrigen mists
+tesseract
+thanos
 the accusers
 the avengers
 the bifrost
@@ -175,10 +306,13 @@ the darkhold
 the defenders
 the hand
 the illuminati
+the kyln
 the phoenix force
 the raft
 the snap
 the vault
+thing
+thor
 thunderbolts
 time stone
 transia
@@ -189,17 +323,30 @@ uni-power
 uru
 utopia
 valhalla
+valkyrie
 vanaheim
+venom
 vibranium
+vision
+vulture
 wakanda
 war dogs
+war machine
+wasp
 weapon plus
 weapon x
 web of life and destiny
+web-shooters
 west coast avengers
+winter soldier
+wolverine
+wong
 x-factor
 x-force
+x-jet
 x-men
 xandar
+xavier institute
 yggdrasil
+yondu
 young avengers

--- a/lists/fiction/marvel.yml
+++ b/lists/fiction/marvel.yml
@@ -4,99 +4,202 @@ category: fiction
 description: "Places, teams, species, artifacts, cosmic powers, and factions from Marvel fiction"
 ---
 a-force
+acolytes
 adamantium
+advanced idea mechanics
 aim
+alchemax
+alfheim
+all-black
+all-black the necrosword
 alpha flight
 annihilus
 asgard
+asteroid m
+astral plane
+attilan
 avengers
 avengers mansion
+battleworld
 baxter building
 black order
 black panther
 blackbird
+blue area of the moon
+book of the vishanti
 brood
 brotherhood of mutants
+cancerverse
+captain universe
+carbonadium
+casket of ancient winters
 celestials
+champions
+chandilar
+contest of champions
+cosmic cube
+counter-earth
+crimson gem of cyttorak
+cross technological enterprises
 daily bugle
+damage control
 danger room
 dark dimension
 darkhold
+death
+deviant
 doctor doom
 doctor strange
+dora milaje
 ego
 ego the living planet
 eternals
+eternity
+evil eye
+excalibur
 fantastic four
 galactus
+generation x
 genosha
+goblin serum
+graymalkin
+great lakes avengers
 guardians of the galaxy
+gungnir
+hala
+hammer industries
+hatut zeraze
+hel
+helicarrier
 hellfire club
+howling commandos
 hulk
 hydra
+in-betweener
+infinity
 infinity gauntlet
 infinity gems
 infinity stones
 inhumans
+invaders
 iron man
+jotunheim
+k'un-lun
 kamar-taj
 klyntar
 knowhere
 krakoa
 kree
 latveria
+legacy virus
+limbo
 living tribunal
+lord chaos
 madripoor
+mandarin rings
+marauders
+master order
 masters of evil
+microverse
 midgard
 midnight sons
 mind stone
 morlocks
+mount wundagore
+muir island
+muspelheim
 mutants
+necrosha
 negative zone
 negative zone portal
 new avengers
 new mutants
+new warriors
+nexus of all realities
+nidavellir
+norn stones
 nova corps
+oblivion
 odinforce
+oscorp
+pleasant hill
 power stone
+promethium
+purifiers
+pym particles
 quantum realm
+quinjets
+rand enterprises
 ravagers
 reality stone
+reavers
 red room
+roxxon
 runaways
 sanctum sanctorum
 savage land
 secret empire
+secret wars
 sentinels
 shield
+silver surfer
 sinister six
 skrull
+skrullos
 sokovia
 sorcerer supreme
 soul stone
 space stone
 spider-man
+spider-verse
+stark industries
 stark tower
+stormbreaker
+super-soldier serum
+svartalfheim
 sword
 symbiote
+symkaria
+ta lo
+techno-organic virus
+ten rings
+terrigen mists
 the accusers
 the avengers
 the bifrost
+the big house
 the blip
 the cabal
+the cube
 the darkhold
 the defenders
 the hand
 the illuminati
 the phoenix force
+the raft
 the snap
+the vault
 thunderbolts
 time stone
+transia
+triskelion
+ultimate nullifier
 ultron
+uni-power
+uru
 utopia
+valhalla
+vanaheim
 vibranium
 wakanda
+war dogs
+weapon plus
 weapon x
+web of life and destiny
+west coast avengers
+x-factor
+x-force
 x-men
 xandar
+yggdrasil
+young avengers

--- a/lists/fiction/mass-effect.yml
+++ b/lists/fiction/mass-effect.yml
@@ -3,82 +3,204 @@ title: Mass Effect names
 category: fiction
 description: "Places, species, factions, ships, artifacts, and powers from Mass Effect"
 ---
+alliance
 anderson
+andromeda
 andromeda initiative
+apros
+archon
 aria
 aria t'loak
+ariana
+ark hyperion
+armali
+arnot
+artemis tau
 asari
+athena
+avina
+bael
+bailey
+banshee
 batarians
+beck
+benning
 biotic
+biotics
+black market
+blood pack
+blue suns
+bravo
+byzantium
 c-sec
+caleston
+capital ship
 catalyst
+ceberus
 cerberus
 cerebus phantom
+chora's den
 citadel
 citadel council
 citadel presidium
 citadel space
 citadel wards
+collector
 collector base
 collectors
 commander shepard
+conrad verner
+cortez
+council
 crucible
+cup
+data
+david anderson
+decimus
+donnel udina
+drack
+dreadnought
+earth
 eden prime
 edi
 elcor
 element zero
+elysium
+eos
+eve
+exogeni
+farris
 femshep
 feros
+flotilla
+flux
+gaea
+garrus vakarian
 geth
+geth prime
+grissom
 grissom academy
 grissom academy students
+grunt
 hanar
 harbinger
+havarl
+hawking eta
+hazel
+helios
+hephaestus
+heretic
+horizon
+humanity
 illium
+illusive
 illusive man
+intruder
+isandus
+jaal
 jack
+jarrahe
+javelin
 javik
 joker
+kadara
+kahoku
 kaidan alenko
 kasumi goto
+kestrel
+kett
+korgan
 krogan
+laverne
+legion
 leviathan
 liara t'soni
 mako
+masani
+mass effect
 mass effect field
 mass relay
+medigel
+mercenary
 migrant fleet
+militia
+milon
 mordin solus
+morinth
+n7
+nakmor
+nef
+nexus
+normandy
 normandy crew
 normandy sr-1
 normandy sr-2
+novaria
 noveria
 omega
 omega 4 relay
 omega station
+omega-4 relay
+omniblade
+omnitool
 overlord
+pathfinder
+peebee
+presidium
+prime
 prothean
+protheans
 quarian
+quarians
 rachni
+raptor
 reaper
 reaper indoctrination
+reapers
 salarians
 samara
 saren
+saren arterius
+savior
+securis
 shadow broker
+shala'raan
 shepard
+shifty looking cow
+sol
 sovereign
+spectre
 spectres
+suvi
 systems alliance
+tali
 tali'zorah
+talon
 thane krios
+the citadel
+the nexus
+the normandy
+the tempest
+therum
 thorian
+tian
+traverse
+traynor
 tuchanka
+turian
 turians
 udina
 udina's coup
+vanguard
 virmire
 volus
 vorcha
+ward
+wards
+weyman
 wrex
+xaene
+yagh
 zaeed
+zaeed massani
+zero

--- a/lists/fiction/narnia.yml
+++ b/lists/fiction/narnia.yml
@@ -3,81 +3,161 @@ title: Narnia names
 category: fiction
 description: "Places, peoples, creatures, and magical beings from C.S. Lewis's Chronicles of Narnia"
 ---
+ahoshta
+anradin
 anvard
+aravis
 archenland
 archenlanders
+aslan
 aslan's country
 aslan's how
+avra
+beaver
 beaversdam
+berna
 beruna
 bism
 black dwarfs
 boggles
+bree
+bulgy bear
+cabadus
 cair paravel
 calormen
 calormen desert
 calormenes
+caspian
 castle of miraz
 centaurs
 charn
 chippingford
+chunder
+cor
+corin
 cruels
 dancing lawn
 dark island
 deathwater island
+deep realm
+digory kirke
+doorn
 dragon island
 dragons
+drinian
 dryads
 duffer's island
 dufflepuds
 dwarfs
 eastern ocean
+edmund pevensie
 efreets
+emeth
+erimon
 ettins
 ettinsmoor
+eustace scrubb
+farsight
+father christmas
 fauns
+felimath
+fledge
 fords of beruna
 galma
 ghouls
 giants
+gilian
+ginger the cat
+glenstorm
+glocke
 great river
+green kirtle
+gumpas
 hags
 harfang
 horrors
+hwin
 incubi
+island of the voices
+jadis
+jewel the unicorn
+jill pole
+king caspian
+king lune
+lady of the green kirtle
 lantern waste
+lasaraleen
 lone islands
+lucy pevensie
+lune
 marsh-wiggles
+maugrim
 merpeople
 minotaurs
+miraz
 monopods
+mr beaver
+mr tumnus
+mrs beaver
 naiads
 narnia
+narrow haven
 narrowhaven
+nikabrik
 ogres
 orknies
+pattertwig
+peepiceek
+peter pevensie
+polly plummer
+prince caspian
+puddleglum
+puzzle the donkey
+rabadash
+ramandu
 ramandu's island
+ramandus island
+reepicheep
+reilian
+rillian
+rishda tarkaan
 river gods
+ruined city of ancient giants
+rupi
 salamanders
 satyrs
 sea people
+seven islands
 seven isles
+shallow lands
+shasta
+shift the ape
 spectres
 stable hill
 star people
 stone table
 stormness head
+strawberry
+susan pevensie
 talking beasts
 talking mice
+tarkaan
+tash
 tashbaan
 telmar
 telmarines
 terebinthia
+tirian
+tisroc
 tree spirits
+trufflehunter
+trumpkin
+tumnus
 underland
 unicorns
 werewolves
 western wild
+white witch
 winged horses
 wood between the worlds
 wooses

--- a/lists/fiction/one-piece.yml
+++ b/lists/fiction/one-piece.yml
@@ -3,83 +3,163 @@ title: One Piece names
 category: fiction
 description: "Places, factions, peoples, creatures, ships, powers, and treasures from One Piece"
 ---
+ace
+akainu
 alabasta
+aokiji
+aramaki
 arlong park
 arlong pirates
+armament haki
 baratie
+bartholomew kuma
+basil hawkins
+beast pirates
+big mom
+blackbeard
 blackbeard pirates
+boa hancock
+bonney
+borsalino
+brook
+buggy
 buggy pirates
+buggy the clown
+calm belt
+capone bege
 celestial dragons
+charlotte linlin
+chopper
+coby
+conquerors haki
 cp9
+crocodile
 devil fruit
+donquixote doflamingo
+dracule mihawk
 dressrosa
 drum island
 east blue
+edward newgate
+egghead
 elbaf
 enel
 enies lobby
+eternal pose
+eustass kid
 fish-man island
 fish-men
+five elders
+franky
 franky family
+fujitora
+garp
+gecko moria
 germa 66
 going merry
+gol d roger
+gold roger
 gomu gomu no mi
+gorosei
 grand line
 haki
 heart pirates
+helmeppo
 impel down
+imu
 island whale
+issho
+jewelry bonney
 jinbe
 kaido
+killer
+kizaru
 kuja pirates
+kuzan
 laboon
 little garden
+log pose
 loguetown
+luffy
+marie jois
 mariejois
+marijoa
 marine admirals
 marineford
 marines
+marshall d teach
 mary geoise
+mihawk
 mink tribe
 mirror world
+monkey d garp
+monkey d luffy
+nami
 new fish-man pirates
 new world
+nico robin
+north blue
+observation haki
 ohara
 one piece
 pacifista
 pluton
+portgas d ace
 poseidon
 punk hazard
 raftel
 red line
+reverse mountain
 revolutionary army
+robin
+roger
 roger pirates
+roronoa zoro
 rumble ball
+ryokugyu
+sabo
+sakazuki
+sanji
+scratchmen apoo
 sea kings
 seastone
+sengoku
 seven warlords
 shandora
 shanks
 skypiea
 smile fruit
+smoker
 sogeking
 soul king
 soul pocus
+south blue
+straw hat
 straw hat pirates
 sunny
 supernovas
+tashigi
 the four emperors
 the poneglyphs
 thousand sunny
 thriller bark
 thriller bark pirates
 tony tony chopper
+trafalgar law
+urouge
+usopp
 vinsmoke family
 void century
 wano
+wano country
 water 7
+west blue
+whitebeard
 whitebeard pirates
 whole cake island
 world government
 world nobles
+worst generation
+x drake
+zoro
 zou

--- a/lists/fiction/pokemon.yml
+++ b/lists/fiction/pokemon.yml
@@ -617,7 +617,7 @@ mightyena
 milcery
 milotic
 miltank
-mime jr.
+mime jr
 mimikyu
 minccino
 minior
@@ -877,7 +877,7 @@ shuppet
 sigilyph
 silcoon
 silicobra
-silph co.
+silph co
 silvally
 simipour
 simisage

--- a/lists/fiction/pokemon.yml
+++ b/lists/fiction/pokemon.yml
@@ -3,63 +3,1140 @@ title: Pokemon names
 category: fiction
 description: "Regions, species, legendary Pokemon, teams, and artifacts from Pokemon"
 ---
+abomasnow
+abra
+absol
+accelgor
+adamant crystal
+aegislash
+aeos island
+aerodactyl
+aether foundation
+aggron
+aipom
+alakazam
+alcremie
+almia
 alola
+alomomola
+altaria
+amaura
+ambipom
+amoonguss
+ampharos
+anorith
+appletun
+applin
+araquanid
+arbok
+arboliva
+arc suit
+arcanine
 arceus
+archaludon
+archen
+archeops
+arctibax
+arctovish
+arctozolt
+ariados
+armaldo
+armarouge
+aromatisse
+aron
+arrokuda
 articuno
+audino
+aurorus
+avalugg
+axew
+azelf
+azumarill
+azurill
+bagon
+baltoy
+banette
+barbaracle
+barboach
+barraskewda
+basculegion
+basculin
+bastiodon
+baxcalibur
+bayleef
+beartic
+beast ball
+beautifly
+beedrill
+beheeyem
+beldum
+bellibolt
+bellossom
+bellsprout
+bergmite
+bewear
+bibarel
+bidoof
+binacle
+bisharp
+blacephalon
+black augurite
+blastoise
+blaziken
+blipbug
+blissey
+blitzle
+blueberry academy
+boldore
+boltund
+bombirdier
+bonsly
+bouffalant
+bounsweet
+braixen
+bramblin
+bramghast
+braviary
+breloom
+brionne
+bronzong
+bronzor
+brute bonnet
+bruxish
+budew
+buizel
 bulbasaur
+buneary
+bunnelby
+burmy
+butterfree
+buzzwole
+cacnea
+cacturne
+calyrex
+camerupt
+capsakid
+carbink
+carkol
+carnivine
+carracosta
+carvanha
+cascoon
+castform
+caterpie
 celebi
+celesteela
+centiskorch
+ceruledge
+cetitan
+cetoddle
+champion stadium
+chandelure
+chansey
+charcadet
 charizard
+charjabug
 charmander
+charmeleon
+chatot
+cherish ball
+cherrim
+cherubi
+chesnaught
+chespin
+chewtle
+chi-yu
+chien-pao
+chikorita
+chimchar
+chimecho
+chinchou
+chingling
+chivalry crest
+cinccino
 cinderace
+clamperl
+clauncher
+clawitzer
+claydol
+clefable
+clefairy
+cleffa
+clobbopus
+clodsire
+cloyster
+coalossal
+cobalion
+cofagrigus
+combee
+combusken
+comfey
+conkeldurr
+copperajah
+corphish
+corsola
+corviknight
+corvisquire
+cosmoem
+cosmog
+cottonee
+crabominable
+crabrawler
+cradily
+cramorant
+cranidos
+crawdaunt
+cresselia
+croagunk
+crobat
+crocalor
+croconaw
+crustle
+cryogonal
+cubchoo
+cubone
+cufant
+cursola
+cutiefly
+cyclizar
+cyndaquil
+dachsbun
 darkrai
+darmanitan
+dartrix
+darumaka
+decidueye
+dedenne
+deerling
+deino
+delcatty
+delibird
+delphox
 deoxys
+devon corporation
+dewgong
+dewott
+dewpider
+dhelmise
 dialga
+diancie
+diggersby
+diglett
+dipplin
 ditto
+dive ball
+dodrio
+doduo
+dolliv
+dondozo
+donphan
+dottler
+doublade
+dracovish
+dracozolt
+dragalge
+dragapult
+dragonair
+dragonite
+drakloak
+drampa
+drapion
+dratini
+dream ball
+drednaw
+dreepy
+drifblim
+drifloon
+drilbur
+drizzile
+drowzee
+druddigon
+dubwool
+ducklett
+dudunsparce
+dugtrio
+dunsparce
+duosion
+duraludon
+durant
+dusclops
+dusk ball
+dusknoir
+duskull
+dustox
+dwebble
+dynamax band
+eelektrik
+eelektross
 eevee
+eiscue
+ekans
+eldegoss
+electabuzz
+electivire
+electrike
+electrode
+elekid
+elgyem
+emboar
+emolga
+empoleon
+enamorus
 entei
+escavalier
+espathra
+espeon
+espurr
 eternatus
+excadrill
+exeggcute
+exeggutor
+exploud
+falinks
+farfetch'd
+farigiraf
+fast ball
+fearow
+feather ball
+feebas
+fennekin
+feraligatr
+ferroseed
+ferrothorn
+ferrum
+fezandipiti
+fidough
+finizen
+finneon
+fiore
+flaaffy
+flabébé
+flamigo
+flapple
+flareon
+fletchinder
+fletchling
+flittle
+floatzel
+floette
+floragato
+florges
+flutter mane
+flygon
+fomantis
+foongus
+forretress
+fraxure
+friend ball
+frigibax
+frillish
+froakie
+frogadier
+froslass
+frosmoth
+fuecoco
+furfrou
+furret
+gabite
 galar
+gallade
+galvantula
+garbodor
+garchomp
+gardevoir
+garganacl
+gastly
+gastrodon
+genesect
 gengar
+geodude
+gholdengo
+gible
+gigalith
+gigas ton ball
+gimmighoul
+girafarig
 giratina
+glaceon
+glalie
+glameow
+glastrier
+gligar
+glimmet
+glimmora
+gliscor
+gloom
+go-rock squad
+gogoat
+golbat
+goldeen
+golduck
+golem
+golett
+golisopod
+golurk
+goodra
+goomy
+gorebyss
+gossifleur
+gothita
+gothitelle
+gothorita
+gouging fire
+gourgeist
+grafaiai
+granbull
+grapploct
+graveler
+great ball
+great tusk
+greavard
+greedent
 greninja
+grimer
+grimmsnarl
+griseous core
+grookey
+grotle
 groudon
+grovyle
+growlithe
+grubbin
+grumpig
+gs ball
+gulpin
+gumshoos
+gurdurr
+guzzlord
+gyarados
+hakamo-o
+happiny
+hariyama
+hatenna
+hatterene
+hattrem
+haunter
+hawlucha
+haxorus
+heal ball
+heatmor
+heatran
+heavy ball
+heavy ball (hisui)
+heliolisk
+helioptile
+heracross
+herdier
+hippopotas
+hippowdon
+hisui
+hitmonchan
+hitmonlee
+hitmontop
 ho-oh
 hoenn
+holon
+honchkrow
+honedge
+hoopa
+hoothoot
+hoppip
+horsea
+houndoom
+houndour
+houndstone
+huntail
+hydrapple
+hydreigon
+hypno
+igylybuff
+illumise
+impidimp
+incineroar
+indeedee
+infernape
+inkay
+inteleon
+iron boulder
+iron bundle
+iron crown
+iron hands
+iron jugulis
+iron moth
+iron thorns
+iron treads
+iron valiant
+ivysaur
+jangmo-o
+jellicent
+jet ball
 jigglypuff
+jirachi
 johto
+jolteon
+joltik
+jumpluff
+jynx
+kabuto
+kabutops
+kadabra
+kakuna
 kalos
+kangaskhan
 kanto
+karrablast
+kartana
+kecleon
+keldeo
+key stone
+kilowattrel
+kingambit
+kingdra
+kingler
+kirlia
+kitakami
+klang
+klawf
+kleavor
+klefki
+klink
+klinklang
+koffing
+komala
+kommo-o
+koraidon
+krabby
+kricketot
+kricketune
+krokorok
+krookodile
+kubfu
 kyogre
+kyurem
+lairon
+lampent
+landorus
+lanturn
+lapras
+larvesta
+larvitar
+latias
+latios
+leaden ball
+leafeon
+leavanny
+lechonk
+ledian
+ledyba
+lental
+level ball
+lickilicky
+lickitung
+liepard
+lileep
+lilligant
+lillipup
+linking cord
+linoone
+litleo
+litten
+litwick
+lokix
+lombre
+lopunny
+lotad
+loudred
+love ball
 lucario
+ludicolo
 lugia
+lumineon
 lunala
+lunatone
+lurantis
+lure ball
+lustrous globe
+luvdisc
+luxio
+luxray
+luxury ball
+lycanroc
+mabosstiff
+machamp
+machoke
+machop
+macro cosmos
+magby
+magcargo
+magikarp
+magmar
+magmortar
+magnemite
+magneton
+magnezone
+makuhita
+malamar
+mamoswine
+manaphy
+mandibuzz
+manectric
+mankey
+mantine
+mantyke
+maractus
+mareanie
+mareep
+marill
+marowak
+marshtomp
+maschiff
+masquerain
 master ball
+masterpiece teacup
+maushold
+mawile
+medicham
+meditite
+mega stone
+meganium
+melmetal
+meloetta
+meltan
+meowscarada
+meowstic
+meowth
+mesprit
+metagross
+metang
+metapod
 mew
 mewtwo
+mienfoo
+mienshao
+mightyena
+milcery
+milotic
+miltank
+mime jr.
+mimikyu
+minccino
+minior
+minun
+miraidon
+misdreavus
+mismagius
 moltres
+monferno
+moon ball
+morelull
+morgrem
+morpeko
+mothim
+mr. mime
+mr. rime
+mudbray
+mudkip
+mudsdale
+muk
+munchlax
+munkidori
+munna
+murkrow
+musharna
+nacli
+naclstack
+naganadel
+natu
 necrozma
+neo team plasma
+nest ball
+net ball
+nickit
+nidoking
+nidoqueen
+nidoran
+nidorina
+nidorino
+nihilego
+nincada
+ninetales
+ninjask
+noctowl
+noibat
+noivern
+nosepass
+numel
+nuzleaf
+nymble
+oblivia
+obstagoon
+octillery
+oddish
+ogerpon
+oinkologne
+okidogi
+omanyte
+omastar
+onix
+orange islands
+oranguru
+orbeetle
+oricorio
+origin ball
+origin ore
+orre
+orthworm
+oshawott
+overqwil
+pachirisu
+palafin
 paldea
 palkia
+palossand
+palpitoad
+pancham
+pangoro
+panpour
+pansage
+pansear
+paras
+parasect
+park ball
+passimian
+passio
+patrat
+pawmi
+pawmo
+pawmot
+pawniard
+peat block
+pecharunt
+pelipper
+perrserker
+persian
+petilil
+phanpy
+phantump
+pheromosa
+phione
 pichu
+pidgeot
+pidgeotto
+pidgey
+pidove
+pignite
 pikachu
+pikipek
+piloswine
+pincurchin
+pineco
+pinsir
+piplup
+plusle
+pml
+poipole
 pokeball
 pokedex
+pokémon pinchers
+politoed
+poliwag
+poliwhirl
+poliwrath
+polteageist
+ponyta
+poochyena
+popplio
+porygon
+porygon-z
+porygon2
+premier ball
+primarina
+primeape
+prinplup
+prison bottle
+probopass
+psyduck
+pumpkaboo
+pupitar
+purrloin
+purugly
+pyroar
+pyukumuku
+quagsire
+quaquaval
+quaxly
+quaxwell
+quick ball
+quilava
+quilladin
+qwilfish
+raboot
+rabsca
+raging bolt
+raichu
+raikou
+ralts
+rampardos
+ransei
+rapidash
+raticate
+rattata
 rayquaza
+regice
+regidrago
+regieleki
+regigigas
+regirock
+registeel
+relic band
+relic copper
+relic crown
+relic gold
+relic silver
+relic statue
+relic vase
+relicanth
+rellor
+remoraid
+repeat ball
 reshiram
+reuniclus
+revavroom
+reveal glass
+rhydon
+rhyhorn
+rhyperior
+ribombee
+rillaboom
+riolu
+roaring moon
+rockruff
+roggenrola
+rolycoly
+rookidee
+roselia
+roserade
+rotom
+rowlet
+rufflet
+runerigus
+ryme city
+sableye
+safari ball
+salamence
+salandit
+salazzle
+samurott
+sandaconda
+sandile
+sandshrew
+sandslash
+sandy shocks
+sandygast
+sawk
+sawsbuck
+scatterbug
+sceptile
+scizor
+scolipide
+scorbunny
+scovillain
+scrafty
+scraggy
+scream tail
+scroll of darkness
+scroll of waters
+scyther
+seadra
+seaking
+sealeo
+seedot
+seel
+seismitoad
+sentret
+serperior
+servine
+sevii islands
+seviper
+sewaddle
+sharpedo
+shaymin
+shedinja
+shelgon
+shellder
+shellos
+shelmet
+shieldon
+shiftry
+shiinotic
+shinx
+shroodle
+shroomish
+shuckle
+shuppet
+sigilyph
+silcoon
+silicobra
+silph co.
+silvally
+simipour
+simisage
+simisear
+sinistea
 sinnoh
+sirfetch'd
+sizzlipede
+skarmory
+skeledirge
+skiddo
+skiploom
+skitty
+skorupi
+skrelp
+skuntank
+skwovet
+slaking
+slakoth
+sliggoo
+slither wing
+slowbro
+slowking
+slowpoke
+slugma
+slurpuff
+smeargle
+smoliv
+smoochum
+sneasel
+sneasler
+snivy
+snom
+snorlax
+snorunt
+snover
+snubbull
+sobble
 solgaleo
+solosis
+solrock
+spearow
+spectrier
+spewpa
+spheal
+spidops
+spinarak
+spinda
+spiritomb
+spoink
+sport ball
+sprigatito
+spritzee
+squawkabilly
 squirtle
+stakataka
+stantler
+staraptor
+staravia
+starly
+starmie
+staryu
+steelix
+steenee
+stonjourner
+stoutland
+strange ball
+stufful
+stunfisk
+stunky
+sudowoodo
 suicune
+sunflora
+sunkern
+surskit
+swablu
+swadloon
+swalot
+swampert
+swanna
+sweet apple
+swellow
+swinub
+swirlix
+swoobat
+sylveon
+sync stone
+sync stone ultimate
+syrup apple
+tadbulb
+taillow
+talonflame
+tandemaus
+tangela
+tangrowth
+tapu bulu
+tapu fini
+tapu koko
+tapu lele
+tarountula
+tart apple
+tatsugiri
+tauros
 team aqua
+team cipher
+team dim sun
 team flare
 team galactic
 team magma
+team meanies
 team plasma
+team rainbow rocket
 team rocket
 team skull
+team snag'em
 team star
 team yell
+teddiursa
+tentacool
+tentacruel
+tepig
+tera orb
+terapagos
+terrakion
+thievul
+throh
+thundurus
+thwackey
+timburr
+timer ball
+ting-lu
+tinkatink
+tinkaton
+tinkatuff
+tirtouga
+toedscool
+toedscruel
+togedemaru
+togekiss
+togepi
+togetic
+torchic
+torkoal
+tornadus
+torracat
+torterra
+totodile
+toucannon
+toxapex
+toxel
+toxicroak
+toxtricity
+trainer lodge
+tranquill
+trapinch
+treecko
+trevenant
+tropius
+trubbish
+trumbeak
+tsareena
+turtonator
+turtwig
+tympole
+tynamo
+type: null
+typhlosion
+tyranitar
+tyrantrum
+tyrogue
+tyrunt
+ultra ball
 ultra beasts
+umbreon
+unfezant
 unova
+unown
+unremarkable teacup
+ursaluna
+ursaring
+urshifu
+uxie
+vanillish
+vanillite
+vanilluxe
+vaporeon
+varoom
+veluza
+venipede
+venomoth
+venonat
+venusaur
+vespiquen
+vibrava
+victini
+victreebel
+vigoroth
+vikavolt
+vileplume
+virizion
+vivillon
+volbeat
+volcanion
+volcarona
+voltorb
+vullaby
+vulpix
+wailmer
+wailord
+walrein
+wartortle
+watchog
+wattrel
+weavile
+weedle
+weepinbell
+weezing
+whimsicott
+whirlipede
+whiscash
+whismur
+wigglytuff
+wiglett
+wimpod
+wing ball
+wingull
+wishiwashi
+wo-chien
+wobbuffet
+woobat
+wooloo
+wooper
+wormadam
+wugtrio
+wurmple
+wynaut
+wyrdeer
+xatu
+xerneas
+xurkitree
+yamask
+yamper
+yanma
+yanmega
+yungoos
+yveltal
+z-crystal
+z-ring
+zacian
+zamazenta
+zangoose
 zapdos
+zarude
+zebstrika
 zekrom
+zeraora
+zigzagoon
+zoroark
+zorua
+zubat
+zweilous
+zygarde

--- a/lists/fiction/star-trek.yml
+++ b/lists/fiction/star-trek.yml
@@ -3,11 +3,16 @@ title: Star Trek
 category: fiction
 description: "Unique names from Star Trek — places, peoples, creatures, factions, and ships combined."
 ---
+acamar iii
 acamarite
 aenar
+akira-class
+akiraprise
 aldara
+aldea
 aldean
 alpha centauri
+ambassador-class
 andoria
 andorian
 andorian imperial guard
@@ -18,8 +23,12 @@ antedean
 antican
 archer iv
 argelius ii
+arkonian
+axanar
+axanarite
 azati prime
 b'hala
+b'rel-class
 ba'ku
 ba'ul
 babel
@@ -27,6 +36,7 @@ bajor
 bajoran
 bajoran militia
 bajoran provisional government
+balthazar
 bandi
 barzan
 benthan guard
@@ -38,15 +48,25 @@ bok'nor
 bolarus ix
 bolian
 boreth
+borg
 borg collective
 borg cooperative
+bree
 breen
 breen confederacy
 brekkian
+bressa
+brikar
+brikarian
+bross
 brunali
+bzzit khaht
+caatati
+cairn
 cait
 caitian
 calamarain
+caldonian
 caldos colony
 capella iv
 capellan
@@ -57,27 +77,42 @@ cardassian liberation front
 cardassian union
 carraya iv
 casperia prime
+centaur-class
 ceti alpha v
+ceti alpha vi
 cetus iii
+challenger-class
 chalnoth
 chameloid
+changeling
+chelarian
 cheron
 children of tama
+chimera-class
 chin'toka
+chulak
 columbia nx-02
 columbus
 confederation of earth
+constellation-class
+constitution-class
 copernicus
 coppelius
 coridan
 cult of the pah-wraiths
 curie
 cytherian
+d'deridex-class
+daedalus-class
 dakhur province
+danube-class runabout
+daxam
 daystrom institute
 deep space 9
 deep space station k-7
+defiant-class
 dekendi iii
+delphic
 delta vega
 deltan
 deneva
@@ -88,6 +123,7 @@ detapa council
 devidian
 devore imperium
 dikironium cloud creature
+dominion
 dosi
 douwd
 earth
@@ -100,13 +136,17 @@ edosian
 efrosian
 ekosian
 el-adrel iv
+el-auria
 el-aurian
+ellora
+elorg
 emerald chain
 empok nor
 enaran
 enterprise nx-01
 excalbia
 excalbian
+excelsior-class
 farius prime
 federation news network
 fenris rangers
@@ -116,16 +156,22 @@ ferengi commerce authority
 ferenginar
 feynman
 first federation
+flaxian
 fluidic space
 founder
+frall
 freecloud
+freedom-class
+gaarian
 galadoran
+galaxy-class
 galdonterre
 galileo
 galileo ii
 gallamite
 galorndon core
 ganges
+genesis planet
 gideon
 gomtuu
 gorn
@@ -135,6 +181,7 @@ haakonian
 haakonian order
 haliian
 halkon
+halon
 hawking
 hazari
 hirogen
@@ -148,7 +195,10 @@ house of mo'kai
 house of mogh
 house of quark
 hur'q
+husnock
+i.s.s. enterprise
 iconian
+ikonian
 iks amar
 iks bortas
 iks gr'oth
@@ -163,8 +213,13 @@ iks rotarran
 iks t'ong
 iks toh'kaht
 iks way'toq
+ilidarian
+illurian
 illyrian
+imaran
+intrepid-class
 iotian
+ircan
 irw belak
 irw bloodwing
 irw gal gath'thong
@@ -176,18 +231,24 @@ irw valdore
 j'naii
 jahsepp
 janus vi
+jarada
 jem'hadar
 jupiter
 jupiter station
+k't'inga-class
+kadi
+kaelonian
 kaminar
 karemma
 karemma commerce ministry
+karigan
 kataan
 kazon
 kazon collective
 kazon-nistrim
 kazon-ogla
 kazon-pommar
+kazon-relic
 kazon-relora
 kelpien
 kelvan
@@ -203,39 +264,61 @@ kohn-ma
 korinas
 kraxon
 krayton
+kreetassan
 krenim
 krenim imperium
 krios prime
 kriosian
+kronos
 kronos one
 ktarian
 kumari
+kurian
+kurlan
 kzinti
 la sirena
 lakarian city
 lake cataria
 le-matya
 lethean
+lhara
 ligonian
+lissepian
+llaran
 luna
+lurian
 lurman
+lyran
+m-class planet
 macrovirus
 magellan
 makus iii
+malcorian
 malon
 malon export module
+maquis
+mari
 mars
+mazarite
 medusan
 mekong
 melkot
 melkotian
 mellanoid slime worm
+melona iv
 memory alpha
+menthar
 metron
+michelians
 military assault command operations
 mintaka iii
 mintakan
+miradorn
+miranda-class
+mizarian
 moab iv
+mokra
+monac
 monks of boreth
 moopsy
 mordan iv
@@ -245,41 +328,63 @@ na'kuhl
 nacene
 narada
 narendra iii
+nausicaa
 nausicaan
+nebula-class
+nechani
+negh'var-class
 neural
 new berlin
 new orleans
 ni'var
 nibiru
 nimbus iii
+norway-class
 nova squadron
+nova-class
+numiri
 nyberrite alliance
+nyrean
 nyrian
+oberth-class
 obsidian order
 ocampa
+olympic-class
 order of the bat'leth
 organia
 organian
 orinoco
 orion
+orion prime
 orion syndicate
 ornaran
 pah-wraith
 pahvo
 pakled
+parada
 paris
+parmen
+paxan
 peliar zel
+peltian
+penthe
+phasm
 phoenix
 phylosian
 pluto
 prakesh
 praxis
+promellian
+prometheus-class
 prophet
 q
 q continuum
 qo'nos
 qowat milat
+qu'vat
 quark's treasure
+rakhar
+ramuran
 ravinok
 red squad
 reman
@@ -303,6 +408,7 @@ rubicun iii
 rura penthe
 rutia iv
 rutian
+saber-class
 san francisco
 saturn
 sauria
@@ -311,21 +417,26 @@ scalos
 scimitar
 section 31
 sehlat
+selay
 seleya
 setlik iii
 sh'ran
 sha ka ree
 shakaar resistance cell
+shatras
 sheliak
 sheliak corporate
 shenandoah
+sherman's planet
 shi'kahr
 sikarian
 sikaris
 skrreea
+skrreeea
 son'a
 son'a command
 son'a prime
+sovereign-class
 space amoeba
 species 8472
 sphere 41
@@ -345,17 +456,21 @@ ss vico
 ss xhosa
 starbase 11
 starbase 173
+starbase 39-vienna
 starbase 74
 starfleet
 starfleet academy
 starfleet intelligence
 starfleet medical
+steamrunner-class
 suliban
 suliban cabal
 suurok
 syrannites
 t'plana-hath
+tak tak
 tal shiar
+talar
 talarian
 talarian republic
 talax
@@ -365,14 +480,19 @@ talos iv
 talosian
 tamarian
 tarchannen iii
+tarei
 tarellian
 targ
+tarkannan
+tarkassian
 tarsus iv
 taurus ii
 tellar prime
 tellarite
 temporal integrity commission
 ten-c
+terellian
+terok nor
 terra prime
 terran empire
 thasian
@@ -433,8 +553,47 @@ tribble
 trill
 triskelion
 tycho city
+tygokor
 tzenkethi
 tzenkethi coalition
+u.s.s. aegis
+u.s.s. al-batani
+u.s.s. bellerophon
+u.s.s. benjamin franklin
+u.s.s. centaur
+u.s.s. challenger
+u.s.s. constellation
+u.s.s. constitution
+u.s.s. dauntless
+u.s.s. defiant
+u.s.s. equinox
+u.s.s. excelsior
+u.s.s. farragut
+u.s.s. galaxy
+u.s.s. grissom
+u.s.s. hathaway
+u.s.s. hood
+u.s.s. intrepid
+u.s.s. lakota
+u.s.s. lantree
+u.s.s. melbourne
+u.s.s. pasteur
+u.s.s. pegasus
+u.s.s. phoenix
+u.s.s. prometheus
+u.s.s. reliable
+u.s.s. renegade
+u.s.s. repulse
+u.s.s. rutledge
+u.s.s. saratoga
+u.s.s. shenzhou
+u.s.s. sovereign
+u.s.s. stargazer
+u.s.s. thunderchild
+u.s.s. valiant
+u.s.s. voyager
+u.s.s. yamato
+u.s.s. yeager
 ullian
 unimatrix zero
 united earth space probe agency
@@ -514,6 +673,7 @@ vaadwaur supremacy
 vagra ii
 val jean
 valakian
+valakis
 vau n'akat
 vedek assembly
 vega colony
@@ -526,14 +686,19 @@ vidiian
 vidiian sodality
 vissian
 volga
+vor'cha-class
 vorta
 voth
 vulcan
+vulcan d'kyr type
 vulcan expeditionary group
 vulcan high command
 vulcan science academy
 wadi
+wadran
+warbird
 wolf 359
+wyr
 xindi
 xindi council
 xindi-aquatic
@@ -550,9 +715,12 @@ xindus
 yangtze kiang
 yonada
 yridian
+ysidian
 yukon
 zakdorn
 zaldan
 zalkonian
+zania
+zaran
 zeon
 zhat vash

--- a/lists/fiction/star-wars.yml
+++ b/lists/fiction/star-wars.yml
@@ -4,31 +4,61 @@ category: fiction
 description: "Unique names from Star Wars — places, peoples, creatures, factions, and ships combined."
 ---
 abafar
+abednedo
 abyssin
 acklay
+adnerb
+advozse
 agamar
 ahch-to
 aiwha
 alderaan
 aldhani
 aleena
+alliance to restore the republic
+almania
 alphabet squadron
+altier
+alzir
+amanaman
+amani
 amanin
+ambria
+anaxes
 anchorhead
+ando
+annooan
 anooba
+ansion
+antamyn
+antares
+antemeridias
+anzat
 anzati
 aqualish
+arc-170 starfighter
 arcona
+aridus
+arkanian
+arkanis
 ascendant justice
+asogian
 atollon
+atzerri
 avenger
+b-wing starfighter
+bakura
+balmorra
 bantha
+barab i
 barabel
 batuu
 beggar's canyon
 besalisk
 bespin
 bestoon legacy
+bimm
+bimmisaari
 bith
 black one
 black spire outpost
@@ -42,14 +72,20 @@ blurrg
 bogano
 bogling
 boma
+bonadan
+borao
 borcatu
 bordok
+borleias
 bothan
+bounty hunters' guild
 bracca
+byss
 caamasi
 can-cell
 canto bight
 cantonica
+carida
 carrion spike
 castilon
 cato neimoidia
@@ -58,21 +94,36 @@ chadra-fan
 chagrian
 chalmun's cantina
 chandrila
+charon
 chimaera
 chiss
+chiss ascendancy
+claw fish
 clawdite
 clone force 99
 cloud city
+cloud-riders
+codru-ji
+colicoid
+colla iv
 colo claw fish
 colossus
+commenor
 concord dawn
+confederacy of independent systems
 conqueror
+consular-class space cruiser
+contruum
 convoree
 corellia
 corellian engineering corporation
 corellian hound
 coronet city
+corporate alliance
 coruscant
+covax
+coway
+cr90 corvette
 crait
 crimson dawn
 csilla
@@ -83,6 +134,7 @@ dantooine
 dathomir
 death star
 death star ii
+death watch
 defel
 delta squad
 devaron
@@ -90,13 +142,19 @@ devaronian
 devastator
 dewback
 dianoga
+dreadnought-class heavy cruiser
 dressellian
+dromund kaas
+duro
 duros
 eadu
 echo base
+elomin
 endor
 eopie
 eriadu
+esseles
+eta-2 actis-class light interceptor
 ewok
 exactor
 executor
@@ -108,31 +166,50 @@ felucia
 ferrix
 finalizer
 firestrike
+firrerre
+flakax
 flesh raider
 florrum
 fondor
 fondor shipyards
 forger
 fortress inquisitorius
+fosh
 freetown
+fury-class imperial interceptor
 fyrnock
+galantos
 gand
 garel
+garos iv
 geonosian
 geonosis
+ghorman
 gigorian
+givin
 gizka
+gladiator-class star destroyer
+glee anselm
 gold squadron
 gorg
 gotal
+gozanti-class cruiser
 gran
 griffin
 guarlara
+guavian death gang
 gundark
 gungan
+gyro
+hammerhead corvette
+hapes
 harch
+haruun kal
 hawk-bat
+herglic
+ho'din
 home one
+honoghr
 hosnian prime
 hoth
 houk
@@ -145,60 +222,99 @@ house vandron
 house vizsla
 house wren
 hutt
+hutt cartel
 ig-2000
 iktochi
 ilum
+imperial senate
+imperial-class star destroyer
 implacable
 incom corporation
 indomitable
 inferno squad
+inquisitorius
 interdictor
+interdictor-class star destroyer
+interstellar banking clan
 intrepid
 invisible hand
 ishi tib
+ithor
 ithorian
 jabba's palace
 jakku
 jawa
 jedha
 jedha city
+jedi order
 joopa
 judicator
 justice
 kaadu
+kal'shebbol
+kalarba
 kamino
 kaminoan
 kanjiklub
+karkarodon
 kashyyyk
 kath hound
 kef bir
 kel dor
 kell dragon
 kessel
+khil
+khomm
+kiffar
 kijimi
 kinrath
+kitonak
+klatooinian
+knights of ren
+korriban
+kovis
 krayt dragon
 krownest
 krykna
 kuat
 kuat drive yards
 kubaz
+kurshi
+kushiban
 kybuck
+kyuzo
 lah'mu
+lambda-class t-4a shuttle
+lancer-class frigate
+lannik
 lars moisture farm
 lasat
+lianna
+lok
+lola sayu
 loth-cat
 loth-wolf
 lothal
 lotho minor
+lucrehulk-class battleship
 lurmen
+lutrillan
 lwhekk
 malachor
 malastare
 malevolence
+mandalorians
+marian
+maridun
 massiff
 maz's castle
+mc80 liberty type star cruiser
+melodie
+metalorn
+militia of ryloth
 mimban
+mining guild
+miraluka
 mirialan
 mist hunter
 mon cala
@@ -208,36 +324,60 @@ mortis
 mos eisley
 mos espa
 mos pelgo
+mrlsst
 mudhorn
 mustafar
 mustafarian
 muun
+muunilinst
 mygeeto
+myneyrsh
 mynock
 mythrol
 naboo
 nal hutta
+nam chorios
 nar shaddaa
 nautolan
+nebula-class star destroyer
+nebulon-b frigate
+neebray
 negotiator
 neimoidian
+nelllah
 nerf
+neti
 nevarro
 nexu
 niamos
+nightsisters of dathomir
 niima outpost
+nikto
+nkllon
+noghri
+nosaurian
+nuba
+nuknog
 numidian prime
 nuna
+obroa-skai
 omega squad
 onderon
+ondoron
+one sith
 opee sea killer
 oppressor
 ord mantell
+ord radama
+orinda
 ortolan
 ossus
 otoh gunga
+pa'lowick
 pacifier
+pacithhip
 paladin
+panna
 pantora
 pantoran
 pasaana
@@ -245,39 +385,64 @@ patriot
 pau'an
 peacekeeper
 peko-peko
+pelleaeon
+pelta-class frigate
+phindel
 phoenix squadron
+phyryx
+pinnacle base
 pioneer
 plunderer
 polaris
 polis massa
 porg
+prakith
 profundity
 protector
+providence-class destroyer
 punishing one
 purrgil
 pursuer
+pydyr
 pyke
+pyke syndicate
+pyrshak
 quarren
 quarzite
+quasar fire-class cruiser-carrier
+quermian
 rakata
+ralltiir
+ranat
 rancor
+rathalay
 rathtar
+rattatak
 ravenous
 reckoning
+recusant-class light destroyer
 red squadron
 redoubtable
 reek
 relentless
 republic intelligence
+republic senate
 resolute
 retribution
+rhen var
+ri'dar
 righteous
+roche asteroids
 rodian
 rogue squadron
 ronto
+runi
+rutan
 ruusan
 ryloth
+ryn
 ryndellia
+sacorria
 saleucami
 sando aqua monster
 sarlacc
@@ -285,38 +450,63 @@ savareen
 scarif
 scipio
 scurrier
+sector rangers
 selkath
+selonia
+selonian
+sentinel-class landing craft
+separatist alliance
 serenno
 shaak
+sheathipede-class transport shuttle
 shili
 shistavanen
 sienar fleet systems
+sith order
+skako
 skako minor
 sketto
 slave i
 snivvian
 soulless one
 sovereign
+space slug
 squib
+sriluur
+ssi-ruu
 stalker
+star dreadnought
 starbreaker 12
 starkiller base
 steadfast
+subjugator-class heavy cruiser
+subterrel
 sullust
 sullustan
 sundari
 supremacy
+t-65b x-wing starfighter
 tactician
 takodana
+talasea
 tallon
+talus
 talz
+tanaab
 tantive iv
+tarasin
+taris
 tatooine
 tauntaun
+techno union
+teek
+teepo
 temple of the kyber
+tepasi
 terentatek
 terror
 teth
+thakwaash
 the 104th battalion
 the 212th attack battalion
 the 501st legion
@@ -495,55 +685,105 @@ the zann consortium
 the zeison sha
 the zillo beast
 theed
+theta-class t-2c shuttle
+thisspiasian
 thunderstrike
+thuul
+thyferra
+tie advanced x1
+tie/d defender
+tie/in interceptor
+tie/sa bomber
+tie/sk striker
+tinnell
 tipoca city
 titan
 titan squadron
 togruta
+toong
+toong'l
 torment
 tosche station
 toydaria
 toydarian
+trade federation
+tralus
 trandosha
 trandoshan
 triumph
 tuk'ata
+tund
 tusken raider
 twi'lek
 tyrant
 tython
+u-wing starfighter
 ugnaught
 umbara
 umbaran
+upsilon-class command shuttle
+urone
 utapau
+utoppan
+uxruan
+vaapad
 vader's castle
+valc vii
+valiant-class star destroyer
 vandor
+vandor-1
+vandor-3
 vanguard
 vanguard squadron
 vanquisher
 varactyl
+venator-class star destroyer
 vengeance
 verpine
 vexis
 victorious
+victory-class star destroyer
 vindicator
+vjun
+vodran
+vong
 vornskr
+vortex
 vulptex
 wampa
+wayland
 weequay
 weik
+wey land
+whiphid
 womp rat
 wookiee
 worrt
+wraith squadron
+wrall
+wronian
+wroona
+x'ting
+xanadu
 xanadu blood
+y-wing starfighter
 yarkora
 yavin 4
+yavin 8
 yavin prime
+yavin xiii
+ylesia
 ysalamiri
+yt-1300 light freighter
+yt-2400 light freighter
 yuzzum
+z-95 headhunter
 zabrak
 zanbar
 zeffo
+zeltron
 ziost
+zolfe
+zonaama sekot
 zygerria
 zygerrian

--- a/lists/fiction/transformers.yml
+++ b/lists/fiction/transformers.yml
@@ -3,62 +3,353 @@ title: Transformers names
 category: fiction
 description: "Places, factions, species, artifacts, and groups from Transformers"
 ---
+acid storm
+acis
 aerialbots
+air raid
+alicon
+aligned continuity
 allspark
 alpha trion
+altihex
+anode
+antilla
+apelinq
+apex armor
+aquablast
+arachnid
+arc
 ark
+ark-19
+armada
+astrotrain
 autobot matrix
 autobots
+axalon
+axial park
+backop
+baffle
+banzai-tron
+barricade
 beast machines
+beast mode
 beast wars
+beast wars neo
+beta max
+binaltech
+binary-bonding
+bio-card
+bitstream
+black arachnia
+black shadow
+blast off
+blaster
+blitzwing
+bluestreak
+blurr
+boneyard
+bouldercrash
+brawn
+breakdown
+broadside
+browning
+bruticus
+bugbite
+bullhorn
 bumblebee
+calcar
+car robot
+carnivac
+centurion
+cerebros
+chemjet
+chrome
+chromia
+clash
+clench
+cliffjumper
+clocker
+cloudraker
+codex
+cognizant
+collector
 combaticons
+combatron
+computron
+coneheads
+conner
 constructicons
+cop-tur
+cosmictrain
+cosmos
+covenant of primus
+crosshairs
+cruellock
+cyber-bee
+cyberkey
+cyberplanet
 cybertron
+cybertron central
+cybertronian
+cyclonus
+daimler
 dark energon
+darkmount
+decepticharge
 decepticons
+deceptigod
+deepcover
+defensor
+delta magnus
+depth charge
 devastator
+devcon
+die-cast
 dinobot
 dinobots
+dirge
+doubledealer
+drag strip
+dreadwind
+duocon
+duststorm
+e-hobby
+eject
 elita one
 energon
+energon cube
+enigma of combination
+enon
+erector
+exillion
+fasttrack
+ferrokons
+fireflight
+fistfight
+flame war
+fracture
+frenzy
+fuzor
 galvatron
+gears
+generation 1
+generation 2
+giga
+gigantion
+glit
+grand maximus
+grapple
+great war
 grimlock
+gringo
+groove
+grotusque
+guzzle
+hardhead
+haywire
+headmaster
+heave
+heavy metal
+highbrow
+hoist
+hollow
 hot rod
+hound
+huffer
+huntsman
+hydra
+hyperdrive
+iacon
+impactor
+inferno
+insecticon
 insecticons
 ironhide
+ironworks
+jackpot
+jallguar
+jazz
+jetfire
 junkions
+kaon
+kickback
+krok
+kup
+lancer
+laserbeak
+leobreaker
+liege maximo
+liokaiser
+lockdown
+long haul
+lugnut
+maccadam
+maccadams old oil house
+magmatron
+magnus
+mainframe
+masterpiece
 matrix of leadership
 maximals
 megatron
+megatronus
+menasor
+metalhawk
 metrobase
 metroplex
+micron
 minicons
+mirage
+misfire
+mudflap
+mutation
 nemesis
+nightbeat
+nitro convoy
+nova prime
+novastar
+octane
 omega lock
+omega supreme
+oneshallstand
+onslaught
+optimal optimus
 optimus prime
+orion pax
+outback
+overlord
+pathfinder
+penn
+perceptor
+pious
+pipes
+pitted
+pook
+powerglide
+powermaster
+predacon
 predacons
+predaking
+prime
+primordial
 primus
+profectus
 protoform
+prowl
+punch-counterpunch
+quack
+quant
+quickslinger
+quickswitch
+quintesson
 quintessons
+ramjet
+rampage
+ransack
 ratchet
+ravage
+re-entry
+red alert
+reflux
+reformatting
+repugnus
+rescue bots
+rev
+rewind
+rhinox
+roadblock
+roadbuster
 rodimus prime
+runabout
+runamuck
+rust sea
+sandstorm
+scourge
+scraplets
+scrapmetal
+seaspray
+sector 7
 seeker
+seekers
 sentinel prime
+shattered glass
 shockwave
+shrapnel
+sideswipe
+silverbolt
+sixshot
+skids
+sky-byte
+skydive
 skyfire
+skywarp
+slag
+slingshot
+sludge
+snarl
+solus prime
+soundblaster
 soundwave
+space bridge
 spark
+sparkplug
+spinet
 starscream
 stasis pod
+steve
+strafe
+streetwise
+strongarm
 stunticons
+submara
+sunstreaker
+superion
+swerve
+swindle
+swoop
+tarantulas
+tarn
+technobots
 teletraan i
+teletran
+terrorsaur
 the allspark
 the covenant of primus
+the fallen
 the matrix
 the primes
+the rust
 the wreckers
+thrust
+thundercracker
+thunderwing
+tigatron
+titanium
+tomy
+topspin
+tracks
+trailbreaker
+treadshot
 triple changer
+tripticon
+twin twist
+twixt
+ultra magnus
+underbite
 unicron
+uprising
+vector prime
 vector sigma
+velocity
+vortex
+warpath
+waspinator
+weirdwolf
+wheelie
 wheeljack
+windblade
+windcharger
+wreck-gar
+wreckers
+zenith
+zeta prime

--- a/lists/fiction/warcraft.yml
+++ b/lists/fiction/warcraft.yml
@@ -4,74 +4,269 @@ category: fiction
 description: "Places, peoples, factions, creatures, artifacts, and powers from the Warcraft universe"
 ---
 a'dal
+aberus
+abyssal
+adamantite
+aegwynn
 ahn'qiraj
+akama
+alexstrasza
 alleria
+alleria windrunner
 alterac
+amirdrassil
+anasterian
+anduin wrynn
+antorus the burning throne
+anub'arak
+anubisath
+arbiter
+arcanite
+archimonde
+archon
+argent crusade
+argent dawn
 argus
 arthas
+arthas menethil
+ashbringer
 ashenvale
+ateish
+auchendoun
+aysa cloudsinger
 azeroth
 azshara
+azsuna
+baine bloodhoof
+balnazzar
+bastion of twilight
+battle for mount hyjal
+battle of dazar'alor
+black temple
+blackfathom deeps
+blackhand
+blackrock depths
+blackrock foundry
 blackrock mountain
+blackrock spire
+blackwing descent
+blackwing lair
+bolvar fordragon
+boralus
+broken isles
+broken shore
+bronzebeard
 burning blade
 burning legion
+bwonsamdi
+c'thraxxi
+c'thun
+cairne bloodhoof
+castle nathria
 cenarion circle
+cenarius
+chen stormstout
+cho'gall
+coilfang reservoir
+court of farondis
+crucible of storms
 dalaran
+dark iron dwarf
 dark portal
 darnassus
+dazar'alor
+death knight
 deathwing
+demon hunter
+detheroc
+dire maul
+doomguard
+dracthyr
 draenei
 draenor
+dragon soul
+dragonwrath
+draka
+dreamweavers
 druid of the claw
 dun morogh
+durotan
 durotar
 earthen ring
 eastern kingdoms
+elementium
+elune
 emerald dream
+emerald nightmare
+eternal palace
+evoker
 exodar
+faceless one
+fangs of the father
+fel iron
+felguard
+felhound
+felslate
+firelands
 forsaken
+freya
 frostmourne
+fyrakk
 gallywix
+garrosh hellscream
+ghost iron
 gnomeregan
+golden lotus
+gorloc
+grommash hellscream
 grommash hold
+grummle
+gruul's lair
 gul'dan
+hagara
+heart of fear
 hellfire citadel
+helya
+highmaul
 highmountain
+highmountain tribe
+hodir
 horde
+hozen
 hyjal
+icecrown citadel
 illidan
+illidan stormrage
+infernal
+iridikron
+iron dwarf
 ironforge
+jailer
+jaina proudmoore
+ji firepaw
+jinyu
+kael'thas sunstrider
+kalecgos
 kalimdor
 karazhan
+keeper
 kel'thuzad
+khadgar
+khorium
+kil'jaeden
+king rastakhan
 kirin tor
+klaxxi
+kul tiran
 kul tiras
+kyparite
+kyrian
+lady vashj
+leystone
+li li stormstout
 lich king
 lightforged draenei
+loa
+loa of graves
+loken
 lordaeron
+lorewalker cho
+lorthemar theron
+lost ones
 maelstrom
+mag'har orc
+magtheridon's lair
+maiev shadowsong
+mal'ganis
 malfurion
+malfurion stormrage
 malygos
+mantid
+maraudon
+mechagnome
+mechagon
+medivh
+mimiron
+mithril
 mogu
+mogu'shan vaults
 molten core
+n'zoth
+naaru
 naga
+nathanos blightcaller
+naxxramas
 nazjatar
+necrolord
+nefarian
 neltharion
+ner'zhul
+nerubian
+night fey
 nightborne
+nightfallen
+nighthold
 northrend
+nozdormu
+ny'alotha
+obsidian destroyer
+odyn
+old god
+onyxia
+orgrim doomhammer
 orgrimmar
 outland
 pandaria
+pit lord
+primus
+qiraji
 quel'thalas
+ragefire chasm
 ragnaros
+raszageth
+razorfen downs
+razorfen kraul
+ruby sanctum
+ruins of ahn'qiraj
+runeblade
+rustbolt resistance
+sanctum of domination
+sargeras
+saronite
+saurok
+scarlet monastery
+scholomance
 scourge
+sen'jin
+sepulcher of the first ones
+serpentshrine cavern
+shadowfang keep
 shadowlands
+shadowmourne
+shadowpan
+shandris feathermoon
 shattrath
+shivarra
+siege of orgrimmar
 silvermoon
+sire denathrius
+stormheim
 stormwind
 stranglethorn
+stratholme
+succubus
+sulfuras
+sunwell plateau
+suramar
 sylvanas
+sylvanas windrunner
+talanji
+taran zhu
+taunka
 tauren
+tempest keep
+temple of ahn'qiraj
+terrace of endless spring
 the alliance
 the barrens
 the bronze dragonflight
@@ -82,15 +277,64 @@ the forsaken
 the horde
 the scarlet crusade
 the scourge
+thorim
+thorium
 thrall
+throne of thunder
 thunder bluff
+thunderfury
+tichondrius
+titan
 titan-forged
+tol'vir
+tomb of sargeras
+trial of the crusader
+trial of valor
+trillium
 troll
+truegold
+turalyon
+twilight's hammer
+tyr
+tyrande whisperwind
 uldaman
+uldir
 ulduar
 undercity
+unshackled
+uther the lightbringer
+val'anyr
 val'kyr
+val'sharah
+valarjar
+varian wrynn
+varimathras
+vault of the incarnates
+velen
+venthyr
+vereesa windrunner
+void elf
+void lord
+voidwalker
+vol'jin
+vulpera
+vyranoth
+wailing caverns
 warchief
+wardens
+watcher
 well of eternity
+wild god
+wildhammer
+winter queen
+wolvar
+wrathion
 wyrmrest accord
+y'shaarj
+yaungol
+yogg-saron
+ysera
 zandalar
+zandalari
+zul'gurub
+zul'jin

--- a/lists/fiction/warhammer40k.yml
+++ b/lists/fiction/warhammer40k.yml
@@ -3,6 +3,7 @@ title: Warhammer 40,000
 category: fiction
 description: "Unique names from Warhammer 40,000 — places, peoples, creatures, factions, and ships combined."
 ---
+abaddon the despoiler
 absalom
 adarnian
 adepta sororitas
@@ -17,19 +18,28 @@ adeptus terra
 aeldari
 aexe cardinal
 agripinaa
+ahriman
 alaitoc
 alcazar remembered
+alizebeth bequin
 alpha
 alpha legion
+alpharius
 altansar
 ambull
+amon tauromachian
 angel of retribution
+angron
+archon
 armageddon
 armageddon steel legion
+asdrubael vect
 askellon sector
 astral claws
+asuryan
 attila
 aurelia
+autarch
 avenger
 baal
 baal's orphan
@@ -41,6 +51,7 @@ barghesi
 beast of nurgle
 beastman
 belis corona
+belisarius cawl
 bellus
 beta
 beta-garmon
@@ -48,6 +59,7 @@ biel-tan
 biovore
 black legion
 black templars
+blackshield
 blade of infinity
 blade of vengeance
 blessed lady
@@ -68,11 +80,13 @@ c'tan
 cadia
 cadian shock troops
 caducades
+caestus metalican
 calderis
 caliban
 calixis sector
 callidus temple
 calth
+canoness
 canoptek scarab
 canoptek spyder
 canoptek wraith
@@ -83,18 +97,24 @@ catachan
 catachan barking toad
 catachan devil
 catachan jungle fighters
+cegorach
+chaos space marines
 chaos spawn
+chapter master
 charadon
 chemos
 chogoris
 chroma
+ciaphas cain
 clawed fiend
 colchis
 colossus
+commissar
 commorragh
 conqueror
 corpse guild
 corsair voidscarred
+corvus corax
 covenant of blood
 creations of bile
 crimson fists
@@ -114,9 +134,11 @@ dal'yth
 dal'yth sept
 damocles gulf
 dark angels
+dark apostle
 dark blood
 dark mechanicum
 darkest angel
+de profundis
 death guard
 death korps of krieg
 death's head
@@ -140,6 +162,7 @@ echo of damnation
 echo of despair
 eisenstein
 elysian drop troops
+emperor of mankind
 emperor's benefaction
 emperor's children
 emperor's shield
@@ -153,14 +176,18 @@ eversor temple
 evil sunz
 executioners
 exocrine
+exodites
 exorcists
 eye of terror
+fabius bile
 fal'shia
+farseer
 farsight enclaves
 felinid
 fenris
 fenrisian wolf
 ferrum
+ferrus manus
 fidelitas lex
 fiend of slaanesh
 fire of heaven
@@ -176,23 +203,31 @@ fortis binary
 fortress of arrogance
 fra'al
 freebooterz
+fulgrim
 furious abyss
 galg
 gallowglass
 gargoyle
+garviel loken
 genestealer
+genestealer cults
 gereon
+ghazghkull thraka
 gheden
 ghost of alaitoc
 ghoul stars
+gideon ravenor
 goffs
+golden throne
 gorbag's revenge
+gork
 gork's grin
 gorkamorka
 gothic sector
 graia
 great unclean one
 greater thurian league
+gregor eisenhorn
 grendel's world
 gretchin
 grey knights
@@ -202,10 +237,12 @@ gudrun
 gyrinx
 hades hive
 hadex anomaly
+haemonculus
 halcyon
 halo stars
 hammer of light
 harakoni warhawks
+harlequins
 harpy
 harridan
 haruspex
@@ -213,6 +250,7 @@ herald of dawn
 herald of night
 hierodule
 hierophant
+high lords of terra
 his will
 hive crone
 hive fleet behemoth
@@ -228,6 +266,7 @@ hive secundus
 hive tyrant
 holy terra
 hormagaunt
+horus lupercal
 house cadmus
 house cawdor
 house delaque
@@ -246,10 +285,12 @@ hrud
 hubris
 hunter's premonition
 hydraphur
+ibram gaunt
 icarus iv
 il-kaithe
 imperator somnium
 imperial fists
+imperial guard
 imperial palace
 imperium nihilus
 imperius dictatio
@@ -264,11 +305,14 @@ iron hands
 iron talon
 iron warriors
 ironhead squat prospectors
+isha
 isstvan iii
 isstvan v
 iyanden
 iybraesil
+jaghatai khan
 jericho reach
+john grammaticus
 jokaero
 juggernaut
 jupiter
@@ -280,6 +324,9 @@ kamiti sura
 kar duniash
 kaurava
 keeper of secrets
+khaine
+kharn the betrayer
+khorne
 khrave
 khur
 khymera
@@ -287,6 +334,7 @@ kiavahr
 kill wrekka
 kin
 knarloc
+konrad curze
 koronus expanse
 krieg
 kronus
@@ -299,31 +347,39 @@ lacrymole
 laer
 laeran
 lamenters
+leagues of votann
 legio astorum
 legio audax
 legio fureans
 legio gryphonicus
 legio ignatum
 legio mortis
+leman russ
 lethe eleven
 lex talonis
 lhamaean
+librarian
 lictor
 light of terra
+lion el'jonson
 lion's gate spaceport
 litany of fury
 lord of change
+lorgar aurelian
 lorn v
 loxatl
 lucifer blacks
 lucius
+lucius the eternal
 lugganath
 luna
 maccabian janissaries
 macharius
 macragge
 macragge's honour
+magnus the red
 malanthrope
+malcador the sigillite
 maleceptor
 mandragora
 mantis warriors
@@ -345,19 +401,24 @@ minotaurs
 monarchia
 mordian
 mordian iron guard
+mork
 mork's teef
+mortarion
 murder
 mymeara
 nagi
+nathaniel garro
 navarre
 navis nobilite
 necromunda
 necron
+necrons
 nephilim
 nephrekh dynasty
 neurothrope
 nicassar
 nicor
+night haunter
 night lords
 nightfall
 nihilakh dynasty
@@ -365,6 +426,7 @@ nocturne
 nostramo
 novokh dynasty
 nuceria
+nurgle
 nurgling
 oberon
 octarius
@@ -372,6 +434,7 @@ officio assassinorum
 ogryn
 old one eye
 olympia
+omegon
 omnissiah's victory
 ophelia vii
 order of our martyred lady
@@ -384,6 +447,7 @@ ordo hereticus
 ordo malleus
 ordo sinister
 ordo xenos
+orfeo's lament
 ork
 palanite enforcers
 paragon of terra
@@ -392,6 +456,7 @@ pavonis
 pax imperialis
 pech
 pelager
+perturabo
 phaeton
 phalanx
 phall
@@ -421,6 +486,9 @@ right of man
 righteous fury
 righteous power
 ripper
+roboute guilliman
+rogal dorn
+rogue traders
 rubicon
 rynn's world
 ryza
@@ -430,6 +498,7 @@ saim-hann
 salamanders
 sameter
 samothrace
+sanguinius
 saruthi
 sautekh dynasty
 scholastia psykana
@@ -441,22 +510,27 @@ signus prime
 silence
 simulacra
 sisters of silence
+slaanesh
 slann
 slaugth
 slayer of worlds
 sluggaboy
+sly marbo
 snakebites
 snotling
 solemnace
 song of iyanden
 sons of malice
 sortiarius
+space marines
 space wolves
+spear of the emperor
 speed freeks
 speranza
 spica aurelia
 spindle drone
 spirit of mars
+spiritseer
 spore mine
 squat
 squig
@@ -467,8 +541,10 @@ stryxis
 stygies viii
 sword of retribution
 swordstorm
+szarekh
 szarekhan dynasty
 t'au
+t'au empire
 t'au sept
 tallarn
 tallarn desert raiders
@@ -478,6 +554,7 @@ tarellian
 tarsis ultra
 tartarus
 tears of isha
+tech-priest
 termagant
 terminus est
 thanatos
@@ -502,6 +579,7 @@ the red terror
 the rock
 the rusted claw
 the scourged
+the silent king
 the spear of khaine
 the swarmlord
 the twisted helix
@@ -517,16 +595,20 @@ tigrus
 titan
 toxicrene
 trans-hyperian alliance
+trazyn the infinite
 tribune
 trisagion
 triumph of reason
 truth proves exacting
 trygon
 typhon primaris
+typhus
 tyran
 tyranid
 tyranid warrior
+tyranids
 tyrannofex
+tzeentch
 ullanor
 ulthwe
 ultramarines
@@ -542,6 +624,7 @@ vampire
 vanus temple
 venenum temple
 vengeful spirit
+vengence of the righteous
 venomthrope
 verghast
 vervunhive
@@ -554,7 +637,9 @@ voss prime
 vostroya
 vostroyan firstborn
 vraner
+vulkan
 wages of sin
+warlock
 watchers in the dark
 water guild
 white maw
@@ -564,8 +649,10 @@ word bearers
 world eaters
 wrathful
 xana ii
+yarrick
 ymyr conglomerate
 ynnari
+ynnead
 yu'vath
 zoanthrope
 zoat

--- a/lists/fiction/wheel-of-time.yml
+++ b/lists/fiction/wheel-of-time.yml
@@ -3,84 +3,242 @@ title: Wheel of Time names
 category: fiction
 description: "Places, peoples, creatures, and groups from The Wheel of Time"
 ---
+a'dam
+access key
 aelfinn
+aes sedai
+aginor
+aiel
+alanna mosvani
+algai'd'siswai
+almoren
 almoth plain
 altara
+alwhin
 amadicia
 amador
+amyrlin seat
+amys
 andor
+androl genhald
+angreal
 arad doman
 arafel
+aran'gar
 aridhol
+artur hawking
+asha'man
+ashandarei
+asmodean
+avendesora
+avendoralera
+aviendha
 baerlon
+bain
+bair
+balthamel
 bandar eban
+bayle domon
+be'lal
+beslan
+birgitte silverbow
+black ajah
+black tower
+blue ajah
 braem wood
+brown ajah
+cadsuane melaidhrin
 caemlyn
 cafar
 cairhien
+callandor
+car'a'carn
 chachin
+chiad
+children of the light
+choedan kal
+clan chief
 cold rocks hold
+coramoor
 corlm
+couladin
+cuendillar
+cyndane
+damane
+darkfriend
 darkhound
+deathwatch guard
+dedicated
+demandred
+der'sul'dam
 deven ride
 draghkar
+dragon's fang
 dragonmount
+dreadlord
+dreamspike
+dreamwalker
+dyelin tarbaran
+eamon valda
 ebou dar
 eelfinn
+egeanin
+egwene al'vere
+elaida a'roihan
+elayne trahand
 emond's field
 fade
 fal dara
 fal moran
 falme
+far dareis mai
 far madding
+flame of tar valon
 four kings
+foxhead medallion
+furyk karede
+gai'shain
+gaidin
+galad damodred
+gareth bryne
+gaul
+gawyn trahand
 ghealdan
 gholam
+graendal
+gray ajah
 gray man
+great stump
+great tree
+green ajah
 grolm
 halfman
+hall of the tower
+hand of the light
+heartstone
+heron-mark sword
+high lady
+high lord
+horn of valere
 hot springs hold
+hurin
 illian
+ingtar
+inquisitor
+ishamael
+jaram
+jaret byar
 jehannah
+jenn aiel
 jumara
 kandor
+keeper of the chronicles
+kerrigan
 kinslayer's dagger
+lan mandragoran
+lanfear
+leane sharif
+lews therin telamon
+liandrin
+logain ablar
+loial
 lopar
+lord captain commander
 lugard
+luthair paendrag
+m'hael
 machin shin
+mah'alleinir
 malkier
+manetheren
+mangin
 maradon
+masema dargar
+matrim cauthon
 mayene
+mazrim taim
+melaine
+min farshaw
+moghedien
+moiraine damodred
+morat'grolm
+morat'raken
+morat'torm
+morgase trahand
+moridin
 murandy
 myrddraal
 nym
+nynaeve al'meara
+oath rod
 ogier
+one power
+osan'gar
+padan fain
+pedron niall
+perrin aybara
+pevara tazanovni
+rahvin
 raken
+rand al'thor
+red ajah
+red shields
+rhuarc
 rhuidean
 s'redit
+sa'angreal
+sad bracelets
+saidar
+saidin
 saldaea
 salidar
+sammael
+seaine herimon
+seana
 seanchan
 seandar
+seeker for truth
+selucia
+sept
 shadar logoth
+shaidar haran
+shaido
 shara
 shayol ghul
 shienar
+siswai'aman
+sitters
+siuan sanche
+soldier
 stedding shangtai
 stedding tsofu
+stone dog
+stormleader
+sul'dam
+sulin
+sung wood
+suroth
+ta'veren
+tallanvor
 tanchico
 tar valon
+tarabon
 taren ferry
+taringail damodred
+tarkan
 tarwin's gap
 tear
 tel'aran'rhiod
+ter'angreal
 thakan'dar
 the aiel waste
 the aryth ocean
 the black tower
 the black wind
 the blight
+the blood
 the borderlands
+the chosen
 the eye of the world
 the fields of merrilor
 the gap of tarwin
@@ -102,13 +260,28 @@ the two rivers
 the waygate
 the ways
 the white tower
+thom merrilin
 to'raken
 toman head
 torm
+treesinger
 tremalking
 trolloc
+true power
+true source
+tuon
+tyler
+uno nomesta
+valan luca
+verin mathwin
+warder
 watch hill
+wetlander
+white ajah
 whitebridge
 whitecliff
+whitecloaks
+wise ones
 worms of the blight
+yellow ajah
 zomara

--- a/lists/fiction/witcher.yml
+++ b/lists/fiction/witcher.yml
@@ -6,24 +6,42 @@ description: "Places, kingdoms, schools, peoples, creatures, and objects from Th
 aedirn
 alder folk
 alghoul
+angouleme
 angren
+anna henrietta
 aretuza
+assire var anahid
 avallac'h
 ban ard
 basilisk
+battle of sodden
 beauclair
+blaviken
 blue mountains
+bonhart
 botchling
+brent
 brokilon
+brokilon forest
 bruxa
+butcher of blaviken
 caed myrkvid
 caer a'muirehen
 caer morhen
+cahir
+calanthe
+caranthir
 cidaris
 ciri
+cirilla
 cockatrice
+coen
+conjunction of the spheres
 crinfrid reavers
 crones of crookback bog
+dandelion
+demavend
+dettlaff
 dijkstra
 djinn
 dol blathanna
@@ -31,38 +49,90 @@ doppler
 drowner
 dryads
 dun banner
+duny
+eithne
+elder blood
 ellige
+emhyr
+emhyr var emreis
+emiel regis
 endrega
+eredin
+ermion
+eskel
 everec estate
 feline school
+field marshal windbag
 fiend
+filippa
 flotsam
 foglet
+foltest
 francesca findabair
+fringilla vigo
+ge'els
+geralt
+geralt of rivia
 ghoul
 golden dragon
 gors velen
 griffin school
 hansa
 harpy
+henselt
+imlerith
+jaskier
 kaedwen
+kaer morhen
+keira metz
 kikimore
+king of the wild hunt
 kovir
+lambert
+lara dorren
+law of surprise
+leo bonhart
 leshen
+lodges of sorceresses
 mahakam
 mantichore school
+meve
+milva
+mousesack
 nilfgaard
 novigrad
 ofieri
 oxenfurt
+pavetta
+philippa eilhart
+pontar valley
+radovid
 redania
+regis
 renfri
+rience
 rivia
+roach
+rynse
+sabrina glevissig
+school of the bear
+school of the cat
+school of the griffin
+school of the manticore
+school of the viper
+school of the wolf
 scoia'tael
+shani
+sheala de tancarville
 skellige
+sodden
+sodden hill
+stefan skellen
 striga
+syanna
 temeria
 thanedd
+thanedd coup
 the conjunction of the spheres
 the continent
 the lodge of sorceresses
@@ -72,15 +142,25 @@ tor lara
 toruviel
 toussaint
 tretogor
+trial of the grasses
+triss
+triss merigold
 vattier de rideaux
 velen
 vengerberg
 verden
 vesemir
+vilgefortz
 viper school
 vizima
 vrans
+wild hunt
+witcher
 wolf school
 wraith
 wyvern
+yarpen zigrin
+yenefer
 yennefer
+yennefer of vengerberg
+zoltan chivay

--- a/lists/fiction/zelda.yml
+++ b/lists/fiction/zelda.yml
@@ -6,14 +6,22 @@ description: "Places, peoples, creatures, artifacts, and powers from The Legend 
 akkala
 ancient arrow
 ancient furnace
+anju
 beedle
+bellum
 blight ganon
+byrne
 calamity ganon
 champions
+clock town
+cole
+crescent island
 dark world
+daruk
 death mountain
 death mountain crater
 deku scrub
+deku tree
 demise
 din
 divine beast vah medoh
@@ -22,20 +30,33 @@ divine beast vah rudania
 divine beast vah ruta
 dragon roost island
 epona
+ezlo
 fairy fountain
 farore
 fi
+four swords
+ganon
+ganon's castle
 ganondorf
 gerudo
 gerudo desert
+gerudo town
 gerudo valley
+ghirahim
 goddess harp
+goddess hylia
 goron
+goron city
+great bay
 great deku tree
 great fairy
 great plateau
+groose
 guardian stalker
+happy mask salesman
 hateno village
+hilda
+holodrum
 hylia
 hylian
 hylian shield
@@ -43,47 +64,91 @@ hyrule
 hyrule castle
 hyrule field
 hyrule warriors
+ikana canyon
+impa
+kafei
 kakariko village
 keese
 king dodongo
+king of red lions
+king rhoam
 kokiri
+kokiri forest
 korok
 korok forest
+labrynna
 lake hylia
 lanayru
+linebeck
+link
 loftwing
 lon lon ranch
+lorule
 lost woods
+majora
 majora's mask
 malice
+malladus
 malon
 master sword
 midna
+mineru
 minish
 minish cap
+mipha
 moblin
+nayru
 ocarina of time
+oshus
 phantom ganon
+purah
+rauru
+ravio
+revali
+rhea
+riju
 rito
 rito village
+robbie
 royal guard
 saria
 sheikah
 sheikah slate
+sheikah tower
+shrine of resurrection
+sidon
 silver arrow
 skull kid
 skyloft
+snowhead
+sonia
 stalfos
 stamina vessel
+tarrey town
 tears of the kingdom
 temple of time
 termina
+tetra
 the four sword
 the golden goddesses
 the great sea
 the triforce
 tingle
+triforce
+triforce of courage
+triforce of power
+triforce of wisdom
+tulin
 twili
+twilight princess
 twilight realm
+urbosa
+vaati
+wind waker
+woodfall
+yuga
+yunobo
+zelda
 zora
 zora's domain
+zoras domain

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -1809,9 +1809,20 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "standard": "^17.0.0"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.0",
     "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
This PR expands the universe name-lists inside `lists/fiction/` to be exhaustively lore-rich. The files updated are:
- `pokemon.yml` (Legendary/Mythical Pokémon, regions, teams, Poké Balls, iconic species)
- `lotr.yml` (Middle-earth characters, locations, items, weapons, battles, races)
- `culture.yml` (Culture series ship names, orbitals, planets, systems, factions)
- `warhammer40k.yml` (Primarchs, deities, major characters, iconic spacecraft, factions)
- `dune.yml` (Frank Herbert's Dune universe characters, terminology, planets, houses)

All additions conform exactly to the required specification (lowercase, unique, sorted alphabetically, original YAML frontmatter retained).