### PR TITLE
Add 10 weird lists: cursed-object, non-euclidean, micro-archetype, etc

### DIFF
--- a/lists/feeling/uncanny.yml
+++ b/lists/feeling/uncanny.yml
@@ -1,0 +1,58 @@
+---
+title: Uncanny feelings
+category: feeling
+description: "Nameless deeply specific modern emotions and uneasy nostalgic states"
+---
+ache for simpler phone that could only text and call
+anxiety that your houseplants gossip when you leave
+comfort of being in building during storm you technically should not be in
+comfort of bus engine vibration that puts you to sleep though destination unknown
+comfort of familiar checkout beep
+comfort of finding hair in food you cooked yourself still comforting
+comfort of laundromat heat when snowing outside even if not doing laundry
+comfort of watching rain with takeaway you cannot finish
+dread of unread email whose preview sounds angry
+dread that algorithm knows you better than friends and recommendation proves it
+dread when autocorrect fixes mistake you intended
+dread when someone says i need to talk to you later without context
+eerie calm after power cut when fridge stops humming
+fear of being revealed as person who does not actually know how to whistle despite pretending
+fear that coworkers can hear internal monologue through open mic
+fear that you already lived this day perfectly normal day deja vu of nothing
+fear your cat judges your taste
+feeling of being extra in own life as side character
+fondness for street you have never lived on that feels like home
+grief for online community that ended without notice
+grief for version of self that almost existed if different choice at uni
+guilt for liking song everyone else cringes to
+guilt of envying friend's grief for making story interesting
+guilt of not waving back after realizing they waved at someone behind you too late to fix
+guilt of using excellent tote for terrible shopping
+joy of secret you keep from everyone even though tiny
+joy of seeing your bus arrive exactly as you reach stop despite being late
+loneliness of hotel breakfast alone surrounded by families
+longing for childhood tv static
+longing to contact friend you ghosted but now time has made it weird
+nose bleed nostalgia when smell of school disinfectant hits
+nostalgia for burnt microwave popcorn that everyone hates
+nostalgia for dial up tone that stressed you then
+nostalgia for life you never lived in country you have never visited
+nostalgia for mall even though mall was objectively depressing
+preemptive loneliness before trip even started
+pride in keeping plant alive longer than any relationship this year
+relief that empty lift means you can be weird for eight seconds
+relief when plans cancelled that you secretly did not want
+relief when texting and both start typing then stop then you win by not sending
+sadness for step that squeaks being fixed after years and now silence
+sadness when favorite shop rearranges layout
+shame of being too early to party that feels like being too needy
+shame of lying about having seen film everyone loves then improvising plot
+shame of pretending to understand meme then spiraling research at 2am
+sudden awareness you have been unblinking in open plan office too long
+sudden panic you forgot language you were fluent in as child but never were
+sudden tenderness for object you are about to throw away that served you
+sudden urge to apologize to house for loud music
+tenderness for elderly couple arguing lovingly in supermarket queue
+tenderness for last biscuit no one wants to take
+unexpected kinship with man alone eating chips on bus at midnight
+warmth of finding money in pocket you forgot but then recall it was for bill

