### PR TITLE
Propose new lists: sport/equipment and places/venue

### DIFF
--- a/lists/places/venue.yml
+++ b/lists/places/venue.yml
@@ -1,0 +1,511 @@
+---
+title: Venues
+category: places
+description: "Event venues for sports, performance, nightlife, conventions, and public gatherings"
+---
+3d cinema
+air dome
+air show field
+airfield showground
+alpine ski resort
+amphitheater
+amphitheater ruins
+amusement park arena
+animal show arena
+aquarium auditorium
+aquarium theater
+aquatics center
+arena
+arena football stadium
+art house cinema
+assembly hall
+athletic complex
+athletic field
+athletic stadium
+athletic track
+auction house
+auditorium
+auto racing circuit
+auto show pavilion
+aviation museum hangar
+awards ceremony hall
+backyard amphitheater
+ballpark
+ballroom
+ballroom dance floor
+band shell
+banquet hall
+banquet room
+bar
+baseball diamond
+baseball field
+baseball park
+baseball stadium
+basilica
+basketball arena
+basketball court
+basketball stadium
+beach amphitheater
+beach club
+beach volleyball court
+beer garden
+beer hall
+big top
+big top circus
+billiard hall
+billiards room
+black box theater
+black box theatre
+blues club
+bmx freestyle park
+bmx track
+boardwalk stage
+boat club
+boat house
+bobsleigh track
+botanical garden pavilion
+bowling alley
+boxing arena
+boxing gym
+boxing stadium
+brewery taproom
+brewpub
+broadway theater
+bullring
+burlesque club
+cabaret
+cabaret club
+cabaret lounge
+cabaret theater
+campus arena
+campus theater
+carnival midway
+casino
+casino arena
+casino floor
+casino showroom
+casino theater
+cathedral
+cathedral hall
+chamber music hall
+chapel
+chapel venue
+children's theater
+church
+church hall
+cinema
+circus arena
+circus big top
+circus tent
+city arena
+city stadium
+civic center
+civic hall
+classical concert hall
+clubhouse
+cocktail lounge
+coliseum
+college arena
+college auditorium
+college field house
+college gymnasium
+college stadium
+colosseum
+comedy cellar
+comedy club
+comedy theater
+community amphitheater
+community center
+community hall
+community theater
+concert arena
+concert bowl
+concert hall
+concert pavilion
+concert venue
+conference center
+conference hall
+conservatory concert hall
+convention center
+convention hall
+country club
+country fair arena
+county fairground
+covered stadium
+cricket ground
+cricket oval
+cricket stadium
+cruise ship theater
+cultural center
+curling rink
+cycling velodrome
+dance academy theater
+dance club
+dance hall
+dinner club
+dinner cruise ship
+dinner theater
+dirt track
+disco
+diving pool
+dojo
+dome stadium
+drag racing strip
+drag strip
+drive-in cinema
+drive-in theater
+electric ballroom
+equestrian arena
+esports arena
+esports cafe
+esports coliseum
+esports stadium
+event center
+event hall
+event pavilion
+event space
+exhibition center
+exhibition hall
+exhibition pavilion
+fair arena
+fairground
+farmers market pavilion
+fencing salle
+festival amphitheater
+festival arena
+festival grounds
+festival hall
+festival tent
+field hockey pitch
+field house
+fight arena
+film festival venue
+film house
+flea market
+floating stage
+folk club
+football arena
+football field
+football ground
+football pitch
+football stadium
+forest amphitheater
+formula 1 circuit
+function hall
+function room
+gala ballroom
+gala venue
+game show studio
+gaming lounge
+garden amphitheater
+garden party venue
+go-kart track
+golf course
+grand ballroom
+grand opera house
+grand theater
+grandstand
+greek amphitheater
+gym
+gymnasium
+hall
+handball court
+hangar venue
+heritage hall
+high school football stadium
+high school gymnasium
+high school stadium
+hippodrome
+historic mansion venue
+historic theater
+hockey arena
+hockey center
+hockey rink
+hockey stadium
+horse racing track
+hotel ballroom
+hotel conference center
+hotel event space
+hotel theater
+ice arena
+ice center
+ice hockey arena
+ice hockey rink
+ice rink
+ice skating rink
+imax cinema
+imax theater
+immersive theater
+indoor arena
+indoor climbing gym
+indoor football field
+indoor soccer arena
+indoor stadium
+indoor tennis center
+indoor track
+indoor water park
+industrial warehouse venue
+jazz club
+jazz lounge
+jazz theater
+jiu-jitsu academy
+karaoke bar
+karaoke lounge
+karate dojo
+karting circuit
+kickboxing gym
+lacrosse field
+lan party venue
+late night talk show studio
+lecture hall
+lecture theater
+lighthouse venue
+live house
+live music venue
+loft venue
+lounge
+luxury box stadium
+lyceum
+magic show theater
+mansion ballroom
+marina clubhouse
+market hall
+martial arts dojo
+medieval banquet hall
+meeting hall
+megachurch auditorium
+memorial stadium
+military parade ground
+mini stadium
+mma gym
+monster truck arena
+mosque
+motocross track
+motorsport circuit
+movie house
+movie palace
+movie theater
+muay thai gym
+multi-purpose arena
+multi-purpose stadium
+multiplex cinema
+multipurpose hall
+municipal auditorium
+municipal stadium
+museum auditorium
+museum hall
+music barn
+music club
+music dome
+music festival grounds
+music hall
+music pavilion
+music theater
+national stadium
+natural amphitheater
+netball court
+night market
+nightclub
+nightclub theater
+observatory dome
+odeon
+off-broadway theater
+olympic aquatics center
+olympic arena
+olympic stadium
+olympic swimming pool
+olympic velodrome
+open air amphitheater
+open air cinema
+open air market square
+open air theater
+open air theatre
+opera house
+opera theater
+orchestra hall
+outdoor amphitheater
+outdoor arena
+outdoor cinema
+outdoor concert stage
+outdoor stadium
+outdoor theater
+padel court
+pageant stage
+palace ballroom
+palace theater
+parade ground
+parade route
+parish hall
+park amphitheater
+park pavilion
+pavilion
+performance hall
+performance space
+performing arts center
+performing arts hall
+philharmonic hall
+piano bar
+pickleball court
+planetarium
+playhouse
+playhouse theater
+plaza stage
+polo field
+pool hall
+pop-up cinema
+pop-up market
+private club
+private dining club
+private event space
+private theater
+proscenium theater
+pub
+public hall
+public house
+puppet theater
+race course
+racetrack
+raceway
+racquetball court
+rally stage
+recital hall
+recreation center
+recreation hall
+red carpet venue
+regional theater
+repertory theater
+resort amphitheater
+resort ballroom
+resort casino
+rock club
+rodeo arena
+rodeo grounds
+roller rink
+roman amphitheater
+roman forum
+rooftop amphitheater
+rooftop bar
+rooftop cinema
+rooftop club
+rooftop terrace venue
+rooftop venue
+rowing club
+rugby pitch
+rugby stadium
+ruin amphitheater
+ruins theater
+running track
+rural fairground
+sailing club
+sailing pavilion
+school auditorium
+school gymnasium
+school hall
+school theater
+senior center
+ship deck venue
+show arena
+show ring
+showroom
+skate park
+skateboard park
+ski jump
+ski lodge event hall
+ski resort
+ski slope
+skybox stadium
+small theater
+soccer field
+soccer pitch
+soccer stadium
+social club
+softball field
+speakeasy
+speakeasy bar
+speedway track
+sporting club
+sports arena
+sports complex
+sports dome
+sports ground
+sports hall
+sports park
+sports stadium
+squash court
+stadium
+stadium bowl
+stadium club
+stadium suite
+stage theater
+state fair arena
+state fairgrounds
+street fair
+studio theater
+suburban arena
+summer stock theater
+sumo arena
+supper club
+surf break
+surf club
+swimming pool
+symphony hall
+synagogue
+synagogue hall
+temple
+tennis center
+tennis club
+tennis court
+tennis stadium
+theater
+theater in the round
+theatre
+theatre in the round
+thrust stage theater
+town arena
+town hall
+town square
+track and field stadium
+track stadium
+trade fair pavilion
+trade show floor
+training camp
+training ground
+tv studio audience
+university arena
+university auditorium
+university lecture theatre
+university stadium
+university theater
+urban arena
+vaudeville hall
+vaudeville theater
+velodrome
+video game arena
+village amphitheater
+village green
+village hall
+vineyard event space
+vineyard wedding venue
+volleyball court
+warehouse rave venue
+warehouse venue
+water park
+water polo pool
+waterfall amphitheater
+wave pool
+wedding barn
+wedding chapel
+wedding hall
+wedding pavilion
+wedding venue
+weightlifting gym
+west end theater
+wine bar
+winter sports arena
+wrestling arena
+yacht club
+youth arena
+youth center
+youth sports complex
+zoo amphitheater
+zoo show arena

