### PR TITLE
feat(proposals): add retro-tech, micro-imperfection, and atmospheric-anomaly list proposals

### DIFF
--- a/lists/nature/atmospheric-anomaly.yml
+++ b/lists/nature/atmospheric-anomaly.yml
@@ -1,0 +1,51 @@
+---
+title: Atmospheric anomalies
+category: nature
+description: "Surreal, science-fiction, and magical weather and atmospheric phenomena"
+---
+anti-gravity rain falling upwards in thin, glistening needles
+bioluminescent fog that glows with a faint green light
+cloud formation resembling a massive, silent tidal wave frozen in time
+cloud formation that drifts in a perfect, rigid grid pattern across the sky
+cloud that remains perfectly motionless despite a howling gale around it
+crimson-hued heat shimmer that makes the horizon appear liquid
+double sun-dog reflecting mirror images of the sun at dawn
+dust-devil made entirely of glittering obsidian sand and ash
+fall of ash composed of glittering mica flakes that catch the sun
+fall of dry, cold, glowing neon dust that collects on leaves like green fireflies
+fall of rain where each droplet is encased in a tiny bubble of soap-like film
+fall of snow composed of delicate, geometric glass-like flakes that do not melt
+fall of sparkling hoarfrost that crystallizes mid-air before landing
+fog that glows with a warm, amber, candle-like illumination from within
+glowing orange sun-pillar that extends vertically into the upper atmosphere
+glowing purple ozone storm with silent, sheet lightning
+ground-level fog that behaves like a slow-moving liquid, pooling in depressions
+ground-level mist that reflects iridescent oil-slick rainbow patterns
+ground-level mist that smells faintly of old books and ozone
+iridescent ice-fog that scatters light like crushed diamonds
+localized atmospheric inversion that makes distant sounds seem inches away
+localized column of golden sunlight that bends at an impossible angle
+localized column of wind that blows upwards in a quiet, dust-free tube
+localized gravity well that pulls nearby clouds into a perfect spiral
+localized rain of soft, glowing dandelion seeds drifting horizontally
+localized raincloud that casts a shadow of stars instead of darkness
+localized storm cloud that rains warm, fragrant tea over a single field
+localized whirlwind that whispers fragments of forgotten conversations
+low-hanging thundercloud that glows from within like a neon lamp
+micro-climate raincloud hovering indoors over a single chair
+mist that dampens sound completely, creating an absolute silence
+mist that slowly polarizes light, making the sky appear like a stained-glass window
+rain of pale, bioluminescent pollen that illuminates the ground at night
+rain of tiny, cold, bioluminescent jellyfish that float softly downwards
+rain of tiny, cold, glowing copper sparks that vanish when they touch the ground
+rain of tiny, soft, feather-like ice crystals that drift like dandelion down
+rain that leaves behind a temporary, faint silver metallic sheen on surfaces
+sky filled with glowing, slow-moving sheets of faint pink heat-lightning
+sky filled with thousands of floating, harmless bubbles of static electricity
+sky filled with three intersecting rings of shimmering ice crystals
+sky that displays a subtle, pulsing grid of golden threads during a solar eclipse
+sky that slowly shifts in color gradient like hot titanium
+sky that turns a deep indigo-black with two glowing, concentric rainbow rings
+sky-splitting emerald aurora-arcs that cast sharp shadows
+whispering wind that creates visible, liquid-like ripples in the air
+wind that causes nearby shadows to lag two seconds behind the objects throwing them

--- a/lists/people/micro-imperfection.yml
+++ b/lists/people/micro-imperfection.yml
@@ -1,0 +1,59 @@
+---
+title: Micro-imperfections
+category: people
+description: "Subtle, organic skin, hair, and facial textures that ground AI portraits in raw reality"
+---
+deep, dimpled chin that catches shadow
+delicate crows-feet wrinkles around the outer eyes
+delicate goosebumps visible along the forearm skin
+delicate laugh lines running from the nostrils to the mouth corners
+delicate, tiny skin tags near the base of the neck
+dry, wind-chapped hands with fine skin cracks around the knuckles
+dusting of golden freckles across the chest and neck skin
+dusting of pale freckles on the backs of the hands
+dusting of silver-white baby hairs near the crown of the head
+dusting of soft freckles along the shoulders and upper back
+faint crease in the skin of the earlobe
+faint dry skin patches on the bridge of the nose
+faint vertical crease in the middle of the forehead
+faint vertical lines on the fingernails of the hand
+faint vertical scar on the throat from an old surgery
+faint vertical scar running down the center of the collarbone
+faint, crescent-shaped scar near the hairline
+faint, curving laugh lines radiating from the corners of the eyes
+faint, elegant vitiligo patches along the jawline and cheek
+faint, horizontal sleep crease on the side of the neck
+faint, horizontal worry lines across the forehead
+faint, soft shadow under the eyes from natural bone structure
+fine, parallel creases on the neck skin when looking down
+fine, silver spider-vein texture on the temple skin
+fine, silver-colored stretch marks on the outer thigh
+light dusting of peach fuzz along the jawline catching backlighting
+silver-grey hairs mixed sparsely at the temples
+silver-threaded stretch marks across the shoulder curve
+slight redness and windburn across the cheekbones and nose
+slight redness around the edges of the nostrils from a cold
+slight shadow of dark stubble showing along the jawline
+slightly crooked front tooth showing in a gentle smile
+slightly dry, peeling skin on the outer ears from sunburn
+slightly textured skin on the forehead with fine bumps
+slightly uneven skin pigmentation with warm sunspots on the forehead
+slightly uneven, organic skin pores with natural oil sheen
+small, pale vaccination scar on the upper bicep
+splattering of sun-bleached freckles across the bridge of the nose
+subtle scar on the upper lip from a childhood scrape
+subtle, dark under-eye circles from sleeplessness
+subtle, dark-spotted sunspots across the collarbone skin
+subtle, faint acne scarring on the lower cheeks
+subtle, vertical scar bisecting the outer edge of the eyebrow
+sun-freckled shoulders and collarbone skin
+sun-kissed peeling skin on the tip of the nose
+tiny dark beauty mark sitting precisely at the corner of the lip
+tiny red spider-angioma dot on the upper cheekbone
+tiny, dark birthmark located on the lower jaw
+tiny, dark mole situated just above the collarbone
+tiny, golden-brown freckle on the iris of one eye
+tiny, pale chickenpox scar on the left temple
+tiny, pale scar on the chin from a playground fall
+wind-burned ears with slightly red skin tips
+wind-chapped lips with fine vertical texture lines