--- a/lists/food/forbidden-food.yml
+++ b/lists/food/forbidden-food.yml
@@ -1,0 +1,59 @@
+---
+title: Forbidden foods
+category: food
+description: "Edible-looking but absolutely not, or cursed combinations that shouldn't exist"
+---
+apple that crunches like glass but edible according to label
+avocado pit that sprouts tiny arm
+banana that bruises in shape of person
+birthday cake where candles relight as iced screaming faces
+bread mold arranged into perfect crop circles
+butter melted into shape of family member
+carrot that tastes like blood after third wash
+cereal that arranges itself into words after milk
+cheese string that never breaks just stretches forever
+cheeseburger left since 2008 on warsaw museum plinth intact
+chia pudding that has grown into chia pet overnight
+chocolate bar that already has bite taken inside wrapper
+chocolate spread that spreads itself at night
+cookie dough that is already baked in fridge waiting
+cornflakes that are just flattened tortillas with gold spray
+edible glitter that glows under uv and stomach
+egg that hatches smaller egg that hatches raw yolk
+energy drink called nuclear coolant banned in 3 eu countries
+fish that smells like ham
+french fry that continues to sweat grease days later
+glow in dark cheese that hums when cut
+granola bar that tastes of old books
+granola that contains tiny handwritten notes instead of cranberries
+honey that bees returned to ask for back
+hot dog that sweats cold water
+ice cream scoop of drywall spackle with rainbow sprinkles
+instant noodle seasoning packet that contains another entire meal
+ketchup bottle that bleeds when squeezed
+kitchen sponge that tastes better than toast after 9pm think about it
+matcha that tastes like grass that apologizes
+mayonnaise that forms face of mayonnaise tube mascot
+meat that is vegan but bleeds more realistically than real
+milk skin aged 39 days into leather with parmesan dust
+night market fish balls that bounce too high
+oatmeal that is grey despite oats
+pasta sauce jar with second hidden sauce inside sauce
+pasta that moves slightly toward edge of bowl
+pickle in jar that floats upright staring
+plastic cheese individually wrapped in cheese wrapper wrapped in more plastic
+popcorn kernels that pop in sealed packet at night
+pumpkin spice hummus with actual pumpkin that sighs
+ramen packet eaten raw with flavor powder snorted as ritual
+rice cake that still sounds like styrofoam after 20 years innovation
+salami sliced so thin you can read through but still tastes
+sandwich made of wet newspaper and american cheese
+soda can that fizzes upwards defying gravity
+soup dumpling that contains tiny living goldfish cracker
+soup that has reflection different to bowl
+steak that is blue when cut well done origin
+tapioca pearls that have started to germinate in boba
+tofu that quivers when someone says vegetarian
+veg straight from store that is still warm
+water that is labelled emotional support water
+yogurt that has grown hair

--- a/lists/interaction/micro-ritual.yml
+++ b/lists/interaction/micro-ritual.yml
@@ -1,0 +1,67 @@
+---
+title: Micro-rituals
+category: interaction
+description: "Tiny unspoken modern behaviors and automatic everyday rituals"
+---
+adjusting ring after washing hands that never faked moisture alarm yet
+announcing leaving room i am going toilet as if need permission
+checking if door locked after locking door twice then walking away then returning
+checking oven is off by opening then closing then opening again
+checking phone after telling person you left it at home
+checking planting app notification then forgetting you opened it then opening again
+checking stock of toilet roll even though you just bought bulk
+double tapping phone screen to wake even when screen already on
+drinking water before bed that guarantees one more toilet ritual at 3am
+eating component of meal you dislike first to ritualize suffering
+fake phone call to avoid small talk with neighbor in lift
+holding breath passing cemetery invented rule from childhood that persisted
+holding door for person too far who transitions from walk to run to justify your hold
+holding door mathematically perfect distance that forces stranger to jog slightly
+holding staircase bannister despite never needing to falling not contagious
+knocking wood after saying something jinx despite not superstitious
+laughing at text that did not deserve laugh to close loop
+leaving last sip in cup because backwash anxiety
+leaving shopping cart slightly forward to signal done browsing
+leaving voicemail then texting to say sorry just left voicemail
+lining up cutlery before photo of food that absolutely no one will see
+looking both ways before crossing one way street for illusion of safety
+looking inside fridge with freezer door open to let light into fridge
+not pressing pedestrian button until second press to not seem inpatient first press
+opening fridge again to confirm you are still not hungry
+opening new tab then forgetting why opened for eleven seconds daily
+passing neighbour with bins and both saying hiya with no second sentence
+placing coaster under coaster to protect coaster
+placing phone face down to signal moral superiority about attention
+pretending to check time when someone says age you forgot
+pretending to cough to cover fart then pretender cough too loud
+pretending to read phone screen when walking past people you know
+putting headphones in without music to avoid being approached
+putting on both socks then both shoes then tying one then other military despite no military
+rearranging desktop icons into spiral before deadline procrastination
+refilling water bottle to exact top every time like ritual
+replaying conversation in shower with correct comeback then losing next time anyway
+saying bless you to sneeze from next room you did not hear
+saying bye seven times before actually leaving zoom
+saying okay labour of love when handed thing you did not labour
+saying same thing in three different meetings expecting different reaction
+saying sorry to inanimate object after bumping it
+saying sorry when someone else bumps you north european compromise
+saying thanks sorry thanks to automate human contact in british
+saying we should catch up when both know never
+screenshotting receipt that will exist in email anyway
+shaking juice carton like maracas before opening
+smelling milk even when new performative distrust
+smelling second-hand book before reading first page
+spinning chair one full rotation before important teams call
+spinning fidget thing while pretending to think already thinking finished anyway
+steaming bathroom mirror then drawing cursed sigil then wiping quickly
+stretching in shop queue to seem taller than you want to be seen
+taking photo of menu instead of choosing
+tapping pocket three times to ensure phone wallet keys existence as prayer
+tapping top of car twice when it is being towed joke for luck
+typing great then deleting to greatt then great with extra meaning
+typing then deleting then typing shorter version of emotional text
+washing reusable coffee cup at work kitchen sink performatively
+waving at car that let you cross then realizing they were waiting to turn
+wiping camera lens before photo that will be blurred anyway
+wiping table that is already clean to appear helpful