--- a/lists/sport/equipment.yml
+++ b/lists/sport/equipment.yml
@@ -1,0 +1,644 @@
+---
+title: Sports equipment
+category: sport
+description: "Athletic gear, protective equipment, training tools, and sport-specific apparatus"
+---
+ab roller
+adjustable dumbbell
+aerobic step
+aggressive inline skate
+agility ladder
+air hockey table
+alpine ski
+american football
+american football tee
+ankle brace
+ankle weight
+aquatics kickboard
+archery arm guard
+archery finger tab
+archery target
+arm guard
+arrow
+athletic cup
+athletic cup protector
+athletic tape
+australian rules football
+axe throwing target
+badminton net
+badminton racket
+badminton racket string
+badminton shuttlecock
+balance beam
+balance beam mat
+balance board
+barbell
+baseball
+baseball base
+baseball bat
+baseball batting glove
+baseball batting helmet
+baseball catcher's mask
+baseball chest protector
+baseball glove
+baseball mitt
+baseball pitcher's glove
+baseball shin guard
+basketball
+basketball backboard
+basketball hoop
+basketball net
+basketball rim
+batting tee
+battle rope
+beach flag
+beach volleyball
+bean bag toss board
+belay device
+bench press
+biathlon rifle
+bicycle helmet
+bicycle pump
+bicycle tire
+bicycle tube
+bike lock
+bike rack
+billiard ball
+billiard cue
+billiard cue chalk
+billiard rack
+billiard table
+bmx bike
+boat trailer
+bobsled
+bobsleigh
+bocce ball
+bodyboard
+bodyboard fins
+bouldering mat
+bow string
+bowling ball
+bowling pin
+bowling shoes
+boxing glove
+boxing headgear
+boxing heavy bag
+boxing mouthguard
+boxing ring
+boxing ring ropes
+boxing speed bag
+boxing timer
+bridle
+bull rope
+buoyancy compensator
+cable crossover machine
+cable machine
+camming device
+canoe
+canoe paddle
+carabiner
+catcher's chest protector
+catcher's mitt
+chalk bag
+cheerleading megaphone
+cheerleading pom-pom
+chess clock
+chess set
+chess timer
+chest protector
+cleats
+climber's helmet
+climbing chalk
+climbing harness
+climbing hold
+climbing rope
+climbing shoe
+climbing wall
+clipless pedal
+coach's clipboard
+competition singlet
+compound bow
+compression sleeve
+cone marker
+cornhole bag
+cornhole board
+cox box
+crampon
+crash pad
+cricket bail
+cricket ball
+cricket bat
+cricket boundary rope
+cricket crease marker
+cricket gloves
+cricket helmet
+cricket pads
+cricket stump
+cricket thigh pad
+cricket whites
+cricket wicket
+croquet ball
+croquet mallet
+cross trainer
+crossbow
+cue ball
+curling broom
+curling slider
+curling stone
+cycling computer
+cycling shoe
+cyclist sunglasses
+cyclocross bike
+dart flight
+dart shaft
+dartboard
+darts
+disc golf basket
+disc golf disc
+discus
+diving board
+diving computer
+diving cylinder
+diving fins
+diving mask
+diving regulator
+diving springboard
+diving weight belt
+dodgeball
+drag chute
+drag racing chute
+dressage saddle
+dumbbell
+dumbbell rack
+dynamo headlamp
+elbow pad
+electronic scoreboard
+elliptical machine
+elliptical trainer
+equestrian helmet
+exercise bike
+exercise mat
+face mask
+fencing bag
+fencing body cord
+fencing foil
+fencing glove
+fencing jacket
+fencing lame
+fencing mask
+fencing piste
+fencing plastron
+fencing scoring machine
+fencing wire
+field cone
+field hockey ball
+field hockey goal
+field hockey stick
+figure eight descender
+figure skate
+finish line tape
+fire suit
+fishing lure
+fishing net
+fishing reel
+fishing rod
+fishing tackle box
+fitness tracker
+flight stick
+floorball stick
+flying disc
+foam pit
+foam roller
+focus mitt
+foosball table
+football
+football cleats
+football goalpost
+football helmet
+football kicking tee
+football shoulder pads
+football tee
+free weight
+frisbee
+futsal ball
+futsal goal
+futsal shoe
+gaming headset
+go-kart
+goal post
+goalie blocker
+goalie catcher
+goalie mask
+goalie stick
+goalkeeper gloves
+goalkeeper jersey
+golf bag
+golf ball
+golf cart
+golf club
+golf driver
+golf glove
+golf iron
+golf putter
+golf tee
+golf wedge
+gravel bike
+groin guard
+gum shield
+gym ladder
+gymnastic chalk
+gymnastic floor mat
+gymnastic rings
+hacky sack
+hammer throw hammer
+hand wrap
+handball
+handball goal
+handball goal net
+hang glider
+hangboard
+harness racing sulky
+helmet visor
+hex bar
+high jump bar
+high jump mat
+hockey goal
+hockey helmet
+hockey puck
+hockey skate
+home gym cable station
+home plate
+horizontal bar
+horse blanket
+horseshoe
+horseshoe set
+hula hoop
+hurdle
+hurley
+hydrofoil board
+ice axe
+ice bath tub
+ice hockey gloves
+ice hockey goal
+ice hockey goalie pads
+ice hockey pads
+ice hockey puck
+ice hockey stick
+ice pack
+ice pick
+ice skate
+incline bench
+incline treadmill
+inline hockey stick
+inline skate
+javelin
+jet ski
+judo gi
+jump box
+jump cup
+jump rope
+jumping saddle
+karate belt
+karate gi
+kayak
+kayak paddle
+kayak spray skirt
+kendo bogu
+kendo shinai
+kettlebell
+kettlebell rack
+kickball
+kickboard
+kickboxing glove
+kite control bar
+kite line
+kiteboard
+knee brace
+knee pad
+korfball
+lacrosse ball
+lacrosse goal
+lacrosse helmet
+lacrosse mesh
+lacrosse stick
+land paddle
+lane rope
+lane rope float
+laser rangefinder
+laser tag gun
+lat pulldown machine
+lawn bowl
+lawn bowling jack
+leg extension machine
+leg press machine
+life jacket
+longboard skateboard
+longbow
+luge sled
+mainsail
+measuring tape
+medicine ball
+medicine ball rack
+megaphone
+mesh bag
+mma glove
+monster truck
+motocross boot
+motocross helmet
+mountain bike
+mountain bike helmet
+mouthguard
+muay thai pad
+multi gym
+neck guard
+net post
+netball
+nordic ski
+oar
+olympic barbell
+olympic ring
+outrigger canoe
+paddle tennis paddle
+paddleboard
+padel racket
+paintball marker
+paintball pellet
+parachute
+parachute harness
+paraglider
+parallel bars
+parallettes
+parkour vault box
+pickleball
+pickleball net
+pickleball paddle
+ping pong paddle
+ping pong table
+pitcher's mound rubber
+pitching machine
+pitching rubber
+plate loaded machine
+plyo box
+plyometric box
+pogo stick
+polo ball
+polo mallet
+polo saddle
+pommel horse
+pool ball
+pool cue
+pool noodle
+pool table
+power rack
+powerlifting belt
+powerlifting singlet
+practice jersey
+protective cup
+pull buoy
+pull-up bar
+punching bag
+putting green
+quad skate
+quickdraw
+quiver
+racing bike
+racing glove
+racing helmet
+racing shell
+racing simulator cockpit
+racing suit
+racquetball
+racquetball racket
+raft
+range finder
+rebounder trampoline
+recurve bow
+referee flag
+referee jersey
+referee whistle
+relay baton
+resistance band
+resistance tube
+rhythmic gymnastics ribbon
+rhythmic gymnastics rope
+rib protector
+riding boot
+riding crop
+road bike
+road racing helmet
+rock climbing cam
+rock climbing nut
+rock climbing rope
+roll cage
+roller skate
+roller ski
+rounders bat
+rowing ergometer
+rowing machine
+rowing oarlock
+rugby ball
+rugby headguard
+rugby scrum cap
+running belt
+running shoe
+running spike
+sabre
+saddle
+saddle pad
+safety harness
+sail
+sailboat
+sandbag
+scooter
+scoreboard
+scuba tank
+scull
+sculling oar
+sculling shell
+shin guard
+shooting glove
+shooting rest
+shot clock
+shot put
+shoulder pad
+shuffleboard cue
+shuttlecock
+sim racing pedal
+sim racing wheel
+sit-up bench
+skate guard
+skateboard
+skateboard deck
+skateboard truck
+skateboard wheel
+skeleton sled
+ski binding
+ski boot
+ski edges
+ski goggles
+ski helmet
+ski pole
+ski wax
+skis
+slackline
+sled
+sled dog harness
+sling
+smith machine
+snooker ball
+snooker cue
+snooker rest
+snooker triangle
+snorkel
+snorkel vest
+snowboard
+snowboard binding
+snowboard boot
+snowmobile
+snowshoe
+soccer ball
+soccer cleat
+soccer corner flag
+soccer goal
+soccer goal net
+softball
+softball base
+softball bat
+softball glove
+sparring glove
+sparring headgear
+spear gun
+speed bag
+speed chute
+speed ladder
+speed skate
+spin bike
+spinnaker
+sport kite
+sports cone
+sports goggles
+sports jersey
+sports water bottle
+springboard
+sprint sled
+squash ball
+squash racket
+stability ball
+standup paddleboard
+starting block
+starting pistol
+stationary bike
+steering wheel
+stirrup
+stopwatch
+strike pad
+strongman atlas stone
+strongman log
+strongman yoke
+surf leash
+surf wax
+surfboard
+swim buoy
+swim cap
+swim fins
+swim goggles
+swim paddle
+swim snorkel
+swimming lane line
+swimwear
+table tennis ball
+table tennis paddle
+table tennis table
+tackle dummy
+taekwondo dobok
+target butt
+target face
+team jersey
+tee
+tennis ball
+tennis ball hopper
+tennis ball machine
+tennis court squeegee
+tennis net
+tennis racket
+tennis shoe
+tetherball pole
+thai pad
+throat guard
+throwing cage
+tiller
+toboggan
+toe board
+track bike
+track spike
+training bib
+training cone
+training dummy
+training hurdle
+training sled
+trampoline
+trap bar
+trap thrower
+trapeze bar
+treadmill
+triathlon wetsuit
+tug of war rope
+tug rope
+turf shoe
+umpire brush
+underwater camera housing
+underwater hockey puck
+underwater hockey stick
+uneven bars
+vault box
+vaulting pole
+vaulting table
+via ferrata kit
+volleyball
+volleyball antenna
+volleyball knee pad
+volleyball net
+wakeboard
+wakeboard binding
+wakeboard tower
+water bottle cage
+water polo ball
+water polo goal
+water ski
+water ski rope
+weight belt
+weight bench
+weight plate
+weight tree
+weighted vest
+weightlifting belt
+weightlifting platform
+wet suit
+whistle
+whitewater helmet
+whitewater paddle
+wicket
+wiffle ball
+windsurf board
+windsurf boom
+windsurf mast
+windsurf sail
+wing foil board
+wingsuit
+wooden dummy
+wrestling headgear
+wrestling mat
+wrestling shoe
+wrestling singlet
+wrist guard
+wrist support
+yo-yo
+yoga ball
+yoga block
+yoga bolster
+yoga mat
+yoga strap
+yoga wheel
+zip line harness
+zorb ball
+épée


