### PR TITLE
Keep releases clean after list sanitisation

### DIFF
--- a/lists/name/family-europe.yml
+++ b/lists/name/family-europe.yml
@@ -43,6 +43,7 @@ bianco
 blanc
 blanchard
 blanco
+böhm
 bondarenko
 bonnet
 bos
@@ -60,7 +61,6 @@ bruno
 burke
 busch
 byrne
-böhm
 cameron
 campbell
 carbone
@@ -200,6 +200,7 @@ hagen
 hahn
 hall
 halvorsen
+hämäläinen
 hansen
 hansson
 harris
@@ -221,13 +222,12 @@ hoffmann
 hofmann
 holm
 horak
+horák
 horn
 horvath
-horák
 huber
 hughes
 hunter
-hämäläinen
 ionescu
 ivanov
 jackson
@@ -240,6 +240,7 @@ jankowski
 jansen
 janssen
 jansson
+järvinen
 jensen
 jesus
 jimenez
@@ -251,10 +252,9 @@ johnson
 joly
 jones
 jonsson
-jung
-järvinen
 jönsson
 jørgensen
+jung
 kaczmarek
 kaiser
 kaminski
@@ -270,6 +270,7 @@ klein
 koch
 kohler
 kok
+könig
 korhonen
 koskinen
 kovacs
@@ -290,7 +291,6 @@ kucera
 kuhn
 kuznetsov
 kwiatkowski
-könig
 lacroix
 laine
 lambert
@@ -333,6 +333,8 @@ maes
 magnusson
 maguire
 maier
+mäkelä
+mäkinen
 makris
 mancini
 marchand
@@ -385,12 +387,10 @@ morozov
 morris
 mulder
 muller
+müller
 munoz
 murphy
 murray
-mäkelä
-mäkinen
-müller
 nagy
 navarro
 nemec
@@ -406,10 +406,10 @@ nilsen
 nilsson
 noel
 novak
+novák
 novikov
 novotny
 novotný
-novák
 nowak
 nunes
 o'brien
@@ -508,6 +508,7 @@ santos
 sartori
 sauer
 schafer
+schäfer
 schmid
 schmidt
 schmitt
@@ -524,7 +525,6 @@ schulze
 schumacher
 schuster
 schwarz
-schäfer
 scott
 seidel
 semenov
@@ -611,12 +611,12 @@ winkler
 winter
 wisniewski
 wojcik
+wójcik
 wolf
 wolff
 wood
 wozniak
 wright
-wójcik
 young
 ziegler
 zielinski

--- a/lists/name/given-africa.yml
+++ b/lists/name/given-africa.yml
@@ -908,6 +908,7 @@ sekela
 sekgohe
 sekgopi
 sekiu
+sékou
 sekyiwaa
 selam
 selemeng
@@ -1172,7 +1173,6 @@ sylvana
 sympathy
 synod
 syviwe
-sékou
 taalo
 tabale
 tabela

--- a/lists/name/given-east-asia.yml
+++ b/lists/name/given-east-asia.yml
@@ -357,9 +357,9 @@ miyuki
 mizuki
 moe
 momoko
+mönkh-erdene
 monkhbat
 my
-mönkh-erdene
 na
 nam
 nami

--- a/lists/name/given-europe.yml
+++ b/lists/name/given-europe.yml
@@ -162,6 +162,7 @@ grace
 greta
 guilherme
 gustav
+håkon
 hanna
 hannah
 harry
@@ -171,7 +172,6 @@ henrik
 henrique
 henry
 hugo
-håkon
 ida
 igore
 ilja
@@ -222,8 +222,11 @@ lara
 lars
 laura
 lea
+léa
 lena
+léna
 leo
+léo
 leon
 leonardo
 leonor
@@ -258,11 +261,9 @@ luisa
 luise
 lukas
 luuk
-léa
-léna
-léo
 madalena
 mael
+maël
 magnus
 maja
 maje
@@ -298,7 +299,6 @@ matti
 mattia
 maxime
 maya
-maël
 mees
 melina
 mia
@@ -313,8 +313,8 @@ molly
 moritz
 muhammad
 natalia
-nathan
 natálie
+nathan
 nele
 nicolas
 nicole
@@ -345,12 +345,12 @@ pedro
 pekka
 peter
 philipp
+pía
 pierre
 pirjo
 polak
 polina
 poppy
-pía
 raphael
 raphaël
 riccardo
@@ -438,6 +438,6 @@ wojciech
 yulia
 yuna
 zoe
-zofia
 zoé
+zofia
 zuzanna

--- a/lists/name/given-latin-america.yml
+++ b/lists/name/given-latin-america.yml
@@ -1894,6 +1894,7 @@ nina
 ninette
 ninfa
 nini
+niño
 niola
 nira
 nirio
@@ -1910,7 +1911,6 @@ nivia
 niyeli
 niyo
 niz
-niño
 noah
 noami
 nobel

--- a/lists/name/given-middle-east.yml
+++ b/lists/name/given-middle-east.yml
@@ -310,6 +310,7 @@ nabil
 nabila
 nada
 nadia
+nádia
 nadir
 nagwa
 nahla
@@ -346,12 +347,12 @@ norah
 nour
 noura
 nursel
-nádia
 oded
 oguz
 okan
 omar
 omer
+ömer
 omid
 omran
 or
@@ -462,8 +463,8 @@ soren
 souad
 stav
 suha
-sultan
 süleyman
+sultan
 tabip
 taghreed
 taha
@@ -538,4 +539,3 @@ ziyad
 zohreh
 zouhair
 zuhair
-ömer

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "pretest": "npm run sanitise; npm run build",
     "build": "node build.js",
-    "test": "standard",
+    "test": "standard && git diff --exit-code -- lists",
     "lint": "standard",
     "lint:fix": "standard --fix",
     "sanitise": "node sanitise.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "pretest": "npm run sanitise; npm run build",
     "build": "node build.js",
-    "test": "standard && git diff --exit-code -- lists",
+    "test": "standard && git diff --exit-code -- lists lists.json list-metadata.json",
     "lint": "standard",
     "lint:fix": "standard --fix",
     "sanitise": "node sanitise.js"

--- a/sanitise.js
+++ b/sanitise.js
@@ -6,6 +6,7 @@ const rootDir = 'lists'
 const excludedLists = [
   'city', 'country', 'territory', 'day', 'parti', 'describe', 'moviegen-bench'
 ]
+const collator = new Intl.Collator('en')
 
 const processDirectory = (dir) => {
   const dirEntries = fs.readdirSync(dir, { withFileTypes: true })
@@ -41,7 +42,7 @@ const processFile = (dir, file) => {
   list = [...new Set(list)]
 
   // Sort
-  list.sort((a, b) => a.localeCompare(b))
+  list.sort(collator.compare)
 
   const newContents = `---${frontmatter}---\n${list.join('\n')}\n`
 


### PR DESCRIPTION
## Why this change is needed

Running the release tool currently fails while bumping the package version because the test step sanitises six newly added name lists and leaves the Git working tree dirty. Contributors need sanitisation problems to fail during testing, before the release reaches npm version.

## What changed

- Normalised the six affected name lists using the existing sanitiser.
- Made the intended English collation explicit instead of relying on the host default locale.
- Made the test command fail if sanitisation changes tracked list sources.

## Why this approach

The existing locale-aware ordering is already used across the established lists, so changing every list to code-point ordering would create broad churn. This keeps the established ordering and adds a direct clean-tree invariant to the release test path.

## Verification

- npm test on Node 24.18.0
- npm test on Node 20.20.2
- A second sanitisation pass leaves lists unchanged
- git diff --check