--- a/lists/people/micro-archetype.yml
+++ b/lists/people/micro-archetype.yml
@@ -1,0 +1,64 @@
+---
+title: Micro-archetypes
+category: people
+description: "Hyper-specific modern human niches and extremely specific personality types"
+---
+19-year-old who moderates celebrity funeral live chat
+24-year-old who reviews every gas station hot dog within 50 miles
+29-year-old woman whose entire personality is sourdough starter named gerald from 1800s lineage
+airbnb superhost who lives in shed behind airbnb to keep costs low
+crypto landlord of three discord servers and zero physical properties
+girl who does death cleaning for friends proactively
+girl who hosts silent reading party in laundromat
+girl who keeps list of fallen leaves by date
+girl who only cooks recipes from back of packaging
+girl who only reads books found on tube
+girl who only wears clothes bought from men who are selling due to breakup
+girl who urban forages in london zone 2 and sells pesto at farmers market
+guy who buys broken synthesizers and hates when they work
+guy who carries film camera and never develops film
+guy who collects lost gloves and pairs them wrong on purpose
+guy who collects typewriters to never type
+guy who does urbex but only of abandoned service stations toilets
+guy who only drinks water from glass bottles he found
+guy who only speaks in podcast transitions
+guy who owns eight slow cookers and uses them all on sundays
+guy who repairs mechanical watches drunk as meditation
+guy who tracks every sneeze since 2019 in notion
+guy whose personality is knowing where every tesco microwave is
+man who befriends elderly at bus stops and knows their entire war history
+man who collects vintage instruction manuals and frames them
+man who does sudoku in pen then frames mistakes
+man who keeps bees on 12th floor balcony against lease
+man who learned morse code to eavesdrop on fridge ice maker
+man who maintains wikipedia page for obscure moth
+man who only eats airport food even when not traveling
+man who restores crt tvs to watch static aesthetically
+man who whispers to houseplants but yells at succulents
+man whose entire fridge is hot sauces and one lime
+person who brings own cutlery to restaurants as statement
+person who catalogues clouds but not by type only by vibe
+person who collects hotel soaps but has never stayed in hotel
+person who counts lorry passing bedroom window for sleep
+person who ironically bought 4000 v-bucks then became genuinely invested
+person who learns third language solely to understand one song
+person who makes dioramas of own flat in various disasters
+person who volunteers to queue for product drops they do not want
+person whose calendar is entirely lunar phases and bin collection
+person whose hobby is restoring shopping carts
+retired pilot who reviews airplane meals at home
+teen who makes ambient mixes from refrigerator hums
+teen who organizes book shelf by emotional impact
+teen who speedruns making tea
+woman who breeds snails as pets with names from succession
+woman who forages in supermarket reduced aisle and calls it tasting menu
+woman who insists she can communicate with sourdough
+woman who keeps succulents alive ironically then genuinely loves them
+woman who knits tiny sweaters for isolated traffic cones
+woman who makes butter as personal brand
+woman who only walks dog in elaborate costumes for dog
+woman who owns 40 tote bags and uses plastic bag
+woman who runs cottagecore instagram from brutalist flat
+woman who thrifts only christmas sweaters in july and resells in december
+woman who trains pigeons to steal chips
+woman whose side hustle is pet portrait in renaissance style from her parents basement