### PR DESCRIPTION
## New list proposals (needs human approval)

Two exhaustive curated lists for AI image/media prompt generation.

### 1. `lists/sport/equipment.yml` — Sports equipment (639 entries)

**What:** Athletic gear, protective equipment, training tools, and sport-specific apparatus across major sports families (ball sports, combat, gym, winter, water, climbing, equestrian, motorsport, track & field, gymnastics, etc.).

**Why useful:** `sport/all` is sport *names* only — nothing for the objects athletes use. Useful for product shots, action scenes, training gyms, and kit still-lifes.

**Examples:** `boxing glove`, `climbing harness`, `ice hockey stick`, `kayak paddle`, `olympic barbell`, `vaulting pole`, `cricket pads`, `surfboard`, `fencing mask`, `starting block`

### 2. `lists/places/venue.yml` — Venues (506 entries)

**What:** Event venues for sports, performance, nightlife, conventions, ceremonies, and public gatherings (stadiums, arenas, theaters, clubs, halls, festival grounds, etc.).

**Why useful:** `places/public` mixes civic facilities, trails, and parks. This list is specifically **event/performance/competition venues** for scene-setting prompts.

**Examples:** `concert hall`, `olympic stadium`, `black box theater`, `jazz club`, `convention center`, `rodeo arena`, `esports arena`, `wedding barn`, `drive-in cinema`, `velodrome`

---

Source-only changes (no generated `lists.json` / metadata). Happy to trim overlaps with `places/public` or expand further after concept review.