### PR TITLE
Add thing/tool, places/liminal, science/laboratory-equipment lists

### DIFF
--- a/lists/places/liminal.yml
+++ b/lists/places/liminal.yml
@@ -1,0 +1,68 @@
+---
+title: Liminal spaces
+category: places
+description: "Transitional and eerie everyday places that evoke nostalgia, unease, or dreamlike stillness"
+---
+abandoned classroom at dusk
+abandoned shopping mall after closing
+airplane aisle while boarding is complete
+airport jet bridge with no windows
+amusement park after the lights have gone out
+arcade at closing time with games still flashing
+back row of an empty bus at night
+basement laundry room with one light on
+bathroom mirror in a motel with a buzzing light
+beach boardwalk closed for the season
+bus depot at 5am in winter
+empty airport terminal at night
+empty attic with a single bare bulb
+empty bathtub in an unfurnished apartment
+empty bowling alley with all pins standing
+empty cargo elevator with scratched walls
+empty church basement with stacked chairs
+empty classroom with chalk dust in the air
+empty corporate office at 2am
+empty dentist waiting room
+empty escalator going down to a dark floor
+empty football stadium on a foggy morning
+empty hotel hallway with flickering fluorescents
+empty hotel lobby at 3am
+empty hotel pool at dawn
+empty ice rink before zamboni
+empty laundromat with humming machines at midnight
+empty lecture hall with projector still on
+empty library stacks after hours
+empty locker room with dripping showers
+empty movie theater after credits
+empty museum gallery about to close
+empty playground on a rainy afternoon
+empty school bus interior
+empty school corridor with buzzing fluorescent light
+empty stairwell with motion-sensor light
+empty swimming pool with a single beach ball
+empty train platform with an approaching light
+empty waiting room with a ticking clock
+endless carpeted office corridors
+endless empty corridor with no doors
+ferry deck in dense fog with no land visible
+fluorescent-lit convenience store at 4am
+fluorescent-lit underground parking garage
+gas station at night in heavy rain
+highway rest stop vending machines at night
+hospital corridor with no patients
+hotel bathroom with water running but no guest
+hotel breakfast buffet set up before guests arrive
+hotel hallway that stretches too long
+indoor mall fountain with no water
+laundromat interior lit by neon at night
+liminal backrooms with yellow carpet and humming lights
+office break room at midnight
+roadside motel parking lot at dusk
+school gym after everyone has left
+stairwell landing with no exit signs
+suburban cul-de-sac on a foggy morning
+supermarket aisle emptied overnight
+underground mall corridor before shops open
+underground pedestrian tunnel with puddles
+underpass with dripping water and graffiti
+vacant car park on the top floor at dusk

--- a/lists/science/laboratory-equipment.yml
+++ b/lists/science/laboratory-equipment.yml
@@ -1,0 +1,120 @@
+---
+title: Laboratory equipment
+category: science
+description: "Lab glassware, instruments, and apparatus for scientific research and analysis"
+---
+agar plate
+analytical balance
+analytical scale
+autoclave
+beaker
+beaker tongs
+bench centrifuge
+biosafety cabinet
+buchner flask
+büchner funnel
+bunsen burner
+burette
+calorimeter
+centrifuge
+centrifuge rotor
+chemical reagent shelf
+chromatography column
+clay triangle
+co2 incubator
+colorimeter
+condenser
+conical tube
+crucible
+cryogenic freezer
+culture dish
+deionizer
+desiccator
+digital microscope
+distillation apparatus
+electron microscope
+electrophoresis chamber
+eprouvette
+erlenmeyer flask
+evaporating dish
+filter paper
+fume hood
+gas chromatograph
+geiger counter
+glass petri dish
+graduated cylinder
+heating mantle
+hot plate
+incubator
+kipp's apparatus
+lab coat hanging on hook
+lab pipette
+lab sink with glassware
+laboratory bench with reagents
+laboratory centrifuge
+laboratory centrifuge tube
+laboratory clamp
+laboratory freezer
+laboratory glassware drying rack
+laboratory gloves
+laboratory incubator
+laboratory notebook open on bench
+laboratory oven
+laboratory scale
+laboratory shaker
+laboratory spatula
+laboratory stand
+laboratory timer
+laboratory tripod
+laminar flow hood
+liquid nitrogen dewar
+magnetic stir bar
+magnetic stirrer
+mass spectrometer
+measuring pipette
+microcentrifuge
+micropipette
+micropipette tips
+microscope slide
+microwave digester
+multichannel pipette
+nuclear magnetic resonance spectrometer
+orbital shaker
+oscilloscope
+particle accelerator model on bench
+petri dish
+ph meter
+pipette tip box
+pipettor
+porcelain crucible with lid
+powder funnel
+reagent bottle
+retort stand
+rotary evaporator
+safety cabinet
+safety goggles
+scanning electron microscope
+separatory funnel
+serological pipette
+soxhlet extractor
+spectrometer
+spectrophotometer
+sterilizer
+stirring rod
+syringe filter
+test tube
+test tube holder
+test tube rack
+thermocycler
+thermometer
+titration setup
+ultra low temperature freezer
+ultracentrifuge
+vacuum desiccator
+vacuum pump
+volumetric flask
+vortex mixer
+watch glass
+water bath
+wire gauze
+x-ray diffractometer