--- a/lists/photography/surveillance-glitch.yml
+++ b/lists/photography/surveillance-glitch.yml
@@ -1,0 +1,61 @@
+---
+title: Surveillance glitches
+category: photography
+description: "CCTV, thermal, dashcam, and baby monitor artifacts that shouldn't be there"
+---
+baby monitor audio catching lullaby sung in language parents do not know
+baby monitor replaying yesterday's audio
+baby monitor showing crib mobile spinning though no wind and stopped when checked
+baby monitor showing extra crib that was never placed
+baby monitor temperature reading 39 degrees on cold night
+baby monitor with cover photo of baby sleeping that is not from this evening
+cctv corner timestamp watermarked with different store name than this store
+cctv corridor clip where second shadow enters after person left
+cctv freeze frame of hallway where everyone still except one person walking backwards
+cctv image enhancement meme where ai department upscaled blur to clearly guilty ai artifact
+cctv of elevator counting down floors that do not exist
+cctv of empty restaurant where all chairs slightly rotated 2 degrees overnight same direction
+cctv of escalator counting steps people not counting
+cctv of kitchen where fridge light turns on by itself pattern of morse code
+cctv of laundry room dryer counting down from 99 minutes when it was off
+cctv of mall corridor during closed hours with all store shutters breathing slightly
+cctv of supermarket fridge aisle with light flicker that spells word
+cctv pixelation that forms face when downscaled by intern
+cctv timestamp from 1999 bleeding into current feed
+dashcam auto plate blur that blurs your house number too every time
+dashcam capturing streetlight that never turns off in middle of town blackout
+dashcam flare on empty highway that stays still while car moves
+dashcam gps overlay showing location 2km north of actual road in field
+dashcam lane detection flickers to count nine lanes on two lane road
+dashcam of parking garage capturing license plate that disappears mid frame
+doorbell cam covered in spider web at 3am motion triggered but no wind
+doorbell cam delivery photo with your door in photo not your door colour
+doorbell cam night vision that fails to show face when someone is at door but shows background sharp
+doorbell cam that auto zooms on empty street
+doorbell cam with person asking to come in using your voice
+gas station cctv of customer paying with hand not holding money
+nanny cam infrared ghost of handprint on crib rail
+nanny cam that goes monochrome only when baby cries
+parking camera plate recognition failing only on your car rendering as unknown
+parking surveillance showing car arriving with no driver exit
+pet cam cat staring directly into camera for six minutes at same spot on wall
+ring camera detecting package where there is none with weight estimated 4 kilograms
+security cam of warehouse where pallet moves inch per frame with no one
+security cam timestamp jumping three seconds forward every hour exactly
+security cam where rain looks like it falls upwards in one square meter
+security camera night vision eye glow from empty corner
+security footage where every clock shows 11 37 but analog
+security snapshot with watermark this recording may contain simulated elements
+security still where motion outline is human but no human visible
+surveillance review where intern counted 4 extra people in building after closing zero overtime
+surveillance still of hallway with emergency exit sign that says exist not exit
+thermal camera of empty waiting room showing warm footprints leading into wall
+thermal camera showing heat shape of person lying in empty bathtub
+thermal deer cam where deer all look at same invisible point off camera
+thermal drone scan of forest showing perfect circle of cold
+thermal image of bed showing arm around empty space
+thermal scan of house showing attic full of birds but attic sealed
+thermal scanner of crowd showing one person with no heat signature
+traffic cam speed readout of stationary car at 402 km hourly
+traffic cam that once captured flamingo crossing london road no follow up
+traffic camera showing queue of cars that are all same model same color