--- a/lists/thing/retro-tech.yml
+++ b/lists/thing/retro-tech.yml
@@ -1,0 +1,68 @@
+---
+title: Retro technology
+category: thing
+description: "Tactile, analog, and early digital consumer electronics that carry a strong physical aesthetic"
+---
+8-track cartridge player with faux-wood paneling
+analog desktop rolodex with blank paper cards
+bakelite tube radio from the 1940s with a dark brown finish
+car dashboard eight-track tape deck with chrome buttons
+cathode-ray tube (crt) television with built-in vcr
+clunky handheld metal detector with a circular search coil and analog meter
+clunky matrix dot-printer with tractor-feed paper
+clunky pocket-sized spell-checker with a grey lcd screen
+clunky tabletop mimeograph machine with a rotating stencil cylinder
+clunky walkie-talkie with a flexible steel whip antenna
+dual-deck audio cassette recorder with tape counter
+early macintosh computer with a beige 9-inch crt screen
+early nokia phone with a green backlit monochrome display
+flip-up pocket organizer with mechanical keys
+floppy disk 3.5-inch with handwritten sticky label
+game boy camera attachment in a purple shell
+handheld mechanical click-counter with a metal ring
+handheld view-master toy with circular 3d slide reels
+handheld vintage light-meter with a needle dial
+heavy vintage rotary calculator with dozens of numbered keys
+heavy vintage slide-viewer with a small illuminated ground-glass screen
+laserdisc player with a heavy metallic tray
+mechanical alarm clock with double brass bells on top
+mechanical pocket watch with exposed golden gears and ticking escapement
+minidisc player with a translucent blue casing
+multi-band shortwave radio receiver with metal toggles
+neon green pager with a tiny monochrome lcd screen
+pocket slide-rule calculator with mechanical sliding parts
+pocket-sized dictaphone with a tiny microcassette
+pocket-sized electronic translator with rubber chiclet keys
+pocket-sized transistor radio with a wrist-strap and single earphone
+pocket-sized vintage compass with a heavy brass casing and fluid-filled dial
+pocket-sized vintage dictaphone with a tiny microcassette
+polaroid land camera with a leather bellows expansion
+portable boombox with double cassette decks and metal speaker grilles
+portable casio black-and-white tv with telescoping antenna
+portable cd walkman with anti-skip protection
+portable super 8 film editor with a small magnifying viewer and hand cranks
+portable super 8 movie camera with a folding grip
+portable thermal label printer with a tiny feed roller
+reel-to-reel magnetic tape recorder with glowing vu meters
+retro car dashboard with a red glowing numeric vacuum fluorescent display
+retro car dashboard with green electroluminescent gauges
+retro coin-operated parking meter with a red expired flag
+retro desk fan with teal-painted metal blades and chrome cage
+retro home intercom station with a master push-to-talk button
+retro neon telephone with a glowing blue tube outlining its body
+retro sylvania flashcube for vintage cameras
+slide projector with a rotating carousel click-wheel
+table-top nickelodeon with a small circular viewfinder
+tabletop ham radio receiver with dozens of knobs and dials
+tabletop record player with a polished wooden casing and brass tonearm
+transparent neon rotary telephone from the 1980s
+transparent plastic game boy color with visible circuit board
+vintage atari 2600 woodgrain game console with joystick
+vintage mainframe computer tape drive unit with spinning reels
+vintage neon beer sign transformer with exposed wiring
+vintage radio shack walkie-talkie with large plastic dials
+vintage smith-corona mechanical typewriter
+vintage sound level meter with a yellow dial and black selector knob
+vintage tabletop oscilloscope with a green glowing circular crt grid
+vintage zenith tabletop radio with a backlit amber dial
+wall-mounted payphone with a heavy chrome handset


### PR DESCRIPTION
This PR introduces three new, exhaustive, and highly visual list proposals to prompt-lists, compiled and sanitized:

1. **lists/thing/retro-tech.yml** — Exhaustive, tactile, and obsolete consumer technology with rich physical and mechanical properties (63 items, e.g. CRT TVs with built-in VCRs, transparent neon rotary phones, reel-to-reel magnetic tape recorders, tape counters, view-masters).
2. **lists/people/micro-imperfection.yml** — Subtle, organic skin, hair, and facial textures (54 items, e.g. splattering of sun-bleached freckles, faint crows-feet wrinkles, collarbone moles, vitiligo, windburn) that act as highly realistic, believable anchors in AI portraits.
3. **lists/nature/atmospheric-anomaly.yml** — Surreal, science-fiction, and magical weather and atmospheric phenomena (46 items, e.g. bioluminescent fog, anti-gravity rain, neon thunderclouds, wind that lags shadows, bubble rain).

All lists have been locally sorted, sanitized, and successfully compiled with zero errors.