--- a/lists/sport/equipment.yml
+++ b/lists/sport/equipment.yml
@@ -175,6 +175,7 @@ elbow pad
 electronic scoreboard
 elliptical machine
 elliptical trainer
+épée
 equestrian helmet
 exercise bike
 exercise mat
@@ -641,4 +642,3 @@ yoga strap
 yoga wheel
 zip line harness
 zorb ball
-épée

--- a/lists/thing/tool.yml
+++ b/lists/thing/tool.yml
@@ -1,0 +1,131 @@
+---
+title: Tools
+category: thing
+description: "Hand tools, power tools, and workshop equipment for construction and crafting"
+---
+adjustable wrench
+air compressor
+angle grinder
+anvil
+auger
+awl
+ball-peen hammer
+bandsaw
+belt sander
+bench grinder
+bench plane
+bench vise
+box cutter
+brace and bit
+bradawl
+brick trowel
+c-clamp
+caliper
+caulking gun
+center punch
+chainsaw
+chalk line
+circular saw
+clamp
+claw hammer
+cold chisel
+combination square
+compass
+coping saw
+cordless drill
+crowbar
+cutting torch
+die grinder
+disc sander
+dremel
+drill bit
+drill press
+drywall saw
+dust collector
+electric sander
+extension cord
+file
+flathead screwdriver
+floor jack
+flush cutter
+fret saw
+glue gun
+hacksaw
+hammer drill
+hand plane
+hand saw
+heat gun
+hex key set
+hole saw
+impact driver
+impact wrench
+jigsaw
+jointed pliers
+jointer
+keyhole saw
+ladder
+laser cutter
+laser level
+lathe
+level
+lineman's pliers
+lumber saw
+magnetic level
+mallet
+mandrel
+miter box
+miter saw
+multimeter
+nail gun
+needle-nose pliers
+orbital sander
+oscillating tool
+paint sprayer
+palette knife
+phillips screwdriver
+pickaxe
+pipe cutter
+pipe wrench
+planer
+pliers
+plumb bob
+pneumatic drill
+power drill
+pry bar
+putty knife
+random orbit sander
+ratchet and socket
+reciprocating saw
+rivet gun
+router
+rubber mallet
+sawhorse
+sawzall
+screwdriver
+scribing tool
+sledgehammer
+sliding bevel
+snap-ring pliers
+socket set
+soldering iron
+spindle sander
+spirit level
+square
+staple gun
+stud finder
+table saw
+tape measure
+tin snips
+torque wrench
+trowel
+try square
+tube bender
+utility knife
+vise
+wire brush
+wire cutters
+wire stripper
+wood chisel
+wood rasp
+workbench
+wrench set


### PR DESCRIPTION
3 new curated lists — ~300 new prompt entries filling genuine gaps:

### 1. `thing/tool` (126 entries)
Hand tools, power tools, workshop equipment. Gap: `thing` has weapon/furniture/gadget but no general tools. Useful for maker, workshop, product, craft prompts.
Examples: `claw hammer`, `cordless drill`, `laser cutter`, `lathe`, `torque wrench`

### 2. `places/liminal` (63 entries) — name shortened per review to avoid verbosity
Transitional / eerie everyday places — major 2024-26 visual trend (backrooms, dreamcore, liminal aesthetic). Not covered by public/room/urban-feature.
Examples: `empty airport terminal at night`, `empty shopping mall after closing`, `fluorescent-lit underground parking garage`, `empty laundromat with humming machines at midnight`

### 3. `science/laboratory-equipment` (115 entries)
Lab glassware, instruments, apparatus. Science category only 9 lists vs fiction 44; `medical-images` describes image types not objects. Useful for sci-fi, research, biopunk, product, education.
Examples: `petri dish`, `centrifuge`, `mass spectrometer`, `electron microscope`, `fume hood`

Bonus: `sport/equipment.yml` sort fix for `épée` accent ordering (from `sanitise.js` run).

Source only — no generated `lists.json` / `list-metadata.json`. All lowercased, deduped, sorted via `npm run sanitise`. Lint clean.

Verified commit identity per fleet policy.