--- a/lists/places/non-euclidean.yml
+++ b/lists/places/non-euclidean.yml
@@ -1,0 +1,67 @@
+---
+title: Non-euclidean places
+category: places
+description: "Impossible architecture and spaces that break physical rules"
+---
+apartment with balcony that overlooks its own living room
+attic whose floorboards creak after you leave
+attic window that shows daylight from a different season
+basement that is larger inside than the house containing it
+basement whose light switch is always in different place
+bathroom mirror reflecting room with extra person behind
+bathroom tile pattern that spells numbers only in steam
+bathroom where gravity is sideways in the corner
+beach where tide recedes but beach never widens
+bedroom closet that opens into slightly wrong copy of bedroom
+bedroom where bed is simultaneously against all walls
+bridge that is same length both directions but never same crossing
+cafe whose interior is street level yet upstairs
+campus quad whose paths avoid where people walk
+city block that looks identical from every approach
+city park bench that is always shaded though no tree
+classroom whiteboard that erases itself slowly
+classroom with perspective vanishing point that moves
+corridor that narrows when you carry something
+corridor with doors only on one side but sounds from both
+desert highway with same cactus every mile
+door that opens to the same room from opposite side
+doorway that frames winter on one side summer on other
+elevator that opens on floor that does not exist
+escalator both up and down depending which foot first
+field where scarecrows all face you when wind changes
+forest that rearranges trees when you blink
+gallery where paintings are windows into other rooms of gallery
+garden shed that contains full overgrown garden
+hallway that gets longer when you run
+harbour that is always dawn even at midnight
+highway shoulder that echoes music from car ahead that is empty
+hospital wing with odd and even rooms overlapping
+hotel corridor that loops after three doors
+hotel lobby whose plant grows inches while you wait
+hotel room number that changes when you glance away
+house where all clocks show different correct times
+house where second floor is forest
+house with more windows outside than inside
+houseboat that is moored but drifts between cities
+ikea that goes down forever but never leaves floor two
+kitchen where distance to fridge depends on hunger
+lake that reflects constellation that does not exist
+library where every aisle leads to the same desk
+lighthouse whose light illuminates past
+mirror maze that reflects person who is not you
+museum whose exit leads to different century
+office where windows show night inside day outside
+parking garage ramp that descends forever
+pool with no shallow end and ladder on all four sides too short
+roadside diner that exists only when it rains
+rooftop door that opens onto different rooftop
+room where ceiling is also floor depending on entry
+room whose corners meet in middle
+shopping mall whose food court never ends
+snowy cabin where footprints appear ahead of you
+staircase that returns you one floor higher when you go down
+staircase whose handrail is warm like pulse
+stairwell where your footsteps echo before you step
+street that slopes down both ways from its middle
+subway platform where trains arrive from both tunnels at once
+tunnel that whispers your name forward but your steps back

