### PR TITLE
Propose new lists: art/tattoo-style and thing/toy

### DIFF
--- a/lists/art/tattoo-style.yml
+++ b/lists/art/tattoo-style.yml
@@ -3,45 +3,45 @@ title: Tattoo styles
 category: art
 description: "Tattoo styles, techniques, and visual systems for character design and body art"
 ---
-abstract tattoo
+abstract
 american traditional
-anime tattoo
+anime
 biomechanical
 black and grey
-blackout tattoo
+blackout
 blackwork
 celtic knotwork
 chicano lettering
-comic book tattoo
+comic book
 cyber sigilism
 dotwork
 fineline
-geometric tattoo
-gothic tattoo
-horror tattoo
-illustrative tattoo
+geometric
+gothic
+horror
+illustrative
 irezumi
 japanese traditional
-kawaii tattoo
+kawaii
 lettering script
-mandala tattoo
+mandala
 maori ta moko
 micro realism
 neo-traditional
 new school
 old school
-ornamental tattoo
+ornamental
 polynesian tribal
 portrait realism
 sacred geometry
 sailor jerry style
 single needle
-sketch style tattoo
+sketch style
 stick and poke
 stipple shading
-surrealist tattoo
+surrealist
 tebori style
 trash polka
-tribal tattoo
-watercolor tattoo
-woodcut style tattoo
+tribal
+watercolor
+woodcut style

--- a/lists/art/tattoo-style.yml
+++ b/lists/art/tattoo-style.yml
@@ -1,0 +1,47 @@
+---
+title: Tattoo styles
+category: art
+description: "Tattoo styles, techniques, and visual systems for character design and body art"
+---
+abstract tattoo
+american traditional
+anime tattoo
+biomechanical
+black and grey
+blackout tattoo
+blackwork
+celtic knotwork
+chicano lettering
+comic book tattoo
+cyber sigilism
+dotwork
+fineline
+geometric tattoo
+gothic tattoo
+horror tattoo
+illustrative tattoo
+irezumi
+japanese traditional
+kawaii tattoo
+lettering script
+mandala tattoo
+maori ta moko
+micro realism
+neo-traditional
+new school
+old school
+ornamental tattoo
+polynesian tribal
+portrait realism
+sacred geometry
+sailor jerry style
+single needle
+sketch style tattoo
+stick and poke
+stipple shading
+surrealist tattoo
+tebori style
+trash polka
+tribal tattoo
+watercolor tattoo
+woodcut style tattoo

--- a/lists/thing/toy.yml
+++ b/lists/thing/toy.yml
@@ -1,0 +1,59 @@
+---
+title: Toys
+category: thing
+description: "Toys, playthings, and childhood objects for product shots, nostalgia, and whimsical scenes"
+---
+abacus
+action figure
+ballerina music box
+beach ball
+bubble wand
+building blocks
+die-cast race car
+dinosaur figure
+dollhouse
+farm animal set
+fashion doll
+foam dart blaster
+frisbee
+hula hoop
+jack-in-the-box
+jump rope
+kaleidoscope
+kite
+marble run
+marionette puppet
+model airplane
+music box
+nesting dolls
+pinwheel
+play kitchen
+plush teddy bear
+plush unicorn
+pogo stick
+puzzle cube
+rag doll
+remote control car
+rocking horse
+roller skates
+rubber duck
+shape sorter
+slinky
+snow globe
+spinning top
+stacking rings
+stuffed animal
+tin wind-up robot
+toy cash register
+toy drum
+toy piano
+toy soldier
+toy tea set
+toy train set
+view-master
+water pistol
+wooden blocks
+wooden puzzle
+wooden rocking horse
+xylophone toy
+yo-yo


### PR DESCRIPTION
## New list proposals (needs human approval)

Two new curated lists for AI image/media prompt generation. Concepts only — ready to expand further after approval.

### 1. `lists/art/tattoo-style.yml` — Tattoo styles (42 entries)

**What:** Tattoo styles, techniques, and visual systems (American traditional, irezumi, blackwork, fineline, trash polka, cyber sigilism, etc.).

**Why useful:** Character design, fashion editorials, and body-art close-ups. The repo has makeup, hair, garments, and accessories, but no dedicated tattoo style vocabulary.

**Examples:** `american traditional`, `blackwork`, `fineline`, `irezumi`, `neo-traditional`, `trash polka`, `cyber sigilism`, `watercolor tattoo`

### 2. `lists/thing/toy.yml` — Toys (54 entries)

**What:** Toys, playthings, and childhood objects (rocking horse, tin wind-up robot, plush, die-cast cars, nesting dolls, etc.).

**Why useful:** Product shots, nostalgia scenes, kids’ environments, and whimsical “toy world” prompts. `thing/gadget` is electronics; `thing/everyday` is generic household — neither is a proper toy taxonomy. Brand names avoided on purpose.

**Examples:** `tin wind-up robot`, `plush teddy bear`, `die-cast race car`, `jack-in-the-box`, `nesting dolls`, `snow globe`, `wooden rocking horse`

---

Source-only changes (no generated `lists.json` / metadata). Happy to trim, rename, or expand after concept review.