--- a/lists/science/rejected-superpower.yml
+++ b/lists/science/rejected-superpower.yml
@@ -1,0 +1,74 @@
+---
+title: Rejected superpowers
+category: science
+description: "Useless, creepy, or situationally cursed minor abilities"
+---
+ability to become fluent in any language for length of single hiccup
+ability to become left handed for 12 minutes after sneeze
+ability to become mildly more attractive to geese
+ability to blink in perfect sync with any stranger
+ability to detect lies but only about whether someone ate your leftovers
+ability to find precisely one sock from dryer but never own
+ability to know exact bus arrival but only after bus left
+ability to know someone else's password but mistype final character always
+ability to make any pen run out precisely when signing important document
+ability to make any phone battery drain 1 percent faster when someone else texted but you have not replied
+ability to make any receipt ink fade twice as fast
+ability to make any screen brightness adjust incorrectly upon entering room
+ability to make any toast shadow look like famous person
+ability to make any traffic light stay green 2 seconds less
+ability to make any vending machine give extra item that you did not want
+ability to make any wikipedia rabbit hole end at surprisingly heavy page
+ability to sense when someone nearby is about to sneeze and not help
+ability to turn invisible to automated customer service voice recognition
+ability to turn off any night light from different room non intentionally
+can breathe underwater but only in bath
+can burp alphabet correctly but backwards and in latin
+can cause any automatic door to take offense and not open
+can conjure perfect parallel parking space after you already parked far
+can duplicate any key but always one copy too many unrelated
+can feel location of lost remote but only when sitting on it
+can freeze water by staring if water is already ice
+can hear bats but only gossiping
+can hear hum of fridge in any building within one mile
+can hear wifi as faint static
+can instantly know price of any item in 1973
+can make any cereal soften instantly
+can make any dog briefly confused about where it buried toy
+can make any plant photosynthesize pessimistically
+can make any queue move backwards by staring
+can make any spoon reflect your face slightly fatter
+can make any stranger think they know you from somewhere generic
+can pause time for 0.8 seconds and use it to think about pausing time
+can predict which lift door will open with 96 percent accuracy
+can speak fluently to ants but they talk only about queens death
+can summon door that leads to broom closet in random building
+can summon second shadow that is late
+can summon slightly damp socks that always fit
+can summon small cloud that follows you and rains only on phone screen
+can summon wind that only affects hair
+can talk to traffic cones but they lie and give bad directions
+can taste color red only on tuesdays
+can telepathically move object one millimeter per hour but only when holding breath
+can teleport breath to other side of room
+can teleport only to places that are already within arm reach
+can translate baby crying accurately and wishes could not
+can turn any food into emergency food that tastes like emergency
+can turn any liquid into tears of mild inconveniences
+can turn into any chair but only plastic garden chairs
+can turn into mist but mist smells faintly of bleach
+can turn water into slightly different water that is room temperature
+can understand meaning of any captcha but fails captcha anyway
+knows exactly when toast will pop but never in time to catch it
+makes any plant die 12 percent slower
+power to know exactly how many steps someone else took today
+power to know exactly when milk will turn but still drink anyway
+power to make any bulb flicker by walking past aggressively
+power to make any plants double jointed
+power to make any queue have one person with very slow coin counting ahead of you
+power to make plants grow towards you slightly faster
+power to make toast land butter side up but cold
+power to open any jar that is already open
+power to understand dreams of goldfish
+turns invisible only when no one including cameras is looking
+สามารถ summon pigeon that always knows where you parked yesterday

--- a/lists/thing/cursed-object.yml
+++ b/lists/thing/cursed-object.yml
@@ -1,0 +1,66 @@
+---
+title: Cursed objects
+category: thing
+description: "Everyday objects that feel haunted, watched, or subtly wrong"
+---
+baby monitor that plays a lullaby no one recorded
+bag of ikea spare screws that multiplies
+balloon that follows you at eye level indoors
+bathroom mirror that fogs one handprint
+beanbag that sighs when no one sits
+bike whose bell rings when house is empty
+bluetooth speaker that whispers a name at 3am
+book whose page numbers run backwards after 100
+car air freshener shaped like a tiny screaming face
+car key fob that locks a different car
+ceiling fan that spells words in shadow
+chair that is always warm
+child's drawing of your bedroom from inside the closet
+christmas lights that spell out messages
+coffee mug that refills itself with cold coffee
+cracked tamagotchi that asks if you are alone
+dollhouse replica of your house with one extra room
+doorbell camera that waves back
+dryer that returns one sock sewn shut
+electric toothbrush that vibrates when ghosts pass
+eternal jawbreaker that hums
+extension cord that plugs into itself
+fidget spinner that never stops
+fridge magnet that spells words you did not arrange
+furby with human teeth
+garden gnome that faces the window each morning
+glasses that show your house with all doors open
+halloween candy that never loses flavor
+houseplant that grows towards inside wall
+jigsaw puzzle with one piece that moves
+kettle that whistles in morse code
+key that fits every lock but your front door
+lamp that turns on a second after you turn it off
+leak that spells help
+lighter that lights by itself in drawers
+magic eight ball that only says ask later until you are alone
+microwave that shows one second more than elapsed
+music box that winds itself
+night light that casts shadow of person not there
+porcelain doll with warm hands
+puzzle box that clicks when someone lies nearby
+rechargeable battery that is still warm hours later
+roomba that draws protection circle
+rubber duck that faces you no matter rotation
+second toothbrush that appears and disappears
+smoke alarm that beeps even with new battery removed
+snow globe where snow never settles
+sock that is always inside out after wash
+stuffed animal whose sewn eyes track you
+taped shut vhs that rewinds itself
+teddy bear with extra stitched pocket containing a note
+thermostat that drops two degrees when you lie
+toaster that burns same face into every slice
+tv remote with button for room you do not have
+umbrella that stays dry
+usb stick that contains photos of your house taken yesterday
+vacuum bag full of hair not yours
+vending machine that dispenses one extra cursed snack
+water bottle that tastes like pennies after midnight
+wind chime that rings when there is no wind
+yo-yo that pauses mid drop

--- a/lists/thing/found-in-wall.yml
+++ b/lists/thing/found-in-wall.yml
@@ -1,0 +1,65 @@
+---
+title: Things found in walls
+category: thing
+description: "Truly weird discoveries from home renovations and demolitions"
+---
+antique doorbell wired to neighbors
+band aid tin full of teeth that are all same molar
+bouquet of dried flowers wired into stud still flowering
+box of vhs porn labeled home repairs 1987
+bundle of fishing line tied to next building
+cassette labeled dave's alibi with no tape
+child's drawing of current homeowner before they moved in
+childs toy walkie talkie that still crackles at night
+concrete hand holding real wedding ring
+dildo wrapped in insulation labeled air gap
+doll with map of house drawn on back
+false cavity with campfire ash and charred mattress springs
+floor safe with combination written on inside of safe
+folded up mcdonald's bag with human baby teeth
+folder of photos of empty rooms of this house
+framed photo of house with all curtains drawn from drone angle
+garage door opener for garage that never had garage
+geocities forum printed and stapled from 2002
+grocery bag of cents exactly 43 dollars in pennies melted together
+hoarder's stash of hotel bibles all same room number
+horsehair plaster with haircuts still attached
+jar of teeth labeled xmas 83
+jenga tower mortared into chimney
+key ring with 40 keys all for schlage and one for unknown lock
+ladder to nowhere capped with drywall both ends
+letter from contractor apologizing for leaving letter in wall
+live bee colony using old playboys as insulation
+mummified squirrel wearing cigarette packet as coffin
+nest of black mold shaped exactly like virgin mary
+nested bird skeleton wearing thimble as hat
+newspaper from future date with your obituary redacted
+nothing in wall that is stud sized human shaped air gap
+old nokia brick still with one percent and unreadable sim
+package that usps tracking shows delivered to this cavity in 2012 unopened
+pair of handcuffs rusted shut around rebar
+pair of tiny handprints in poured concrete
+plastic army men glued battle formation inside hvac duct
+polaroids of previous owner sleeping
+porn magazine from 1971 rolled into pipe insulation
+power tool battery that is bigger than cavity but inside cavity
+printer full of blank paper jammed with one sheet printed no
+receipt for wall itself installation dated before house built
+rusted lunchbox with rotting union newsletter from 1973
+school tie from 1964 with name stitched jonathan your street
+shampoo bottle full of screws
+shoebox diorama of living room with previous owners frozen mid dinner
+shower curtain used as insulation cut to exact window
+shrink wrapped vhs of static labeled watch when you move
+single converse shoe with live succulent growing
+smoke detector with wire cut and note saying sorry
+time capsule from only two years ago already cemented
+tin full of barbies with shaved heads
+tiny door that opens to brick with tiny handle on brick side also
+tv aerial cable feeding live tv to nothing
+vodka bottle filled with pennies mortared into brick
+wall cavity full of unopened junk mail from 1998 to 2007
+wall clock embedded in plaster still ticking without battery
+wall outlet that powers nothing and leads to brick
+wasp nest built around fuse
+whole unopened amazon box containing only packing peanuts and usb powers for tv

--- a/lists/thing/impossible-tool.yml
+++ b/lists/thing/impossible-tool.yml
@@ -1,0 +1,58 @@
+---
+title: Impossible tools
+category: thing
+description: "Surreal and impossible tools that should not exist but look convincing in product shots"
+---
+angle grinder that grinds perspective
+brush that sweeps under rug that sweeps under bigger rug
+bucket that holds only sound of rain
+cable tie that ties together two different days
+caliper that measures distance between you and version of you in ad
+caulking gun that fills gaps between what said and what meant
+chisel that carves patience into stone
+clamp that holds breath for you
+compass saw that saws compass rose into floor creating true north inside
+compass that points to next place you will lose phone
+crowbar that pries open closed minds requires two people
+detector that beeps when someone is thinking of you three houses away
+drill that makes holes you can see through to tuesday
+eraser that removes footprints from sand you never walked
+extension ladder that extends into other person's dream
+file that smooths awkward pauses
+funnel that funnels attention span back into head through ear
+glue gun that sticks fractured timelines back together badly
+hammer that only nails shadows to wall permanently at dusk
+heat gun that melts frozen small talk
+ladder rung labeled do not use precisely middle rung most used
+ladder that leads exactly to where you started but side view
+levelling tool that shows how tilted your life is
+magnet that attracts lost things but only when not looking for them
+multi tool with spoon fork regret and tiny saw for expectations
+nail gun that fires compliments that stick for two seconds
+paintbrush that paints yesterday onto today
+pickaxe that mines nostalgia from childhood garden
+plumb line that hangs towards past
+plunger for unclogging time in kitchen sink of time
+power washer that washes off doubt
+pry bar for prying truth from polite people
+ruler that measures brightness of idea
+sandpaper that sands off first impression second chance
+saw that cuts silence into manageable pieces
+sawhorse comprised of actual seahorse on stilts
+scissors that cut only promises
+screwdriver for unscrewing other people's memories
+shovel that digs hole that digs itself deeper while you sleep
+sledgehammer for breaking fourth wall structurally unsound after
+socket set where sockets fit emotions exactly 10mm always lost
+soldering iron that solders broken promises good as new for one use
+spanner that tightens loose ends of conversations
+spirit level that shows balance between work and imaginary work
+stapler that staples moment to memory permanently
+stethoscope that listens to walls that remember
+stud finder that finds confidence in walls
+tape measure that measures regrets in centimeters
+torque wrench calibrated in sighs
+tweezers for plucking single grey hairs from future
+voltmeter that reads voltage of eye contact
+wire stripper that strips small talk to copper truth
+wrench that loosens jar that universe tightened


### PR DESCRIPTION
10 weirder, more unhinged, peculiar lists (~589 entries) for surreal / horror / comedy AI prompts:

1. `thing/cursed-object` (61) — everyday objects subtly haunted: porclain doll warm hands, vhs that rewinds itself, furby human teeth, tamagotchi asks if alone
2. `places/non-euclidean` (62) — impossible architecture: ikea staircase down forever still floor 2, hallway longer when run, bathroom gravity sideways in corner
3. `people/micro-archetype` (59) — hyper-specific modern niches: gas station hot dog reviewer, crypto landlord of 3 discords, guy who carries film camera never develops
4. `science/rejected-superpower` (69) — useless/cursed minor powers: summon damp socks, invisible only when no one looks, talk to traffic cones but they lie
5. `thing/found-in-wall` (60) — true weird renovation finds: bee colony using playboys as insulation, jar teeth xmas 83, child's drawing of you pre-move
6. `photography/surveillance-glitch` (56) — cctv/thermal/dashcam artifacts: doorbell web 3am, thermal person not there, cctv timestamp from 1999 bleeding
7. `food/forbidden-food` (54) — edible-looking but not / cursed combos: glowing cheese hums, wet newspaper sandwich, milk skin aged 39 days into leather
8. `feeling/uncanny` (53) — nameless modern feelings: nostalgia for unlived life, tenderness for object about to trash, guilt of not waving back too late
9. `interaction/micro-ritual` (62) — tiny unspoken modern rituals: fridge recheck, fake phone call to avoid chat, tapping car twice when towed
10. `thing/impossible-tool` (53) — surreal tools: hammer nails shadows, tape measures regrets, levelling tool shows how tilted your life is

All yml have frontmatter matching existing style, lowercased, sorted, deduped via `sanitise.js`, lint clean. Source-only (no generated lists.json).

Commit as fofr-foffee with co-author trailer per AGENT-CONTEXT.