### PR TITLE
Expand fiction coverage with 105 world lists

### DIFF
--- a/lists/fiction/abhorsen.yml
+++ b/lists/fiction/abhorsen.yml
@@ -1,0 +1,40 @@
+---
+title: Old Kingdom names
+category: fiction
+description: "Places, peoples, creatures, institutions, artifacts, and distinctive names from Garth Nix's Old Kingdom series"
+---
+abhorsen
+abhorsen's house
+ancelstierre
+ancient charter
+astarael
+belgaer
+charter
+charter magic
+charter marks
+clayr
+clayr glacier
+death
+deep clayr
+disreputable dog
+dyrim
+free magic
+free magic creatures
+great charters
+greenwash
+kerrigor
+kibeth
+life
+mogget
+mosrael
+nine precincts of death
+old kingdom
+paperwing
+ranna
+red lake
+saraneth
+the walker
+the wall
+wallmakers
+western desert
+wyverley college

--- a/lists/fiction/adventure-time.yml
+++ b/lists/fiction/adventure-time.yml
@@ -1,0 +1,53 @@
+---
+title: Adventure Time world
+category: fiction
+description: "Kingdoms, peoples, creatures, factions, artifacts, and distinctive names from Adventure Time"
+---
+banana guards
+billy
+bmo
+candy kingdom
+card wars
+cosmic owl
+crystal dimension
+demon blood sword
+enchiridion
+farmworld
+fern
+finn the human
+fire kingdom
+flame princess
+golb
+grass sword
+gunter
+huntress wizard
+ice crown
+ice king
+ice kingdom
+jake the dog
+james baxter
+lemongrab
+lich
+lumpy space
+lumpy space princess
+magic man
+marceline
+mo
+nightosphere
+peppermint butler
+princess bubblegum
+prismo
+rainicorns
+scarlet
+simon petrikov
+slime kingdom
+snail
+sweet p
+the candy people
+the citadel
+the land of ooo
+the tree house
+tree trunks
+vampire king
+wildberry kingdom
+wizard city

--- a/lists/fiction/amphibia.yml
+++ b/lists/fiction/amphibia.yml
@@ -1,0 +1,43 @@
+---
+title: Amphibia world
+category: fiction
+description: "Amphibian peoples, places, creatures, technology, factions, and artifacts from Amphibia"
+---
+andrias leviathan
+anne boonchuy
+armored herons
+bessie
+calamity box
+calamity gems
+calamity powers
+core
+domino ii
+frobo
+frog valley
+grime
+herons
+hop pop plantar
+lady olivia
+land of amphibia
+leif plantar
+marcy wu
+moss man
+mother olm
+newtopia
+newtopian army
+night guard
+olms
+plantar farm
+polly plantar
+resistance
+sasha waybright
+snird
+sprig plantar
+toad tower
+toads
+toadstool
+tritonio espada
+valeriana
+wartwood
+wartwood swamp
+yunan

--- a/lists/fiction/artemis-fowl.yml
+++ b/lists/fiction/artemis-fowl.yml
@@ -1,0 +1,46 @@
+---
+title: Artemis Fowl world
+category: fiction
+description: "Fairy peoples, organizations, places, technology, creatures, and distinctive names from the Artemis Fowl novels"
+---
+artemis fowl ii
+atlantis
+b'wa kell
+berserkers
+blue rinse
+butler
+centaur
+chute e1
+commander root
+d'arvit
+demon island
+dwarfs
+elf
+fairy book
+foaly
+fowl manor
+goblins
+haven city
+holly short
+hybras
+imp
+julius root
+leprecon
+lower elements
+lower elements police
+magic ritual
+mesmer
+mulch diggums
+neutrino 2000
+no1
+opal koboi
+p-suit
+pixie
+retrieval squad
+roving eye
+shuttleport e37
+the c cube
+the people's council
+time tunnel
+troll
+warlock

--- a/lists/fiction/attack-on-titan.yml
+++ b/lists/fiction/attack-on-titan.yml
@@ -1,0 +1,44 @@
+---
+title: Attack on Titan world
+category: fiction
+description: "Nations, factions, peoples, walls, Titan powers, places, and military technology from Attack on Titan"
+---
+ackerman clan
+anti-marleyan volunteers
+armored titan
+attack titan
+beast titan
+cart titan
+colossal titan
+eldia
+eldians
+eren yeager
+female titan
+founder ymir
+founding titan
+garrison regiment
+great titan war
+humanity within the walls
+liberio
+marley
+marleyan warriors
+military police brigade
+nine titans
+paradis island
+paths
+pure titans
+reiss family
+royal government
+rumbling
+shiganshina district
+survey corps
+three-dimensional maneuver gear
+titan serum
+underground city
+wall maria
+wall rose
+wall sheena
+wall titans
+war hammer titan
+warriors unit
+yaegerists

--- a/lists/fiction/bartimaeus.yml
+++ b/lists/fiction/bartimaeus.yml
@@ -1,0 +1,39 @@
+---
+title: Bartimaeus Sequence names
+category: fiction
+description: "Places, spirits, magical institutions, artifacts, factions, and distinctive names from Jonathan Stroud's Bartimaeus Sequence"
+---
+afrit
+alexandria
+amulet of samarkand
+british empire
+commoners
+demons
+djinn
+elemental spheres
+essence
+faculty
+fifth plane
+foliots
+gladstone's staff
+government
+imperial conference
+imps
+magicians
+marids
+ministry of internal affairs
+night police
+other place
+parliament
+pentacle
+prague
+ring of solomon
+seven planes
+simurgh
+spheres
+spirit world
+the resistance
+the tower of london
+utukku
+westminster
+whitehall

--- a/lists/fiction/belgariad.yml
+++ b/lists/fiction/belgariad.yml
@@ -1,0 +1,51 @@
+---
+title: Belgariad world names
+category: fiction
+description: "Places, peoples, gods, creatures, factions, artifacts, and distinctive names from David Eddings's Belgariad and Malloreon"
+---
+aloria
+alorn council
+alorns
+angarak
+angarak gods
+arendia
+arends
+ashaba
+bear-cult
+belgarath
+belgarion
+cherek
+chereks
+cthol mishrak
+cthol murgos
+drasnia
+drasnian intelligence
+dryads
+gar og nadhrak
+grolims
+isle of the winds
+mallorea
+maragor
+marags
+melcene empire
+mimbrates
+mrins codex
+murgo
+nadrak
+nyissa
+orb of aldur
+perivor
+riva
+rivans
+sendar
+sendaria
+serpent queen
+stone of the rivan king
+tol honeth
+tol nedra
+torak
+tree of the dryads
+ulgo
+ulgoland
+vale of aldur
+western kingdoms

--- a/lists/fiction/berserk.yml
+++ b/lists/fiction/berserk.yml
@@ -1,0 +1,41 @@
+---
+title: Berserk world
+category: fiction
+description: "Kingdoms, factions, apostles, places, creatures, and artifacts from Berserk"
+---
+apostles
+band of the hawk
+behelit
+black swordsman
+casca
+chitch
+dragon slayer
+eclipse
+elfhelm
+falconia
+fantasia
+farnese
+flora
+god hand
+griffith
+guts
+holy see
+interstice
+kingdom of midland
+misty valley
+moonlight boy
+nosferatu zodd
+puck
+qiphoth
+schierke
+skull knight
+the astral world
+the brand of sacrifice
+the great roar of the astral world
+the holy iron chain knights
+the kushan empire
+the reborn band of the hawk
+the sea god
+the tower of conviction
+the world spiral tree
+vritannis

--- a/lists/fiction/black-company.yml
+++ b/lists/fiction/black-company.yml
@@ -1,0 +1,37 @@
+---
+title: Black Company names
+category: fiction
+description: "Places, factions, peoples, artifacts, creatures, and distinctive names from Glen Cook's Black Company world"
+---
+annals
+barrowland
+battle at charm
+black castle
+black company
+black hounds
+circle of eighteen
+comet
+croaker
+domination
+forsberg
+glittering stone
+great general
+hound
+howler
+lady
+limper
+longshadow
+plain of fear
+radisha
+rebellion
+shadowgate
+shadowlands
+shivetya
+silver spike
+soulcatcher
+taglios
+ten who were taken
+the taken
+tower at charm
+true names
+white rose

--- a/lists/fiction/bleach.yml
+++ b/lists/fiction/bleach.yml
@@ -1,0 +1,39 @@
+---
+title: Bleach world
+category: fiction
+description: "Soul Reapers, Hollows, realms, factions, powers, and named weapons from Bleach"
+---
+arrancar
+bankai
+central 46
+espada
+fullbringers
+garganta
+gotei 13
+hogyoku
+hollows
+hueco mundo
+ichigo kurosaki
+karakura town
+las noches
+menos grande
+quincy
+rukia kuchiki
+seireitei
+shikai
+shin'o academy
+shinigami
+soul king
+soul society
+squad zero
+the dangai
+the royal palace
+the wandenreich
+thousand-year blood war
+uryu ishida
+visored
+white
+yamamoto
+yhwach
+zangetsu
+zanpakuto

--- a/lists/fiction/bloodborne.yml
+++ b/lists/fiction/bloodborne.yml
@@ -1,0 +1,55 @@
+---
+title: Bloodborne names
+category: fiction
+description: "Districts, factions, hunters, great ones, creatures, and relics from Bloodborne's Yharnam"
+---
+amygdala
+arianna
+astral clocktower
+beasthood
+bergenwerth
+blood moon
+blood saints
+cainhurst castle
+celestial emissary
+choir
+church hunters
+ebrietas
+executioners
+fishing hamlet
+forbidden woods
+gehrman
+great ones
+healing church
+hunter of hunters
+hunter's dream
+hypogean gaol
+iosefka's clinic
+kos
+lady maria
+lecture building
+ludwig
+lumenflower gardens
+mensis cage
+mergo
+mergo's loft
+micolash
+moon presence
+nightmare frontier
+nightmare of mensis
+old blood
+old hunters
+old yharnam
+orphan of kos
+paleblood
+pthumerians
+school of mensis
+the doll
+the hunter
+the one reborn
+the workshop
+vicar amelia
+vilebloods
+yahar'gul
+yharnam
+yharnam stone

--- a/lists/fiction/borrowers.yml
+++ b/lists/fiction/borrowers.yml
@@ -1,0 +1,39 @@
+---
+title: The Borrowers world
+category: fiction
+description: "Borrower families, big people, homes, settlements, and borrowed objects from Mary Norton's Borrowers novels"
+---
+arrietty clock
+aunt sophy
+badger's sett
+big people
+borrower village
+borrowers
+clock family
+crampfurl
+dreadful spiller
+eggletina
+firbank hall
+fordham
+harpsichord family
+hendreary
+homily clock
+little fordham
+lupy
+mild eye
+miss menzies
+model village
+overmantel family
+peagreen overmantel
+pod clock
+rain-pipe family
+rookery
+spiller
+st. bute's
+the boy
+the cottage
+the dread rat-catcher
+the old rectory
+the platters
+tom goodenough
+uncle hendreary

--- a/lists/fiction/cardcaptor-sakura.yml
+++ b/lists/fiction/cardcaptor-sakura.yml
@@ -1,0 +1,83 @@
+---
+title: Cardcaptor Sakura world
+category: fiction
+description: "Cardcaptors, guardians, places, magical objects, and named Clow Cards from Cardcaptor Sakura"
+---
+cerberus
+clow book
+clow cards
+clow reed
+clow staff
+eriol hiiragizawa
+kaho mizuki
+kero-chan
+li clan
+li syaoran
+moon bell
+ruby moon
+sakura cards
+sakura kinomoto
+sakura star
+sealing wand
+spinel sun
+star key
+the arrow
+the big
+the bubbles
+the change
+the cloud
+the create
+the dark
+the dash
+the dream
+the earthy
+the erase
+the fight
+the firey
+the float
+the flower
+the fly
+the freeze
+the glow
+the illusion
+the jump
+the libra
+the light
+the little
+the lock
+the loop
+the maze
+the mirror
+the mist
+the move
+the nothing
+the power
+the rain
+the return
+the sand
+the shadow
+the shield
+the shot
+the silent
+the sleep
+the snow
+the song
+the storm
+the sweet
+the sword
+the through
+the thunder
+the time
+the twin
+the voice
+the watery
+the wave
+the windy
+the wood
+tomoeda
+tomoeda elementary school
+tomoyo daidouji
+touya kinomoto
+tsukimine shrine
+tsukishiro yukito
+yue

--- a/lists/fiction/castlevania.yml
+++ b/lists/fiction/castlevania.yml
@@ -1,0 +1,43 @@
+---
+title: Castlevania names
+category: fiction
+description: "Castles, clans, hunters, creatures, relics, and supernatural powers from the Castlevania game canon"
+---
+alucard
+balore
+belmont clan
+brauner
+brauner's castle
+castle dracula
+chaos
+clock tower
+crimson stone
+dark lord
+death
+devil forgemasters
+dracula
+ecclesia
+forbidden library
+hector
+infinite corridor
+isaac
+leon belmont
+mathias cronqvist
+morris clan
+olrox
+portrait castle
+richter belmont
+sacred whip
+simon belmont
+soma cruz
+succubus
+the castle keep
+the inverted castle
+trevor belmont
+vampire killer
+vampire sisters
+war of 1999
+warakiya
+whip of alchemy
+white dragon
+year 1999

--- a/lists/fiction/cosmere.yml
+++ b/lists/fiction/cosmere.yml
@@ -1,0 +1,69 @@
+---
+title: Cosmere names
+category: fiction
+description: "Worlds, Shards, peoples, organizations, Invested Arts, artifacts, and distinctive names from Brandon Sanderson's Cosmere"
+---
+adonalsium
+aluminum
+ambition
+anti-investiture
+autonomy
+braize
+breath
+canticle
+celestial shades
+cognitive realm
+cosmere
+cultivation
+dawnshards
+devotion
+dominion
+elantris
+endowment
+feruchemy
+fifth heightening
+fused
+ghostbloods
+great aethers
+hallandren
+heralds
+hoid
+honor
+honorspren
+investiture
+iriali
+kandra
+knights radiant
+komashi
+llumar
+merciful domi
+nalthis
+odium
+preservation
+roshar
+ruin
+scadrial
+sel
+seventeenth shard
+shades
+shadesmar
+shardblades
+shardplate
+shardpool
+shards of adonalsium
+silverlight
+skybreakers
+spren
+stormlight
+surgebinding
+tal'dain
+the beyond
+the dor
+the shattering
+threnody
+tones of roshar
+vessels
+virtue
+voidbringers
+worldhoppers
+yolen

--- a/lists/fiction/cuphead.yml
+++ b/lists/fiction/cuphead.yml
@@ -1,0 +1,45 @@
+---
+title: Cuphead names
+category: fiction
+description: "Isles, characters, bosses, creatures, charms, and relics from Cuphead's Inkwell Isles"
+---
+baroness von bon bon
+beppi the clown
+cagney carnation
+calamaria
+captain brineybeard
+chalice
+chef saltbaker
+converge
+crackshot
+cuphead
+devil's casino
+djimmi the great
+elder kettle
+esther winchester
+grim matchstick
+hilda berg
+inkwell hell
+inkwell isle one
+inkwell isle three
+inkwell isle two
+king dice
+king's leap
+mausoleum
+moonshine mob
+mortimer freeze
+ms chalice
+mugman
+porkrind's emporium
+ribby and croaks
+root pack
+rumor honeybottoms
+sally stageplay
+soul contracts
+the angel and demon
+the devil
+the divine relic
+the phantom express
+the queen
+werner werman
+whetstone

--- a/lists/fiction/daevabad.yml
+++ b/lists/fiction/daevabad.yml
@@ -1,0 +1,46 @@
+---
+title: Daevabad names
+category: fiction
+description: "Places, djinn tribes, creatures, factions, artifacts, and distinctive names from S. A. Chakraborty's Daevabad Trilogy"
+---
+afshin
+agni
+anol
+ashman
+daeva
+daevabad
+dev
+djinn
+djinnistan
+fire worshippers
+geziri
+ghoul
+ifrit
+istakhri
+kahina
+marid
+nahid
+nahid council
+nahid lake
+nahid seal
+nahida
+peris
+qahtani
+qahtani dynasty
+qandisha
+royal guard
+sahar
+shafit
+shafit quarter
+shedu
+suleiman's seal
+tanzeem
+the citadel
+the crocodile river
+the great temple
+the harem
+the lake
+the palace
+the steppe
+zariaspa
+zaydi

--- a/lists/fiction/dark-is-rising.yml
+++ b/lists/fiction/dark-is-rising.yml
@@ -1,0 +1,43 @@
+---
+title: The Dark Is Rising names
+category: fiction
+description: "Places, powers, factions, artifacts, and distinctive names from Susan Cooper's The Dark Is Rising sequence"
+---
+bird rock
+book of gramarye
+chiltern hills
+circle of signs
+dark rider
+dolydd
+doors
+greenwitch
+grey house
+grey king
+hawkin
+herne the hunter
+huntercombe
+huntercombe manor
+kemare head
+lady
+llanffyllin
+llyn mwyngil
+lost land
+mare
+merlion
+midsummer tree
+old ones
+oldway lane
+pendragon
+sign of bronze
+sign of fire
+sign of iron
+sign of stone
+sign of water
+sign of wood
+silver on the tree
+six signs
+sleepers
+the white horse
+trewissick
+tywyn
+welsh hills

--- a/lists/fiction/dark-souls.yml
+++ b/lists/fiction/dark-souls.yml
@@ -1,0 +1,62 @@
+---
+title: Dark Souls names
+category: fiction
+description: "Kingdoms, peoples, covenants, creatures, lords, and relics from the Dark Souls trilogy"
+---
+aldia's keep
+anor londo
+archdragon peak
+artorias the abysswalker
+ash lake
+astora
+bed of chaos
+bell keepers
+blades of the darkmoon
+blue sentinels
+catacombs of carthus
+chaos servants
+darkroot garden
+darkwraiths
+drangleic
+duke's archives
+earthen peak
+eleum loyce
+estus flask
+fire keepers
+firelink shrine
+forest hunters
+four kings
+giant's kinship
+gwyndolin
+heirs of the sun
+irithyll
+izalith
+kingseeker frampt
+knights of catarina
+londor
+lordran
+lordvessel
+lothric
+manus father of the abyss
+millwood knights
+nashandra
+nito
+oolacile
+painted world of ariamis
+path of the dragon
+ringed city
+royal rat authority
+scholars of the first sin
+seath the scaleless
+shulva
+the abyss
+the ashen one
+the chosen undead
+the dark soul
+the first flame
+the kiln
+the undead curse
+throne of want
+velka
+vendrick
+warriors of sunlight

--- a/lists/fiction/dark-sun.yml
+++ b/lists/fiction/dark-sun.yml
@@ -1,0 +1,48 @@
+---
+title: Dark Sun names
+category: fiction
+description: "City-states, peoples, factions, creatures, sorcerer-kings, and artifacts from the Dark Sun world of Athas"
+---
+agis of asticles
+athas
+avangion
+balic
+black
+cerulean storm
+crimson savanna
+dark lens
+defilers
+dragon of tyr
+draj
+elemental clerics
+forest ridge
+giustenal
+gulg
+halflings of the forest ridge
+ivory triangle
+jagged cliffs
+kreen empire
+last sea
+moon priests
+mul
+nibenay
+obsidian plains
+preservers
+pristine tower
+raam
+rajat
+ringing mountains
+sadira
+sea of silt
+shadow giants
+sorcerer-kings
+tablelands
+templars
+the order
+thri-kreen
+tyr
+tyrian gladiators
+ur draxa
+veiled alliance
+verdant belt
+windbreak mountains

--- a/lists/fiction/delicious-in-dungeon.yml
+++ b/lists/fiction/delicious-in-dungeon.yml
@@ -1,0 +1,42 @@
+---
+title: Delicious in Dungeon world
+category: fiction
+description: "Adventurers, peoples, monsters, places, dishes, magic, and artifacts from Delicious in Dungeon"
+---
+ancient dwarven kingdom
+chilchuck tims
+cockatrice
+corpse retrievers
+demons
+dragon ham
+dungeon cleaners
+dungeon ecosystem
+dungeon lord
+dungeon rabbits
+falin touden
+falin's chimera
+golden country
+griffin soup
+harpies
+kabru
+laios touden
+living armor
+marcille donato
+mimic
+monster cuisine
+namari
+nightmares
+orc settlement
+red dragon
+resurrection magic
+senshi
+shuro
+succubus
+the canaries
+the dungeon
+the dungeon rabbit stew
+the island
+the lunatic magician
+the winged lion
+thistle
+undine

--- a/lists/fiction/demon-slayer.yml
+++ b/lists/fiction/demon-slayer.yml
@@ -1,0 +1,45 @@
+---
+title: Demon Slayer world
+category: fiction
+description: "Demon Slayers, demons, locations, ranks, breathing styles, and blades from Demon Slayer"
+---
+akaza
+blue spider lily
+breathing styles
+butterfly mansion
+demon slayer corps
+demons
+entertainment district
+final selection
+flame breathing
+flower breathing
+genya shinazugawa
+gyokko
+hashira
+hinokami kagura
+infinity castle
+inosuke hashibira
+kagaya ubuyashiki
+kanao tsuyuri
+kokushibo
+kyojuro rengoku
+love breathing
+lower ranks
+mist breathing
+mount sagiri
+mugen train
+muzan kibutsuji
+nezuko kamado
+nichirin sword
+obanai iguro
+shinobu kocho
+sun breathing
+swordsmith village
+tanjiro kamado
+tengen uzui
+twelve kizuki
+upper ranks
+water breathing
+wind breathing
+yoriichi tsugikuni
+zenitsu agatsuma

--- a/lists/fiction/diablo.yml
+++ b/lists/fiction/diablo.yml
@@ -1,0 +1,48 @@
+---
+title: Diablo names
+category: fiction
+description: "Realms, peoples, factions, angels, demons, creatures, and relics from the Diablo world of Sanctuary"
+---
+angiris council
+arreat
+black soulstone
+burning hells
+caldeum
+cathedral of light
+crusaders of zakarum
+dark exiles
+diablo
+dreadlands
+duriel
+eternal conflict
+heavenly host
+hellforge
+horadrim
+imperius
+inarius
+khanduras
+kurast
+leah
+lilith
+lorath nahr
+lut gholein
+malthael
+mephisto
+mount arreat
+nephalem
+nightmare sigils
+pandemonium fortress
+prime evils
+sanctuary
+scosglen
+skovos isles
+soulstones
+the crystal arch
+the high heavens
+the worldstone
+tristram
+tyrael
+westmarch
+worldstone keep
+xiansai
+zakarum

--- a/lists/fiction/divinity-original-sin.yml
+++ b/lists/fiction/divinity-original-sin.yml
@@ -1,0 +1,49 @@
+---
+title: Divinity Original Sin names
+category: fiction
+description: "Places, peoples, factions, creatures, source powers, and relics from the Divinity Original Sin games"
+---
+alexandar
+amadia
+ancient empire
+arx
+black ring
+blackpits
+bloodmoon island
+braccus rex
+cyseal
+deathfog
+dragon knight
+driftwood
+eternal aetera
+eternals
+fort joy
+god king
+godwoken
+hall of echoes
+hunters edge
+lucian the divine
+magisters
+maxos
+nameless isle
+nemesis
+paladins
+phantom forest
+reaper's coast
+rivellon
+sacred stone
+seeker camp
+seekers
+seven gods
+source
+source hunters
+source king
+source masters
+star stone
+the academy
+the divine order
+the doctor
+the void
+the well of ascension
+void dragon
+voidwoken

--- a/lists/fiction/dragon-age.yml
+++ b/lists/fiction/dragon-age.yml
@@ -1,0 +1,51 @@
+---
+title: Dragon Age names
+category: fiction
+description: "Nations, cities, peoples, factions, creatures, deities, and relics from the Dragon Age world of Thedas"
+---
+adamant fortress
+antiva
+antivan crows
+arkanists
+avvar
+black city
+breach
+chantry
+circle of magi
+dalish
+darkspawn
+deep roads
+denerim
+dwarven carta
+eluvian
+emerald graves
+fade
+ferelden
+free marches
+friends of red jenny
+grey wardens
+halamshiral
+haven
+inquisition
+kirkwall
+lyrium
+minrathous
+montsimmard
+nevarra
+orlais
+ostagar
+par vollen
+red lyrium
+seekers of truth
+skyhold
+tevinter imperium
+the anchor
+the dread wolf
+the idol of red lyrium
+the qun
+the veil
+thedas
+titans
+val royeaux
+vigil's keep
+weisshaupt fortress

--- a/lists/fiction/dragon-prince.yml
+++ b/lists/fiction/dragon-prince.yml
@@ -1,0 +1,46 @@
+---
+title: The Dragon Prince world
+category: fiction
+description: "Kingdoms, peoples, primal magic, creatures, factions, and artifacts from The Dragon Prince"
+---
+aaravos
+archdragon
+avizandum
+banther lodge
+black sands
+callum
+celestial elves
+corvus
+dark magic
+del bar
+dragonguard
+earth arcanum
+earthblood elves
+ezran
+human kingdoms
+katolis
+key of aaravos
+king harrow
+lux aurea
+moon nexus
+moon opal
+moonshadow elves
+neolandia
+ocean arcanum
+primal stones
+rayla
+runaan
+silvergrove
+sky arcanum
+skywing elves
+sol regem
+star arcanum
+startouch elves
+storm spire
+sun arcanum
+sunfire elves
+the breach
+the midnight desert
+viren
+xadia
+zym

--- a/lists/fiction/earthsea.yml
+++ b/lists/fiction/earthsea.yml
@@ -1,0 +1,62 @@
+---
+title: Earthsea names
+category: fiction
+description: "Places, peoples, creatures, institutions, artifacts, and distinctive names from Ursula K. Le Guin's Earthsea"
+---
+archipelago
+astowell
+atnini
+atuan
+awabah
+awabath
+awad
+dragon's run
+dragons
+dry land
+east reach
+ebea
+enlad
+enlades
+erreth-akbe
+far sorr
+gebbeth
+ged
+gont
+great house of roke
+hardic peoples
+havnor
+hur-at-hur
+iffish
+inmost sea
+jaws of enlad
+karego-at
+kargad empire
+kargs
+labyrinth of atuan
+lookfar
+low wall
+master chanter
+master doorkeeper
+master hand
+master herbal
+master namer
+master patterner
+master summoner
+master windkey
+mountains of pain
+old powers of the earth
+old speech
+orm embar
+otaks
+pendor
+ring of erreth-akbe
+roke
+roke knoll
+segoy
+selidor
+shadow
+tehanu
+tenar
+the hands
+tombs of atuan
+west reach

--- a/lists/fiction/eberron.yml
+++ b/lists/fiction/eberron.yml
@@ -1,0 +1,50 @@
+---
+title: Eberron names
+category: fiction
+description: "Nations, cities, peoples, dragonmarked houses, factions, creatures, and relics from Eberron"
+---
+argonnnessen
+argonth
+aurum
+azer
+breland
+church of the silver flame
+daelkyr
+droaam
+dusk hag
+eberron
+eldeen reaches
+emerald claw
+flamekeep
+great crater
+house cannith
+house deneith
+house ghallanda
+house jorasco
+house kundarak
+house lyrandar
+house medani
+house orien
+house phiarlan
+house sivis
+house tharashk
+house thuranni
+house vadalis
+karrnath
+khorvaire
+khyber
+lightning rail
+lord of blades
+morgrave university
+mournland
+quori
+rakshasa rajahs
+sharn
+sovereign host
+the draconic prophecy
+the dreaming dark
+the twelve
+thrane
+undying court
+warforged
+xen'drik

--- a/lists/fiction/elden-ring.yml
+++ b/lists/fiction/elden-ring.yml
@@ -1,0 +1,57 @@
+---
+title: Elden Ring names
+category: fiction
+description: "Regions, peoples, orders, demigods, outer gods, creatures, and relics from Elden Ring"
+---
+academy of raya lucaria
+albinaurics
+altus plateau
+ancient dragons
+ansbach
+bayle the dread
+beastmen of farum azula
+black knives
+caelid
+carian royal family
+crucible knights
+elden beast
+elden ring
+erdtree
+farum azula
+finger maidens
+frenzied flame
+godfrey
+godwyn the golden
+golden order
+haligtree
+hornsent
+lands between
+leyndell
+limgrave
+liurnia
+malenia
+marika the eternal
+messmer the impaler
+miquella
+mohg
+moonlight altar
+mount gelmir
+mountaintops of the giants
+night of black knives
+nokron
+radagon
+radahn
+ranni
+realm of shadow
+roundtable hold
+rykard
+stormveil castle
+tarnished
+the fingers
+the greater will
+the scarlet rot
+the shattering
+the subterranean shunning-grounds
+three fingers
+two fingers
+volcano manor

--- a/lists/fiction/elric.yml
+++ b/lists/fiction/elric.yml
@@ -1,0 +1,43 @@
+---
+title: Elric's Young Kingdoms names
+category: fiction
+description: "Places, peoples, gods, creatures, factions, artifacts, and distinctive names from Michael Moorcock's Elric saga"
+---
+arig farez
+arioch
+chaos
+chaos engineers
+crimson gate
+cymoril
+dead gods' book
+dyvim tvar
+elemental lords
+elric of melnibone
+eternal champion
+imrryr
+island of purple towns
+law
+lords of chaos
+lords of law
+melnibone
+melniboneans
+mirror of memory
+moonbeam roads
+moonglum
+multiverse
+myshella
+nihrain
+pan tang
+quarzhasaat
+rackhir the red archer
+sadric
+sea kings
+silent citadel
+stormbringer
+the balance
+the dreaming city
+theleb k'aarna
+xiombarg
+young kingdoms
+yyrkoon
+zarozinia

--- a/lists/fiction/exandria.yml
+++ b/lists/fiction/exandria.yml
@@ -1,0 +1,53 @@
+---
+title: Exandria names
+category: fiction
+description: "Continents, cities, peoples, factions, deities, creatures, and relics from Critical Role's Exandria"
+---
+aeor
+ank'harel
+ashari
+betrayer gods
+cael morrow
+catha
+cerberus assembly
+chroma conclave
+claret orders
+cobalt soul
+cognouza
+dwendalian empire
+empyrean ward
+exandria
+feywild
+gloomed jungles
+greying wildlands
+issylra
+jrusar
+kraghammer
+kryn dynasty
+lucidian ocean
+marquet
+menagerie coast
+molaesmyr
+netherdeep
+othanzia
+pallid grove
+raishan
+republic of tal'dorei
+ruidus
+shattered teeth
+silken squall
+syngorn
+tal'dorei
+the calamity
+the divergence
+the luxon
+the matron of ravens
+the mighty nein
+the prime deities
+the whispered one
+vasselheim
+vestiges of divergence
+vox machina
+whitestone
+wildemount
+xhorhas

--- a/lists/fiction/fable-game.yml
+++ b/lists/fiction/fable-game.yml
@@ -1,0 +1,53 @@
+---
+title: Fable game names
+category: fiction
+description: "Regions, settlements, factions, creatures, heroes, and relics from the Fable games' Albion"
+---
+albion
+arena
+aurora
+balverines
+bandit coast
+bloodstone
+bower lake
+bowerstone
+brightwall
+castle fairfax
+crawler
+crucible
+darkwood
+demon doors
+driftwood
+echo mine
+fairfax gardens
+great spire
+heroes' guild
+hook coast
+knothole glade
+knothole island
+lady grey
+lucien fairfax
+mistpeak valley
+oakfield
+oakvale
+old kingdom
+old town
+reaver
+rookridge
+rose cottage
+sanctuary
+scythe
+silver keys
+snowspire
+temple of avo
+temple of shadows
+the archon
+the court
+the darkness
+the guild seal
+the spire
+the sword of aeons
+theresa
+westcliff
+witchwood
+wraithmarsh

--- a/lists/fiction/fablehaven.yml
+++ b/lists/fiction/fablehaven.yml
@@ -1,0 +1,43 @@
+---
+title: Fablehaven names
+category: fiction
+description: "Magical preserves, creatures, factions, institutions, artifacts, and distinctive names from Brandon Mull's Fablehaven world"
+---
+blackwell keep
+chocolate milk
+chronometer
+conference of the evening star
+cyclops
+dark unicorn
+demon prison
+dragon sanctuary
+dryads
+eternal source
+fablehaven
+fairy queen
+fairy realm
+fairy shrine
+forgotten chapel
+gorgrog
+grindstone
+inverted tower
+knights of the dawn
+lost mesa
+milk of fablehaven
+narcoblix
+oblivion
+oculus
+patton's journal
+revenant
+secret preserves
+shadow plague
+society of the evening star
+sphinx
+talismans
+the artifact keys
+the preserve
+the quiet box
+the singing sisters
+unicorn horn
+whisper hound
+zyzyx

--- a/lists/fiction/fairy-tail.yml
+++ b/lists/fiction/fairy-tail.yml
@@ -1,0 +1,44 @@
+---
+title: Fairy Tail world
+category: fiction
+description: "Guilds, mages, kingdoms, creatures, places, magic, and artifacts from Fairy Tail"
+---
+acnologia
+alvarez empire
+celestial spirit keys
+celestial spirits
+dragon lacrima
+dragon slayers
+earth land
+edolas
+etherious
+fairy glitter
+fairy law
+fairy sphere
+fairy tail guild
+fiore kingdom
+grand magic games
+grimoire heart
+happy
+heartfilia family
+lamia scale
+laxus dreyar
+lucy heartfilia
+mage guilds
+magic council
+magnolia town
+mavis vermillion
+mermaid heel
+natsu dragneel
+oración seis
+phantom lord
+raven tail
+sabertooth
+spriggan 12
+tartaros
+ten wizard saints
+the book of e.n.d
+the dragon king festival
+the eclipse gate
+tower of heaven
+zeref dragneel

--- a/lists/fiction/fire-emblem.yml
+++ b/lists/fiction/fire-emblem.yml
@@ -1,0 +1,53 @@
+---
+title: Fire Emblem names
+category: fiction
+description: "Continents, kingdoms, peoples, orders, dragons, and relics from multiple Fire Emblem worlds"
+---
+akaneia
+almyra
+altea
+askr
+begnion
+black eagles
+blue lions
+bragi's sword
+branded
+chalphy
+church of seiros
+crest of flames
+dawn brigade
+divine dragons
+durandal
+elibe
+embla
+falchion
+ferox
+fire emblem
+fodlan
+golden deer
+grail mercenaries
+grannvale
+hresvelg
+laguz
+lehran's medallion
+loptous
+lycia
+macedon
+mark of the exalt
+medeus the dark dragon
+mila's turnwheel
+nohr
+outrealm gate
+ragnell
+renais
+rigel
+sacred stones
+seiros
+shepherds
+tellius
+the black fang
+the four hounds
+the scouring
+thracia
+valentia
+ylisse

--- a/lists/fiction/first-law.yml
+++ b/lists/fiction/first-law.yml
@@ -1,0 +1,57 @@
+---
+title: First Law world names
+category: fiction
+description: "Places, peoples, factions, institutions, artifacts, and distinctive names from Joe Abercrombie's First Law world"
+---
+adua
+angland
+bayaz
+bethod
+black dow
+bloody-nine
+breakers
+canal
+carleon
+circle of the world
+closed council
+dagoska
+eaters
+euz
+far country
+first law
+first of the magi
+gurkhul
+gurkish empire
+high places
+house of the maker
+inquisition
+javre
+king's own
+kingsway
+magisterium
+makers
+midderland
+named men
+northern library
+northmen
+old empire
+open council
+order of magi
+ospria
+protectorate
+seed
+shanka
+starikland
+styria
+the burners
+the great change
+the great leveller
+the heroes
+the maker's sword
+the north
+the other side
+the union
+the university
+union army
+valbeck
+westport

--- a/lists/fiction/frieren.yml
+++ b/lists/fiction/frieren.yml
@@ -1,0 +1,44 @@
+---
+title: Frieren world
+category: fiction
+description: "Mages, demons, peoples, cities, dungeons, spells, and artifacts from Frieren: Beyond Journey's End"
+---
+amme
+arnsbacht
+aura the guillotine
+celestial capital
+continental magic association
+demons
+denken
+elf
+fern
+first-class mage exam
+flamme
+frieren
+graf granat's domain
+größer forest
+heaven
+heiter
+hero's party
+himmel
+kraft
+land
+mage association
+mana suppression
+method of killing demons
+northern plateau
+qual
+reelseiden
+serie
+seven sages of destruction
+solitär
+soul track
+stark
+stille
+the dungeon of the ruined king's tomb
+the goddess monument
+the hero's sword
+the northern lands
+ubel
+weise
+zoltraak

--- a/lists/fiction/fullmetal-alchemist.yml
+++ b/lists/fiction/fullmetal-alchemist.yml
@@ -1,0 +1,42 @@
+---
+title: Fullmetal Alchemist world
+category: fiction
+description: "Alchemy, nations, institutions, factions, homunculi, places, and artifacts from Fullmetal Alchemist"
+---
+alchemical circle
+alchemists
+alkahestry
+alphonse elric
+amestris
+central city
+central command
+chimera
+edward elric
+father
+flame alchemy
+fort briggs
+gluttony
+greed
+homunculi
+ishval
+ishvalan war of extermination
+king bradley
+liore
+lust
+may chang
+mustang unit
+philosopher's stone
+pride
+promised day
+resenbool
+roy mustang
+scar
+sloth
+state alchemist
+truth
+truth's gate
+van hohenheim
+winry rockbell
+wrath
+xerxes
+xing

--- a/lists/fiction/gentleman-bastard.yml
+++ b/lists/fiction/gentleman-bastard.yml
@@ -1,0 +1,52 @@
+---
+title: Gentleman Bastard world names
+category: fiction
+description: "Cities, peoples, factions, institutions, artifacts, and distinctive names from Scott Lynch's Gentleman Bastard sequence"
+---
+alcegrante
+amberglass
+bondsmagi
+camorr
+carteain
+catchfire bar
+deep roots
+elderglass
+elderglass towers
+five towers
+gentleman bastards
+glass roses
+god of thieves
+gray king
+handball
+house of perelandro
+iron sea
+jeremite islands
+karthain
+lashain
+leocanto
+magistrates
+meraggio's countinghouse
+midnighters
+ministry of necessity
+naja's barge
+nameless thirteenth
+perelandro
+poison orchid
+priory quarter
+requin
+right people
+salvara game
+seven marrows
+silk palace
+sinspire
+spider
+tal verrar
+the capa
+the revels
+the secret peace
+the yellowjackets
+therin people
+therin throne
+thorn of camorr
+vault of the shades
+vengeful dream

--- a/lists/fiction/god-of-war.yml
+++ b/lists/fiction/god-of-war.yml
@@ -1,0 +1,49 @@
+---
+title: God of War names
+category: fiction
+description: "Realms, peoples, gods, creatures, factions, and relics from the God of War games"
+---
+aesir
+alfheim
+asgard
+athena
+atreus
+baldur
+blades of chaos
+brok
+dark elves
+draupnir spear
+freya
+giants of jotunheim
+gjallarhorn
+greek pantheon
+helheim
+jormungandr
+jotunheim
+kratos
+lake of nine
+leviathan axe
+light elves
+midgard
+mimir
+mount olympus
+muspelheim
+niflheim
+odin
+pandora's box
+ragnarok
+realm between realms
+sindri
+sparta
+spartans
+surtr
+the fates
+the mask
+thor
+tyr
+valhalla
+valkyries
+vanaheim
+vanir
+yggdrasil
+zeus

--- a/lists/fiction/golden-sun.yml
+++ b/lists/fiction/golden-sun.yml
@@ -1,0 +1,45 @@
+---
+title: Golden Sun names
+category: fiction
+description: "Continents, settlements, clans, creatures, adepts, and relics from the Golden Sun world of Weyard"
+---
+alchemy forge
+alchemy well
+anemos
+angara
+apollo lens
+atlantica
+atteka
+belinsk
+colosso
+djinn
+eclipse tower
+gaia rock
+garoh
+gondowan
+hesperia
+imil
+indra
+izumo
+jupiter lighthouse
+kalay
+lemuria
+mars lighthouse
+mercury lighthouse
+mithril bag
+mogall forest
+osenia
+proxis
+psynergy
+sanctum
+shaman's rod
+sol sanctum
+taopo swamp
+teleport lapis
+tundaria
+tundaria tower
+vale
+venus lighthouse
+weyard
+wise one
+yampi desert

--- a/lists/fiction/gravity-falls.yml
+++ b/lists/fiction/gravity-falls.yml
@@ -1,0 +1,44 @@
+---
+title: Gravity Falls world
+category: fiction
+description: "People, creatures, places, societies, journals, and anomalies from Gravity Falls"
+---
+8½th president of the united states
+bill cipher
+blendin blandin
+bottomless pit
+dream demon
+gideon gleeful
+giffany
+gnomes
+gravity falls
+gravity falls forest
+greasy's diner
+hand witch
+journal 1
+journal 2
+journal 3
+lake gravity falls
+mabel pines
+manotaurs
+memory gun
+multibear
+mystery shack
+northwest manor
+pacifica northwest
+quantum destabilizer
+society of the blind eye
+stanford pines
+stanley pines
+summerween trickster
+the apocalypse bunker
+the bottomless pit
+the gobblewonker
+the shapeshifter
+time wish
+time-tape
+unicorn hair barrier
+weirdmageddon
+wendy corduroy
+widdle waddles
+zodiac

--- a/lists/fiction/green-bone-saga.yml
+++ b/lists/fiction/green-bone-saga.yml
@@ -1,0 +1,44 @@
+---
+title: Green Bone Saga names
+category: fiction
+description: "Places, clans, institutions, artifacts, cultural terms, and distinctive names from Fonda Lee's Green Bone Saga world"
+---
+abukei
+andjian
+barukan
+beru
+clean blade
+espania
+green bone warrior
+green bones
+greenest island
+isho
+jade
+jade discipline
+jade dogs
+jade hands
+jade mountain
+jade smugglers
+janloon
+kaul du-jen
+kaul family
+kekon
+kekon jade alliance
+kekonese
+koshin
+lantern men
+mount ain
+mount of a thousand
+mountain clan
+no peak clan
+oshki
+pillarman
+royal council
+shine
+stone-eyes
+the academy
+the twice lucky
+tiro
+weather man
+white rats
+yellow eel district

--- a/lists/fiction/greyhawk.yml
+++ b/lists/fiction/greyhawk.yml
@@ -1,0 +1,57 @@
+---
+title: Greyhawk names
+category: fiction
+description: "Realms, cities, factions, peoples, deities, creatures, and artifacts from the World of Greyhawk"
+---
+baklunish basin
+bandit kingdoms
+blackmoor
+bone march
+celene
+circle of eight
+dyvers
+ekbir
+flanaess
+free city of greyhawk
+furyondy
+geoff
+great kingdom
+greyhawk castle
+greyhawk ruins
+hardby
+horned society
+ice barbarians
+invoked devastation
+iuz
+keoland
+ket
+knights of holy shielding
+knights of the hart
+land of black ice
+lordship of the isles
+mage of the vale
+nyr dyv
+oerth
+old faith
+pact of greyhawk
+pale
+pomarj
+rain of colorless fire
+rel astra
+scarlet brotherhood
+shield lands
+silent ones
+snow barbarians
+st cuthbert
+temple of elemental evil
+tenser
+the wild coast
+turrosh mak
+uleks
+urnst
+valley of the mage
+verbobonc
+vesve forest
+wolf nomads
+yeomanry
+zagyg

--- a/lists/fiction/grishaverse.yml
+++ b/lists/fiction/grishaverse.yml
@@ -1,0 +1,43 @@
+---
+title: Grishaverse names
+category: fiction
+description: "Countries, peoples, creatures, factions, institutions, artifacts, and distinctive names from Leigh Bardugo's Grishaverse"
+---
+amplifiers
+corporalki
+druskelle
+etherealki
+ferolind
+fjerda
+grisha
+heartrenders
+ice court
+jurda
+jurda parem
+kaelish
+keramzin
+ketterdam
+kuwei's lab
+little palace
+materialki
+merzost
+morozova's amplifiers
+novyi zem
+os alta
+os kervo
+ravka
+royal palace
+second army
+shadow fold
+shu han
+skiff
+small science
+stadwatch
+the barrel
+the crow club
+the darkling
+the menagerie
+the wandering isle
+volcra
+western ravka
+zoya's garden

--- a/lists/fiction/guild-wars.yml
+++ b/lists/fiction/guild-wars.yml
@@ -1,0 +1,50 @@
+---
+title: Guild Wars names
+category: fiction
+description: "Continents, peoples, factions, gods, creatures, cities, and relics from the Guild Wars world of Tyria"
+---
+abaddon
+ascalon
+asura
+balthazar
+black citadel
+cantha
+charr
+crystal desert
+divinity's reach
+dragonsblood spear
+druids of maguuma
+durmand priory
+dwayna
+ebon vanguard
+elder dragons
+eye of the north
+far shiverpeaks
+flame legion
+glint
+great destroyer
+hoelbrak
+jade sea
+joko
+kormir
+kryta
+kurzicks
+lion's arch
+luxons
+maguuma jungle
+melandru
+mistlock observatory
+norn
+order of whispers
+orr
+pale tree
+primordus
+rite of the great dwarf
+six human gods
+soo-won
+sylvari
+the mists
+tyria
+vigil
+zaishen order
+zhaitan

--- a/lists/fiction/hades-game.yml
+++ b/lists/fiction/hades-game.yml
@@ -1,0 +1,55 @@
+---
+title: Hades game names
+category: fiction
+description: "Places, gods, shades, creatures, weapons, and artifacts from Supergiant Games' Hades underworld"
+---
+achilles
+adamant rail
+alecto
+aphrodite
+ares
+artemis
+aspect of arthur
+aspect of beowulf
+asphodel
+asterius
+athena
+bone hydra
+chaos
+charon
+codex of the underworld
+companions
+demeter
+dionysus
+dusa
+elysium
+eurydice
+fated list of minor prophecies
+furies
+hades
+heart-seeking bow
+hermes
+house of hades
+hypnos
+megaera
+mirror of night
+nyx
+olympus
+orpheus
+patroclus
+persephone
+poseidon
+satyr sack
+shield of chaos
+sisyphus
+skelly
+stygian blade
+styx
+tartarus
+thanatos
+theseus
+tisiphone
+twin fists of malphon
+varatha
+zagreus
+zeus

--- a/lists/fiction/he-man.yml
+++ b/lists/fiction/he-man.yml
@@ -1,0 +1,48 @@
+---
+title: Masters of the Universe world
+category: fiction
+description: "Heroes, villains, peoples, places, vehicles, and artifacts from Masters of the Universe"
+---
+adam of eternia
+battle cat
+castle grayskull
+clawful
+cringer
+dark hemisphere
+eternia
+evil-lyn
+faker
+fisto
+fright zone
+grayskull
+he-man
+hordak
+horde troopers
+king hiss
+king randor
+man-at-arms
+man-e-faces
+mer-man
+moss man
+orko
+panthor
+prince adam
+princess adora
+ram man
+rotar
+snake men
+snake mountain
+sorceress of castle grayskull
+stratos
+sword of power
+teela
+the evil horde
+the heroic warriors
+the royal palace
+the three towers
+trap jaw
+tri-klops
+trolla
+two bad
+wind raider
+zoar

--- a/lists/fiction/hellboy.yml
+++ b/lists/fiction/hellboy.yml
@@ -1,0 +1,43 @@
+---
+title: Hellboy names
+category: fiction
+description: "Places, peoples, occult organizations, creatures, witches, and relics from the Hellboy comics universe"
+---
+abe sapien
+agartha
+baba yaga
+black flame
+bureau for paranormal research and defense
+castle giurescu
+cavendish hall
+club zodiac
+conqueror worm
+dragon of revelation
+excalibur
+frog monsters
+grigori rasputin
+hecate
+hellboy
+hyperborea
+kate corrigan
+liz sherman
+lobster johnson
+nimung-gulla
+ogdru hem
+ogdru jahad
+osiris club
+pandemonium
+professor bruttenholm
+right hand of doom
+roger the homunculus
+sadu-hem
+secret chiefs
+the black goddess
+the foundry
+the iron maiden
+the queen of blood
+the seven gods of chaos
+the visitor
+torch of liberty
+vril
+witchfinder

--- a/lists/fiction/hollow-knight.yml
+++ b/lists/fiction/hollow-knight.yml
@@ -1,0 +1,51 @@
+---
+title: Hollow Knight names
+category: fiction
+description: "Regions, tribes, bugs, gods, creatures, and relics from Hollow Knight's Hallownest"
+---
+ancient basin
+beasts' den
+black egg temple
+city of tears
+colosseum of fools
+crystal peak
+deepnest
+dirtmouth
+dream nail
+dreamers
+fog canyon
+fungal wastes
+godhome
+grimm troupe
+hallownest
+howling cliffs
+hunter's journal
+infected crossroads
+isma's grove
+king's brand
+kingdom's edge
+mantis lords
+mantis tribe
+monomon the teacher
+nightmare heart
+pale king
+path of pain
+queen's gardens
+radiance
+resting grounds
+royal waterways
+soul sanctum
+the abyss
+the hive
+the hollow knight
+the infection
+the knight
+the last stag
+the snail shamans
+the vessels
+the white lady
+troupe master grimm
+unn
+void heart
+watcher's spire
+white palace

--- a/lists/fiction/how-to-train-your-dragon.yml
+++ b/lists/fiction/how-to-train-your-dragon.yml
@@ -1,0 +1,48 @@
+---
+title: How to Train Your Dragon world
+category: fiction
+description: "Vikings, dragons, tribes, islands, places, and artifacts from Cressida Cowell's How to Train Your Dragon novels"
+---
+americas
+barbarian tribes
+barbaric archipelago
+berk
+bog-burglars
+camicazi
+darkbreath
+death's head headland
+dragon furious
+dragon jewel
+dragon rebellion
+dragonese
+exterminator
+fishlegs
+hairy hooligans
+hiccup horrendous haddock iii
+horrorcow
+hysterics
+island of berk
+lava-lout
+meatheads
+monstrous nightmare
+norsemen
+outcasts
+red rage
+roman fort
+seadragonus giganticus maximus
+speedifist
+stormblade
+stormfly
+swordfight-at-sea
+terrible terrors
+the dragonmarker
+the lost throne
+the meathead library
+the slaves of the witch
+toothless
+ugly thugs
+venomous vorpent
+viking swimming pool
+volcano island
+wilderwest
+wrath-of-thor

--- a/lists/fiction/howls-moving-castle.yml
+++ b/lists/fiction/howls-moving-castle.yml
@@ -1,0 +1,46 @@
+---
+title: Howl's Moving Castle names
+category: fiction
+description: "Places, magical institutions, artifacts, creatures, and distinctive names from Diana Wynne Jones's Moving Castle books"
+---
+abdullah
+black-down
+calcifer
+castle door
+castle in the air
+cattack
+charmain's house
+fanny hatter
+farness valley
+flower shop
+flower-in-the-night
+great mansion
+hasruel
+high norland
+howl jenkins pendragon
+ingary
+kingsbury
+lettie hatter
+market chipping
+martha hatter
+megan parry
+michael fisher
+morgan pendragon
+norsebury
+peter
+pontalis
+portal door
+porthaven
+prince justin
+royal magician
+seven-league boots
+sophie hatter
+strangia
+upper folding
+vale end
+wales
+waste
+witch of the waste
+wizard jenkin
+wizard pendragon
+wizard suliman

--- a/lists/fiction/hunter-x-hunter.yml
+++ b/lists/fiction/hunter-x-hunter.yml
@@ -1,0 +1,41 @@
+---
+title: Hunter x Hunter world
+category: fiction
+description: "Hunters, nations, creatures, organizations, places, Nen systems, and artifacts from Hunter x Hunter"
+---
+black whale
+chimera ants
+dark continent
+gon freecss
+greed island
+heavens arena
+hunter association
+hunter exam
+hunters
+kakin empire
+killua zoldyck
+kurapika
+leorio paradinight
+meteor city
+nen
+nen beasts
+nen contracts
+nen users
+netero
+new continent
+ngl autonomous region
+phantom troupe
+succession contest
+the calamities
+the chimera ant queen
+the gatekeepers
+the hunter license
+the royal guards
+the zodiacs
+three great treasures
+trick tower
+whale island
+world tree
+yorknew city
+zoldyck estate
+zoldyck family

--- a/lists/fiction/inheritance-cycle.yml
+++ b/lists/fiction/inheritance-cycle.yml
@@ -1,0 +1,39 @@
+---
+title: Alagaësia names
+category: fiction
+description: "Places, peoples, creatures, factions, artifacts, and distinctive names from Christopher Paolini's Inheritance Cycle world of Alagaësia"
+---
+alagaesia
+alalea
+beor mountains
+brisingr
+carvahall
+cathedral of helgrind
+dauthdaert
+du vrangr gata
+du weldenvarden
+eldunari
+elves
+farthen dur
+galbatorix
+gray folk
+helgrind
+humans
+ilirea
+knurlan
+kull
+lethrblaka
+mount arngor
+palancar valley
+ra'zac
+riders
+surda
+the ancient language
+the broddring kingdom
+the forsworn
+tronjheim
+urgals
+uru'baen
+vardens
+werecats
+zar'roc

--- a/lists/fiction/inuyasha.yml
+++ b/lists/fiction/inuyasha.yml
@@ -1,0 +1,44 @@
+---
+title: Inuyasha world
+category: fiction
+description: "Demons, villages, factions, places, weapons, and artifacts from Inuyasha"
+---
+band of seven
+bone-eater's well
+byakuya
+demon slayers
+goshinboku
+hiraikotsu
+inuyasha
+jaken
+kaede
+kagome higurashi
+kanna
+kikyo
+kirara
+koga
+meido zangetsuha
+miroku
+mount hakurei
+naraku
+nekomata
+new moon
+rin
+sacred arrow
+sango
+sesshomaru
+shikon jewel
+shikon shards
+shippo
+shishinki
+shrine of the sacred jewel
+tenseiga
+tessaiga
+the feudal era
+the modern era
+the noh mask
+the panther demon tribe
+the wolf demon tribe
+tokijin
+totosai
+wind scar

--- a/lists/fiction/jujutsu-kaisen.yml
+++ b/lists/fiction/jujutsu-kaisen.yml
@@ -1,0 +1,40 @@
+---
+title: Jujutsu Kaisen world
+category: fiction
+description: "Sorcerers, curses, schools, clans, domains, techniques, and cursed objects from Jujutsu Kaisen"
+---
+black flash
+cursed corpses
+cursed energy
+cursed objects
+cursed spirits
+cursed techniques
+death painting wombs
+domain expansion
+finger bearer
+gojo clan
+hollow purple
+infinite void
+jujutsu headquarters
+kenjaku
+kyoto jujutsu high
+mahito
+malevolent shrine
+megumi fushiguro
+nobara kugisaki
+prison realm
+reverse cursed technique
+rika orimoto
+ryomen sukuna
+satoru gojo
+shibuya
+six eyes
+suguru geto
+ten shadows technique
+toge inumaki
+toji fushiguro
+tokyo jujutsu high
+veil
+yuji itadori
+yuta okkotsu
+zenin clan

--- a/lists/fiction/kiki-delivery-service.yml
+++ b/lists/fiction/kiki-delivery-service.yml
@@ -1,0 +1,33 @@
+---
+title: Kiki's Delivery Service world
+category: fiction
+description: "Witches, townspeople, places, shops, animals, and objects from Kiki's Delivery Service"
+---
+bakery attic
+broomstick
+clock tower
+delivery service
+forest cabin
+gütiokipänjä bakery
+jeff
+jiji
+kiki
+kiki's radio
+kiki's satchel
+kokiri
+koriko
+madame
+okino
+osono
+osono's bakery
+painted crow
+pie delivery
+propeller bicycle
+stuffed black cat
+tombo kopoli
+tombo's aviation club
+ursula
+witch training
+witch's broom
+witch's familiar
+zeppelin

--- a/lists/fiction/kingkiller-chronicle.yml
+++ b/lists/fiction/kingkiller-chronicle.yml
@@ -1,0 +1,49 @@
+---
+title: Kingkiller Chronicle names
+category: fiction
+description: "Places, peoples, creatures, factions, institutions, artifacts, and distinctive names from Patrick Rothfuss's Kingkiller Chronicle"
+---
+adem
+ademre
+alveron's court
+amyr
+arcanum
+ceald
+chandrian
+commonwealth
+eolian
+fae realm
+four corners of civilization
+great stone road
+haert
+imre
+iron law
+lakeless
+lanre
+loeclos box
+maer's court
+medica
+modeg
+moon
+myr tariniel
+namers
+old stone bridge
+severen
+severen-high
+severen-low
+shapers
+sithe
+skindancers
+stone doors
+tarbean
+temerant
+the archives
+the cthaeh
+the lackless door
+the lightning tree
+the rookery
+the underthing
+the university
+the waystone inn
+vintas
+waystones

--- a/lists/fiction/kings-quest.yml
+++ b/lists/fiction/kings-quest.yml
@@ -1,0 +1,43 @@
+---
+title: King's Quest names
+category: fiction
+description: "Kingdoms, peoples, creatures, villains, heroes, and magical objects from the King's Quest series"
+---
+agnes
+castle daventry
+cedric
+cloudland
+daventry
+death's realm
+etheria
+falderal
+genesta
+graham
+green isles
+hagatha
+isle of the crown
+isle of the sacred mountain
+isle of wonder
+kolyma
+land of the dead
+llewdor
+lolotte
+magic chest
+magic mirror
+magic shield
+malicia
+mannanan
+masked man
+mordack
+mountain of the winds
+old wood
+prince alexander
+princess cassima
+rosella
+serenia
+shadrack
+silver cloak
+the black cloak society
+the three treasures of daventry
+valanice
+vizier abdul alhazred

--- a/lists/fiction/kirby.yml
+++ b/lists/fiction/kirby.yml
@@ -1,0 +1,46 @@
+---
+title: Kirby names
+category: fiction
+description: "Planets, peoples, creatures, heroes, villains, and relics from the Kirby game universe"
+---
+ancient tower
+bandana waddle dee
+butter building
+castle dedede
+cloudy park
+dark matter
+dimension mirror
+dream fountain
+dream land
+dream rod
+dreamstalk
+floralia
+galacta knight
+halberd
+hypernova
+jambandra
+kirby
+lor starcutter
+magolor
+marx
+master crown
+maxim tomato
+meta knight
+mirror world
+new world
+nightmare
+nova
+planet popstar
+prism plains
+rainbow sword
+rick kine and coo
+robobot armor
+star allies sparkler
+star rod
+the ancients
+the arena
+the mage-sisters
+triple star
+waddle dee town
+warp star
+zero

--- a/lists/fiction/last-unicorn.yml
+++ b/lists/fiction/last-unicorn.yml
@@ -1,0 +1,26 @@
+---
+title: The Last Unicorn names
+category: fiction
+description: "Places, creatures, artifacts, institutions, and distinctive names from Peter S. Beagle's The Last Unicorn world"
+---
+amalthea
+butterfly
+captain cully
+castle haggard
+celaeno
+cully's men
+drinn
+hagsgate
+king haggard
+lady amalthea
+lir
+mabruk
+molly grue
+mommy fortuna's midnight carnival
+outlaws
+red bull
+ruhk
+schmendrick
+the clock
+the unicorns
+unicorn forest

--- a/lists/fiction/magicians.yml
+++ b/lists/fiction/magicians.yml
@@ -1,0 +1,40 @@
+---
+title: The Magicians names
+category: fiction
+description: "Places, magical institutions, creatures, artifacts, and distinctive names from Lev Grossman's Magicians world"
+---
+after island
+brakebills
+brakebills south
+chatwin children
+ember
+fillorian gods
+fillory
+flying forest
+free trader beowulf
+further country
+great clock
+hoberman's invisibility spell
+keepers of the neitherlands
+lorian
+martin chatwin
+masters of brakebills
+moonstone
+muntjac
+neitherlands
+old gods
+order of the library
+physical kids' cottage
+plover
+rabbits
+seven golden keys
+the beast
+the cozy horse
+the fountains
+the library
+the mosaic
+the unity key
+the wandering dune
+umber
+welters
+whitespire

--- a/lists/fiction/memory-sorrow-thorn.yml
+++ b/lists/fiction/memory-sorrow-thorn.yml
@@ -1,0 +1,50 @@
+---
+title: Osten Ard names
+category: fiction
+description: "Places, peoples, creatures, factions, artifacts, and distinctive names from Tad Williams's Memory, Sorrow, and Thorn world of Osten Ard"
+---
+asua
+binabik
+black rimmersmen
+bright-nail
+da'ai chikiza
+ernistors
+ernystir
+fisher king
+forest of aldheorte
+ghants
+green angel tower
+hernystir
+hernystiri
+inward sea
+jarnauga
+jiriki
+kingsguard
+league of the scroll
+memory
+nakkiga
+norns
+osten ard
+qantaqa
+qanuq
+rimmersgard
+rimmersmen
+sithi
+skodi
+sorrow
+stormspike
+the dragonbone chair
+the forge
+the garden
+the hayholt
+the red hand
+the stone of farewell
+the white arrow
+thrithings
+thrithings-men
+utuk'ku
+valada geloe
+warinsten
+white foxes
+white hand
+witchwood

--- a/lists/fiction/might-and-magic.yml
+++ b/lists/fiction/might-and-magic.yml
@@ -1,0 +1,43 @@
+---
+title: Might and Magic names
+category: fiction
+description: "Worlds, kingdoms, factions, peoples, creatures, and artifacts from the Might and Magic series"
+---
+academy
+ancients
+antagarich
+ashan
+castle ironfist
+celeste
+dragon gods
+dungeon
+enroth
+erathia
+forge
+fortress
+free haven
+great experiment
+heavenly forge
+inferno
+ironfist
+kreegan
+necropolis
+new sorpigal
+nighon
+paradise valley
+roland ironfist
+sandro
+shaera
+silverskull
+sword of frost
+sword of the gods
+tatalia
+temple of baa
+the elemental lords
+the hive
+the oracle
+the silence
+the web of worlds
+the world tree
+varn
+xeen

--- a/lists/fiction/miraculous-ladybug.yml
+++ b/lists/fiction/miraculous-ladybug.yml
@@ -1,0 +1,45 @@
+---
+title: Miraculous Ladybug world
+category: fiction
+description: "Miraculous holders, kwamis, places, factions, powers, and magical objects from Miraculous Ladybug"
+---
+adrien agreste
+akuma
+alya césaire
+amok
+bee miraculous
+black cat miraculous
+butterfly miraculous
+cat noir
+chloé bourgeois
+collège françoise dupont
+eagle miraculous
+felix fathom
+gabriel agreste
+guardian of the miraculous
+hawk moth
+ladybug
+ladybug miraculous
+lila rossi
+lucky charm
+marinette dupain-cheng
+master fu
+mayura
+miracle box
+miraculous holders
+miraculous ladybug
+nino lahiffe
+nooroo
+paris
+peacock miraculous
+plagg
+queen bee
+rena rouge
+rooster miraculous
+shadow moth
+snake miraculous
+tikki
+turtle miraculous
+unified miraculous
+wayzz
+yo-yo

--- a/lists/fiction/miss-peregrine.yml
+++ b/lists/fiction/miss-peregrine.yml
@@ -1,0 +1,43 @@
+---
+title: Miss Peregrine's Peculiar Children world
+category: fiction
+description: "Peculiars, ymbrynes, loops, creatures, places, and institutions from Miss Peregrine's Peculiar Children"
+---
+abaton
+abe portman
+addison mac henry
+alfred
+ambrosia
+bronwyn bruntley
+cairnholm
+caul
+claire densmore
+devil's acre
+emma bloom
+enoch o'connor
+fiona frauenfeld
+flaming man
+hollowgast
+horace somnusson
+hugh apiston
+jacob portman
+library of souls
+loop
+malthus
+map of days
+millard nullings
+miss avocet
+miss peregrine
+miss wren
+miss yew
+noor pradesh
+peculiar animals
+peculiar children
+peculiar home
+peculiar souls
+peculiardom
+samuel
+the council of ymbrynes
+the panloopticon
+wights
+ymbryne

--- a/lists/fiction/monkey-island.yml
+++ b/lists/fiction/monkey-island.yml
@@ -1,0 +1,44 @@
+---
+title: Monkey Island names
+category: fiction
+description: "Islands, pirates, crews, creatures, establishments, and artifacts from the Monkey Island series"
+---
+big whoop
+blood island
+booty island
+brimstone beach club
+cannibal village
+carla
+club 41
+cutthroat bill
+deep gut
+dinky island
+elaine marley
+fin island
+flotsam island
+giant monkey head
+grog
+guybrush threepwood
+herman toothrot
+hook island
+international house of mojo
+jambalaya island
+lechuck
+lechuck's fortress
+lucre island
+mad monkey
+meathook
+melee island
+mojo
+monkey island
+otis
+phantom beard
+plunder island
+scabb island
+skull island
+stan's previously owned vessels
+swordmaster
+the crossroads
+the voodoo lady
+three trials
+tiny lafeet

--- a/lists/fiction/moomin.yml
+++ b/lists/fiction/moomin.yml
@@ -1,0 +1,36 @@
+---
+title: Moominvalley names
+category: fiction
+description: "Places, peoples, creatures, institutions, artifacts, and distinctive names from Tove Jansson's Moomin world"
+---
+ancestor
+boat house
+cedric
+comet
+floating theatre
+groke
+hattifatteners
+hemulens
+island lighthouse
+king's ruby
+moominhouse
+moominmamma's handbag
+moomins
+moominvalley
+muskrat
+mymble
+sea orchestra
+snork maiden
+snorks
+snufkin's harmonica
+the cave
+the fairground
+the hobgoblin
+the invisible child
+the lighthouse
+the lonely mountains
+the observatory
+the river
+the valley
+toffle
+woodies

--- a/lists/fiction/naruto.yml
+++ b/lists/fiction/naruto.yml
@@ -1,0 +1,44 @@
+---
+title: Naruto world
+category: fiction
+description: "Shinobi, villages, clans, factions, beasts, techniques, and artifacts from Naruto"
+---
+akatsuki
+anbu
+byakugan
+chakra
+chunin exams
+five great shinobi countries
+five kage
+gaara
+hidden cloud village
+hidden leaf village
+hidden mist village
+hidden rain village
+hidden sand village
+hidden stone village
+hokage
+hyuga clan
+jinchuriki
+kakashi hatake
+kurama
+madara uchiha
+mangekyo sharingan
+naruto uzumaki
+ninja academy
+rasengan
+sakura haruno
+samurai
+sasuke uchiha
+seven ninja swordsmen
+sharingan
+shinobi alliance
+tailed beasts
+the five kage summit
+the sage of six paths
+the three sannin
+uchiha clan
+uzumaki clan
+valley of the end
+white fang
+wood release

--- a/lists/fiction/neverland.yml
+++ b/lists/fiction/neverland.yml
@@ -1,0 +1,27 @@
+---
+title: Neverland names
+category: fiction
+description: "Places, peoples, creatures, factions, artifacts, and distinctive names from J. M. Barrie's Peter Pan world"
+---
+black castle
+captain hook
+children's house
+darling nursery
+fairies
+hangman's tree
+jolly roger
+kidd's creek
+lost boys
+marooners' rock
+mermaids
+mermaids' lagoon
+never bird
+neverland
+pan's pipes
+peter pan
+pirates
+the little house
+ticking crocodile
+tiger lily
+tiger lily's tribe
+tinker bell

--- a/lists/fiction/nevermoor.yml
+++ b/lists/fiction/nevermoor.yml
@@ -1,0 +1,38 @@
+---
+title: Nevermoor names
+category: fiction
+description: "Places, creatures, institutions, factions, artifacts, and distinctive names from Jessica Townsend's Nevermoor series"
+---
+arcane arts
+courage square
+cursed children
+dearborn dragons
+elder ghosts
+free state
+gobleans
+gossamer line
+hotel deucalion
+jupiter north
+magnificat
+nevermoor
+nine
+nine crowns
+parliament square
+proudfoot house
+republic
+scholar mist
+smoking parlor
+squall
+stinkfin
+the bazaar of deceit
+the glorious garden
+the great evil
+the hallowmas ball
+the hunt of smoke and shadow
+the wunderground
+unit 919
+wunder
+wunderous arts
+wunderous society
+wundersmith
+wunimals

--- a/lists/fiction/ori.yml
+++ b/lists/fiction/ori.yml
@@ -1,0 +1,49 @@
+---
+title: Ori names
+category: fiction
+description: "Forests, regions, spirits, creatures, clans, and relics from the Ori games"
+---
+ancestral trees
+baur's reach
+black root burrows
+blind forest
+decay
+decaying woods
+forlorn ruins
+ginso tree
+gorlak ore
+gorlek
+gumo
+hollow grove
+horu fields
+inkwater marsh
+ku
+kwolok
+luma pools
+midnight burrows
+moki
+moon grotto
+mouldwood depths
+mount horu
+naru
+nibel
+niwen
+ori
+owl graveyard
+silent woods
+spirit arc
+spirit edge
+spirit flame
+spirit shards
+spirit tree
+spring glades
+sunstone
+swallow's nest
+the eyes of the forest
+the light of nibel
+the voice of the forest
+thorns of the old world
+water vein
+well of the spirit willow
+willow's end
+windswept wastes

--- a/lists/fiction/over-the-garden-wall.yml
+++ b/lists/fiction/over-the-garden-wall.yml
@@ -1,0 +1,38 @@
+---
+title: Over the Garden Wall world
+category: fiction
+description: "People, animals, places, creatures, and objects from the Unknown in Over the Garden Wall"
+---
+adelaide
+auntie whispers
+beatrice
+black turtles
+bluebird scissors
+cloud city
+dark lantern
+edelwood
+enoch
+fred the horse
+frog ferry
+greg
+jason funderburker
+jimmy brown
+lantern bearer
+lorna
+margueritte grey
+miss langtree
+old grist mill
+pottsfield
+quincy endicott
+sara
+schoolhouse
+the beast
+the highwayman
+the tavern
+the unknown
+the woodsman
+the woodsman's daughter
+the woodsman's lantern
+toy village
+wirt
+woodland school

--- a/lists/fiction/owl-house.yml
+++ b/lists/fiction/owl-house.yml
@@ -1,0 +1,43 @@
+---
+title: The Owl House world
+category: fiction
+description: "Witches, demons, covens, places, glyphs, and artifacts from The Owl House"
+---
+abomination coven
+amity blight
+bat queen
+belos
+boiling isles
+bonesborough
+collector
+construction coven
+coven brands
+covention
+eda clawthorne
+emperor's castle
+emperor's coven
+emperor's scouts
+glandus high
+glyph magic
+golden guard
+hexside school of magic and demonics
+hooty
+illusion coven
+kikimora
+king clawthorne
+light glyph
+lilith clawthorne
+luz noceda
+owlbert
+palismen
+plant coven
+raine whispers
+selkidomus
+the conformatorium
+the demon realm
+the owl house
+the titan
+the titan trapper island
+titan blood
+willow park
+witches wool

--- a/lists/fiction/oz.yml
+++ b/lists/fiction/oz.yml
@@ -1,0 +1,50 @@
+---
+title: Land of Oz names
+category: fiction
+description: "Places, peoples, creatures, factions, artifacts, and distinctive names from L. Frank Baum's Oz books"
+---
+arboz
+china country
+city of ev
+deadly desert
+emerald city
+ev
+fiddlestick forest
+flatheads
+flutterbudgets
+forest of burzee
+gillikin country
+glass city
+great outside world
+hammer-heads
+iland
+land of oz
+magic belt
+mangaboos
+merryland
+mo
+munchkin country
+nome kingdom
+nomes
+o-z-o-p-o-l-i-s
+ogaboo
+ozma's palace
+palace of the emerald city
+patchwork girl
+phunnyland
+quadlings
+quox
+royal palace of ev
+sawhorse
+silver shoes
+skeezers
+sky island
+tin woodman
+tottenhots
+truth pond
+utensia
+valley of voe
+wheelers
+winkie country
+yellow brick road
+yips

--- a/lists/fiction/pathfinder-golarion.yml
+++ b/lists/fiction/pathfinder-golarion.yml
@@ -1,0 +1,54 @@
+---
+title: Pathfinder Golarion names
+category: fiction
+description: "Nations, cities, peoples, organizations, deities, creatures, and artifacts from Pathfinder's Golarion setting"
+---
+abaddon
+absalom
+aldori swordlords
+andoran
+aspis consortium
+azlant
+belkzen
+brevoy
+chelaxian empire
+dagger of a thousand bites
+darklands
+dead vault
+diobel
+druma
+eagle knights
+eye of dread
+five kings mountains
+garund
+geb
+golarion
+gravelands
+hellknights
+inner sea
+irrisen
+isger
+katapesh
+kellids
+kortos
+lands of the linnorm kings
+lastwall
+mana wastes
+mendev
+mwangi expanse
+nidal
+numeria
+old cheliax
+pathfinder society
+razmiran
+river kingdoms
+runelords
+shackles
+starstone
+taldor
+tar-baphon
+thassilon
+the test of the starstone
+ustalav
+varisia
+worldwound

--- a/lists/fiction/percy-jackson.yml
+++ b/lists/fiction/percy-jackson.yml
@@ -1,0 +1,52 @@
+---
+title: Percy Jackson world
+category: fiction
+description: "Demigods, camps, deities, creatures, places, factions, and artifacts from the Percy Jackson novels"
+---
+annabeth chase
+argo ii
+artemis
+athena parthenos
+backbiter
+blackjack
+camp half-blood
+camp jupiter
+charon's ferry
+chiron
+clarisse la rue
+cyclopes
+daedalus's labyrinth
+festus
+grover underwood
+hazel levesque
+hephaestus cabin
+house of hades
+hunters of artemis
+imperial gold
+jason grace
+kampê
+leo valdez
+lotus hotel and casino
+medusa
+minotaur
+mist
+mount olympus
+nectar
+new rome
+nico di angelo
+oceanus
+oracle of delphi
+pegasi
+percy jackson
+piper mclean
+rachel elizabeth dare
+riptide
+sally jackson
+satyrs
+sea of monsters
+stygian iron
+tartarus
+thalia grace
+the seven
+tyson
+underworld

--- a/lists/fiction/pillars-of-eternity.yml
+++ b/lists/fiction/pillars-of-eternity.yml
@@ -1,0 +1,48 @@
+---
+title: Pillars of Eternity names
+category: fiction
+description: "Nations, peoples, factions, gods, creatures, and relics from the Pillars of Eternity world of Eora"
+---
+abydon
+aedyr empire
+animancy
+berath
+caed nua
+deadfire archipelago
+defiance bay
+durgan's battery
+dyrwood
+eir glanfath
+engwithans
+eora
+eothas
+galawain
+godhammer
+godlike
+hollowborn
+huana
+hylea
+leaden key
+magran
+magran's teeth
+neketaka
+ondra
+principi sen patrena
+rauatai
+republics of vailia
+rymrgand
+saint's war
+skaen
+the circle of archmagi
+the crucible knights
+the dozen
+the gods of eora
+the hand occult
+the pallid knight
+the watcher
+the wheel
+the white march
+vailian trading company
+wael
+woedica
+xaurips

--- a/lists/fiction/planescape.yml
+++ b/lists/fiction/planescape.yml
@@ -1,0 +1,55 @@
+---
+title: Planescape names
+category: fiction
+description: "Planes, gate-towns, factions, peoples, creatures, and artifacts from the Planescape multiverse"
+---
+abyss
+acheron
+arborea
+arcadia
+astral plane
+athar
+baator
+beastlands
+believers of the source
+bleak cabal
+bytopia
+carceri
+chaosmen
+concordant opposition
+curst
+darkwood
+doomguard
+elysium
+ethereal plane
+fated
+fraternity of order
+gate-towns
+gehenna
+great ring
+harmonium
+hopeless
+infinite staircase
+lady of pain
+mechanus
+mercykillers
+modrons
+mount celestia
+outlands
+pandemonium
+planes of chaos
+planes of conflict
+planes of law
+planes of power
+prison
+ring-givers
+sigil
+society of sensation
+spines of sigil
+the factions
+the great wheel
+the mazes
+the rilmani
+transcendent order
+union
+yggdrasil

--- a/lists/fiction/princess-bride.yml
+++ b/lists/fiction/princess-bride.yml
@@ -1,0 +1,37 @@
+---
+title: The Princess Bride names
+category: fiction
+description: "Places, factions, artifacts, creatures, and distinctive names from William Goldman's The Princess Bride world"
+---
+albino
+battle of guilder
+brute squad
+cliffs of insanity
+count rugen
+deadly nightshade
+despair
+dread pirate roberts
+fezzik
+fire swamp
+flame spurts
+florin
+florinese army
+guilder
+humperdinck's castle
+inigo montoya
+lightning sand
+machine
+miracle max
+pit of despair
+prince humperdinck
+princess buttercup
+revenge
+rodents of unusual size
+rugen's torture chamber
+shriek eels
+six-fingered sword
+thieves' forest
+three terrors
+true love
+westley
+zoo of death

--- a/lists/fiction/princess-mononoke.yml
+++ b/lists/fiction/princess-mononoke.yml
@@ -1,0 +1,34 @@
+---
+title: Princess Mononoke world
+category: fiction
+description: "Clans, gods, creatures, places, weapons, and distinctive names from Princess Mononoke"
+---
+akkoto
+animal gods
+ashitaka
+boar clan
+boar god
+corrupted god
+emishi
+emishi village
+gonza
+great forest
+iron town
+ironworks
+jigo
+kodama
+lady eboshi
+leper colony
+matchlock rifle
+moro
+moro's den
+night-walker
+san
+shishigami
+shōjō
+the emperor's hunters
+the great boar army
+the sacred forest pool
+wolf clan
+wolf god
+yakul

--- a/lists/fiction/prydain.yml
+++ b/lists/fiction/prydain.yml
@@ -1,0 +1,45 @@
+---
+title: Prydain names
+category: fiction
+description: "Places, peoples, creatures, factions, artifacts, and distinctive names from Lloyd Alexander's Chronicles of Prydain"
+---
+achren
+adaon
+annuvin
+aran
+arawn death-lord
+black cauldron
+caer cadarn
+caer dallben
+caer dathyl
+caer llygad
+cauldron-born
+dalben
+dallben's book
+doli
+don
+fair folk
+flewddur flam
+forest of idris
+gurgi
+gwystyl
+gwythaints
+hen wen
+isle of mona
+llanina
+llanwen
+llyan
+marshes of morva
+medwyn
+morda
+morva
+mount dragon
+prydain
+realm of the summer stars
+red fallows
+spiral castle
+sword dyrnwyn
+the companions
+the sons of don
+three witches of morva
+under kingdom

--- a/lists/fiction/ravenloft.yml
+++ b/lists/fiction/ravenloft.yml
@@ -1,0 +1,48 @@
+---
+title: Ravenloft names
+category: fiction
+description: "Domains, settlements, darklords, factions, creatures, and relics from the Domains of Dread"
+---
+amber temple
+azalin rex
+barovia
+borca
+castle ravenloft
+chakuna
+church of ezra
+cyre 1313
+dark powers
+darkon
+dementlieu
+domains of dread
+falkovnia
+fraternity of shadows
+har'akir
+hazlan
+house of lament
+invidia
+isle of ravens
+ivana boritsi
+kalakeri
+kargat
+kartakass
+lamordia
+lord soth
+markovia
+mists of ravenloft
+mordent
+mordentish
+nightmare lands
+nova vaasa
+prisoners of the mists
+richemulot
+sea of sorrows
+sithicus
+strahd von zarovich
+the carnival
+the core
+the vistani
+valachan
+van richten
+vlad drakov
+wereravens

--- a/lists/fiction/realm-of-the-elderlings.yml
+++ b/lists/fiction/realm-of-the-elderlings.yml
@@ -1,0 +1,48 @@
+---
+title: Realm of the Elderlings names
+category: fiction
+description: "Places, peoples, creatures, institutions, magics, and distinctive names from Robin Hobb's Realm of the Elderlings"
+---
+aslevjal
+bingtown
+buck duchy
+buckkeep
+catalyst
+chalced
+clerres
+coastal duchies
+dragon haven
+eda and el
+elderlings
+farrow
+farseer throne
+gallants
+jamailia
+kelsingra
+liveships
+mountain kingdom
+old blood
+others
+outislanders
+pirate isles
+rain wild river
+rain wild traders
+rain wilds
+red ship raiders
+rooster crown
+satrapy of jamailia
+sea serpents
+six duchies
+skill
+skill pillars
+the black man
+the fool
+the pale woman
+the skill road
+trade council
+traders
+verity's dragon
+white prophet
+whites
+wit-bond
+withywoods

--- a/lists/fiction/redwall.yml
+++ b/lists/fiction/redwall.yml
@@ -1,0 +1,52 @@
+---
+title: Redwall names
+category: fiction
+description: "Places, woodland peoples, creatures, factions, artifacts, and distinctive names from Brian Jacques's Redwall world"
+---
+abbey bell
+abbey pond
+badgers
+black gull
+blackstone
+bloodwrath
+brockhall
+castle floret
+corsairs
+deepcoiler
+dibbuns
+doomwyte
+eulalia
+ferrets
+foxes
+gawtrybe
+great hall
+green isle
+guosim
+hares
+holt lutra
+joseph bell
+kotir
+land of ice and snow
+long patrol
+marshank
+martin's sword
+mossflower country
+mount pitfall
+noonvale
+otters
+redwall abbey
+roaming warriors
+rosewood
+saint ninian's
+salamandastron
+sea rats
+shrews
+southsward
+sparra
+the badger lords
+the tapestry
+the wild south coast
+vermin
+wall race
+warriors of redwall
+western sea

--- a/lists/fiction/riftwar.yml
+++ b/lists/fiction/riftwar.yml
@@ -1,0 +1,43 @@
+---
+title: Riftwar Cycle names
+category: fiction
+description: "Worlds, places, peoples, creatures, factions, artifacts, and distinctive names from Raymond E. Feist's Riftwar Cycle"
+---
+academy of magic
+arutha
+brotherhood of the dark path
+castle crydee
+cho-ja
+conclave of shadows
+crydee
+dasati
+demon legion
+dread
+elvandar
+emerald queen
+empire of great kesh
+free cities of natal
+great ones
+hall of worlds
+ishap
+islands of sunset
+kelewan
+kesh
+kingdom of the isles
+krondor
+mad god
+midkemia
+moredhel
+nighthawks
+novindus
+pantathians
+pug
+rillanon
+stardock
+taredhel
+the nameless one
+the rift
+tomas
+tsurani
+valheru
+war of the five crowns

--- a/lists/fiction/roots-of-chaos.yml
+++ b/lists/fiction/roots-of-chaos.yml
@@ -1,0 +1,54 @@
+---
+title: Roots of Chaos names
+category: fiction
+description: "Realms, peoples, creatures, institutions, artifacts, and distinctive names from Samantha Shannon's Roots of Chaos world"
+---
+ascalun
+ashen sea
+carmentum
+carscaro
+celestial dragons
+clan kuposa
+clan of the dawn
+clan of the east
+clan of the west
+clans of seiiki
+draconic plague
+dreadmount
+edin
+empire of the twelve lakes
+feather island
+fleet of the tiger eye
+golden empress
+great sorrow
+grief of ages
+haithwood
+high sea guard
+hitanin
+house of berethnet
+house of lievelyn
+house of noziken
+hroth
+inys
+knights of the body
+knights of the mind
+kwiriki
+lady of the woods
+lasia
+mentendon
+mount ipyeda
+nameless one
+orange tree
+orisima
+priory of the orange tree
+red damsels
+seiiki
+sepul
+the abyss
+the ersyr
+the siden
+unceasing emperor
+virtudom
+western dragons
+wyrms
+yscalin

--- a/lists/fiction/runeterra.yml
+++ b/lists/fiction/runeterra.yml
@@ -1,0 +1,46 @@
+---
+title: Runeterra names
+category: fiction
+description: "Regions, peoples, factions, creatures, champions, and artifacts from the canonical Runeterra setting"
+---
+aatrox
+ahri
+ascended
+aurelion sol
+bandle city
+bard
+bilgewater
+black mist
+black rose
+brackern
+camavor
+celestials
+darkin
+demacia
+demacian steel
+freljord
+hexcore
+hextech
+iceborn
+immortal bastion
+ionia
+ixtal
+kindred
+kumungu
+mount targon
+nashramae
+noxus
+petricite
+piltover
+rahorak
+runeterra
+shadow isles
+shurima
+spirit realm
+sun disc
+the aspects
+the void
+trifarix
+vastaya
+world runes
+zaun

--- a/lists/fiction/sailor-moon.yml
+++ b/lists/fiction/sailor-moon.yml
@@ -1,0 +1,46 @@
+---
+title: Sailor Moon world
+category: fiction
+description: "Sailor Guardians, kingdoms, factions, places, powers, creatures, and artifacts from Sailor Moon"
+---
+black moon castle
+black moon clan
+black moon crystal
+crystal palace
+dark kingdom
+dead moon circus
+death busters
+deep aqua mirror
+dream mirror
+eternal sailor moon
+golden crystal
+guardian cosmos
+holy grail
+jadeite
+luna
+moon kingdom
+moon stick
+neo queen serenity
+nephrite
+pharaoh 90
+princess serenity
+sailor chibi moon
+sailor cosmos
+sailor guardians
+sailor jupiter
+sailor mars
+sailor mercury
+sailor moon
+sailor neptune
+sailor pluto
+sailor saturn
+sailor uranus
+sailor venus
+shadow galactica
+silver crystal
+silver millennium
+silver moon crystal
+space sword
+star seed
+the golden kingdom
+tuxedo mask

--- a/lists/fiction/sandman.yml
+++ b/lists/fiction/sandman.yml
@@ -1,0 +1,46 @@
+---
+title: The Sandman names
+category: fiction
+description: "Realms, beings, factions, dreams, nightmares, and artifacts from Neil Gaiman's Sandman comics"
+---
+azazel
+barbie's land
+basanos
+book of destiny
+corinthian
+death
+delirium
+desire
+despair
+destiny
+destruction
+dream
+dream's helm
+dreaming
+dreamstone
+endless
+fiddler's green
+gate of horn
+gate of ivory
+house of mystery
+house of secrets
+lucien
+lucifer morningstar
+lyta hall
+matthew the raven
+mervyn pumpkinhead
+nada
+nightmare realm
+orpheus
+remiel
+rose walker
+ruby of dream
+silver city
+the cereal convention
+the cuckoo
+the kindly ones
+the library of dreams
+the oldest game
+the threshold
+thessaly
+wandering star

--- a/lists/fiction/scholomance.yml
+++ b/lists/fiction/scholomance.yml
@@ -1,0 +1,43 @@
+---
+title: Scholomance names
+category: fiction
+description: "Places, magical communities, creatures, institutions, artifacts, and distinctive names from Naomi Novik's Scholomance trilogy"
+---
+alchemist enclave
+argonet
+artificers
+bangkok enclave
+beijing enclave
+corrupt malia
+crystal maw
+darkest sutras
+domina
+enclaves
+graduation hall
+induction
+induction point
+maleficaria
+maleficer
+malia
+mana
+mawmouth
+new york enclave
+orion lake
+paper spells
+power-sharer
+purifying sutras
+reclamation
+scholomance
+school shop
+senior hall
+shanghai enclave
+spell books
+the cleansing
+the gym
+the library
+the void
+the workshop
+thirteen enclaves
+toronto enclave
+warning bells
+world tree spell

--- a/lists/fiction/septimus-heap.yml
+++ b/lists/fiction/septimus-heap.yml
@@ -1,0 +1,39 @@
+---
+title: Septimus Heap names
+category: fiction
+description: "Places, magical peoples, creatures, institutions, artifacts, and distinctive names from Angie Sage's Septimus Heap world"
+---
+alfrun
+apprentice supper
+badlands
+castle alchemie
+castle walls
+chief hermetic scribe
+darke
+dragon boat
+foryx house
+great chamber of alchemie
+heaps
+ice tunnels
+jenna's crown
+magog
+manuscriptorium
+marram marshes
+marsh python
+message rat
+old way
+one hundred and five days
+pathfinder
+queen's room
+saffron pool
+scribes
+seal watchers
+seven sons
+snake slipway
+spit fyre
+the forest
+time glass
+time room
+trading post
+two-faced ring
+young army

--- a/lists/fiction/she-ra.yml
+++ b/lists/fiction/she-ra.yml
@@ -1,0 +1,55 @@
+---
+title: She-Ra and the Princesses of Power world
+category: fiction
+description: "Princesses, factions, peoples, places, technology, and artifacts from She-Ra and the Princesses of Power"
+---
+adora
+angella
+beast island
+bright moon
+catra
+crimson waste
+crypto castle
+crystal castle
+despondos
+double trouble
+dryl
+entrapta
+etheria
+etherian runestones
+first ones
+first ones tech
+fright zone
+frosta
+glimmer
+grayskull
+hordak
+horde clones
+horde prime
+kingdom of snows
+light hope
+lonnie
+madame razz
+mara
+melog
+mermista
+micah
+moonstone
+mystacor
+netossa
+perfuma
+plumeria
+princess alliance
+princess prom
+salineas
+scorpia
+sea gate
+shadow weaver
+she-ra
+spinnerella
+swift wind
+sword of protection
+the heart of etheria
+the horde
+the rebellion
+whispering woods

--- a/lists/fiction/shovel-knight.yml
+++ b/lists/fiction/shovel-knight.yml
@@ -1,0 +1,43 @@
+---
+title: Shovel Knight names
+category: fiction
+description: "Kingdoms, knights, orders, creatures, locations, and relics from the Shovel Knight saga"
+---
+armor outpost
+black knight
+burstmaster
+chester
+clockwork tower
+darkness
+explodatorium
+flare wand
+flying machine
+hall of champions
+king knight
+king knight's keep
+lich yard
+lost city
+mole knight
+mona
+order of no quarter
+phase locket
+plague knight
+pocket dungeon
+polar knight
+propeller dagger
+propeller knight
+reize
+relics
+shield knight
+shovel blade
+shovel knight
+specter knight
+stranded ship
+the enchantress
+the grand quadrangle
+the tower of fate
+the troupple king
+treasure knight
+troupple chalice
+village
+wandering travelers

--- a/lists/fiction/skulduggery-pleasant.yml
+++ b/lists/fiction/skulduggery-pleasant.yml
@@ -1,0 +1,44 @@
+---
+title: Skulduggery Pleasant world
+category: fiction
+description: "Sorcerers, sanctuaries, factions, creatures, places, and magical artifacts from Skulduggery Pleasant"
+---
+accelerator
+ancients
+black cleaver
+china sorrows
+cleavers
+crystal of the saints
+darquesse
+dead men
+death bringer
+dimensional shunter
+dusk
+echo-gordon
+elementals
+faceless ones
+finbar wrong
+fletcher renn
+god-killer sword
+grand mage
+grotesquery
+irish sanctuary
+leibniz universe
+lord vile
+mevolent
+necromancers
+nye
+remnants
+roarhaven
+sanctuary
+scythe
+sensitive
+serpine
+skulduggery pleasant
+springheeled jack
+tanith low
+teleporter
+the caves of the void
+the sceptre of the ancients
+valkyrie cain
+vampires

--- a/lists/fiction/spiderwick.yml
+++ b/lists/fiction/spiderwick.yml
@@ -1,0 +1,40 @@
+---
+title: The Spiderwick Chronicles world
+category: fiction
+description: "Faeries, creatures, people, places, and magical objects from The Spiderwick Chronicles"
+---
+arthur spiderwick
+boggart
+bridge troll
+brownie
+byron
+cockatrice
+dwarves
+faerie fruit
+field guide
+goblins
+griffin
+hobgoblin
+hogsqueal
+invisible world
+jared grace
+lucinda spiderwick
+mallory grace
+mulgarath
+nixie
+ogre
+phoenix
+protective circle
+quintus
+river troll
+simon grace
+sprite
+stray sod
+the grace children
+the seeing stone
+the spiderwick estate
+thimbletack
+tree folk
+trolls
+unicorn
+will o' the wisp

--- a/lists/fiction/spirited-away.yml
+++ b/lists/fiction/spirited-away.yml
@@ -1,0 +1,35 @@
+---
+title: Spirited Away world
+category: fiction
+description: "Spirits, workers, guests, places, foods, and magical objects from Spirited Away"
+---
+aburaya
+aogaeru
+boh
+chichiyaku
+chihiro ogino
+duck spirits
+haku
+herbal soak tokens
+kamaji
+kashira
+kasuga-sama
+kohaku river
+lin
+no-face
+ogino family
+oil spirit
+oshira-sama
+radish spirit
+red bean bun
+river spirit
+sea railway
+sen
+shikigami
+stink spirit
+susuwatari
+the sixth station
+the tunnel
+yubaba
+yubaba's bird
+zeniba

--- a/lists/fiction/super-mario.yml
+++ b/lists/fiction/super-mario.yml
@@ -1,0 +1,49 @@
+---
+title: Super Mario names
+category: fiction
+description: "Kingdoms, peoples, creatures, heroes, villains, and artifacts from the core Super Mario game world"
+---
+birdo
+boo
+bowser
+bowser jr
+bowser's kingdom
+bullet bill
+cap kingdom
+cappy
+chain chomp
+cloud kingdom
+daisy
+dark land
+dinosaur land
+donkey kong
+fire flower
+flower kingdom
+goomba
+isle delfino
+koopa troop
+luigi
+luncheon kingdom
+mario
+metro kingdom
+moon kingdom
+mushroom kingdom
+new donk city
+peach's castle
+power moon
+power star
+princess peach
+rosalina
+shy guy
+star road
+super star
+tanooki suit
+the koopalings
+toad
+toad brigade
+toadette
+waluigi
+wario
+warp pipe
+yoshi
+yoshi's island

--- a/lists/fiction/temeraire.yml
+++ b/lists/fiction/temeraire.yml
@@ -1,0 +1,57 @@
+---
+title: Temeraire names
+category: fiction
+description: "Dragon breeds, corps, places, institutions, artifacts, and distinctive names from Naomi Novik's Temeraire world"
+---
+anglewing
+bright copper
+british dragon corps
+celestial
+chanson-de-guerre
+chasseur vocifere
+chequered nettle
+chinese dragon corps
+defendeur-brave
+divine wind
+dragon transport
+dragonets
+emerald glass
+feral dragons
+flamme-de-gloire
+flecha-del-fuego
+fleur-de-nuit
+grand chevalier
+grey copper
+grey widowmaker
+greyling
+honneur-d'or
+imperial
+incan dragon empire
+jade dragon
+kazilik
+king's covert
+longwing
+malachite reaper
+napoleon's aerial corps
+old english black
+papillon noir
+parnassian
+pascal's blue
+pecheur-couronne
+pecheur-raye
+peking
+petit chevalier
+plein-vite
+poux-de-ciel
+prussian dragon corps
+regal copper
+roi-de-vitesse
+scarlet flower
+sharpspitter
+shen-lung
+siu riu
+spanish dragon corps
+temeraire
+winchester
+xenica
+yellow reaper

--- a/lists/fiction/thomas-covenant.yml
+++ b/lists/fiction/thomas-covenant.yml
@@ -1,0 +1,43 @@
+---
+title: The Land names
+category: fiction
+description: "Places, peoples, creatures, factions, artifacts, and distinctive names from Stephen R. Donaldson's Thomas Covenant chronicles"
+---
+andelaine
+anya
+banefire
+bloodguard
+caer-caveral
+cavewights
+claves
+colossus of the fall
+creator
+earthpower
+elenmesnedene
+forestals
+foul's creche
+giants
+gravellingas
+haruchai
+illearth stone
+insequent
+kevin's dirt
+krill
+landwaster
+lord foul
+lords
+one forest
+ranyhyn
+revelstone
+sandgorgons
+stone of the earth
+the land
+the lurker
+the one tree
+the seven wards
+the staff of law
+the white gold
+ur-viles
+viles
+waynhim
+woodhelven

--- a/lists/fiction/ultima.yml
+++ b/lists/fiction/ultima.yml
@@ -1,0 +1,54 @@
+---
+title: Ultima names
+category: fiction
+description: "Continents, cities, peoples, virtues, creatures, factions, and artifacts from the Ultima world of Britannia"
+---
+ambrosia
+ankh of spirituality
+avatar
+black gate
+blackthorn
+britannia
+buccaneer's den
+castle britannia
+codex of ultimate wisdom
+compassion
+cove
+deceit
+destard
+empath abbey
+exodus
+fellowship
+honesty
+honor
+humility
+hythloth
+isle of the avatar
+jhelom
+justice
+lord british
+magincia
+minoc
+moongates
+new magincia
+ophidian
+order of the serpent
+pagan
+principles of truth love and courage
+sacrifice
+serpent isle
+shame
+skara brae
+skull of mondain
+sosaria
+spirituality
+stonegate
+the abyss
+the guardian
+the shrine of spirituality
+trinsic
+valor
+vesper
+virtues
+wrong
+yew

--- a/lists/fiction/undertale.yml
+++ b/lists/fiction/undertale.yml
@@ -1,0 +1,41 @@
+---
+title: Undertale names
+category: fiction
+description: "Regions, monsters, factions, creatures, souls, and artifacts from Undertale's Underground"
+---
+alphys
+asgore dreemurr
+asriel dreemurr
+barrier
+chara
+core
+determination
+dog shrine
+echo flower
+fallen humans
+flowey
+frisk
+gaster
+gerson
+glamburger
+hotland
+judgment hall
+mettaton
+monster kid
+muffet
+napstablook
+new home
+papyrus
+royal guard
+ruins
+sans
+snowdin
+soul traits
+temmie village
+the anomaly
+the artifact
+the underground
+toriel
+true laboratory
+undyne
+waterfall

--- a/lists/fiction/unfortunate-events.yml
+++ b/lists/fiction/unfortunate-events.yml
@@ -1,0 +1,49 @@
+---
+title: A Series of Unfortunate Events world
+category: fiction
+description: "People, places, organizations, disguises, coded objects, and institutions from A Series of Unfortunate Events"
+---
+anxious clown
+baudelaire mansion
+briny beach
+caligari carnival
+captain sham
+count olaf
+daily punctilio
+denouement brothers
+dr. medicalschool
+ersatz elevator
+eye insignia
+fire-fighting side
+fire-starting side
+georgina orwell
+gregor anwhistle
+heimlich hospital
+henchperson of indeterminate gender
+hotel denouement
+incredibly deadly viper
+isadora quagmire
+island
+justice strauss
+klaus baudelaire
+lachrymose leeches
+lemony snicket
+lucky smells lumbermill
+madame lulu
+medusoid mycelium
+montgomery montgomery
+mortmain mountains
+mulctuary money management
+prufrock preparatory school
+quagmire triplets
+schism
+snicket file
+sunny baudelaire
+the great unknown
+the inquisitive
+the last safe place
+the world is quiet here
+verbal fridge dialogue
+violet baudelaire
+volunteer feline detectives
+volunteer fire department

--- a/lists/fiction/winx-club.yml
+++ b/lists/fiction/winx-club.yml
@@ -1,0 +1,45 @@
+---
+title: Winx Club world
+category: fiction
+description: "Fairies, witches, schools, realms, factions, creatures, and magical objects from Winx Club"
+---
+alfea
+ancestral witches
+andros
+avalon
+bloom
+cloud tower
+codex
+darkar
+domino
+dragon flame
+enchantix
+fairy animals
+flora
+harmonic nebula
+infinite ocean
+ixia
+legendarium
+linphea
+lockette
+magix
+musa
+mythix
+omega dimension
+pixies
+red fountain
+relix
+roxy
+selkies
+solaria
+specialists
+stella
+tecna
+the great dragon
+the trix
+tir nan og
+valtor
+winx
+wizards of the black circle
+world of dreams
+zenith

--- a/lists/fiction/wonderland.yml
+++ b/lists/fiction/wonderland.yml
@@ -1,0 +1,42 @@
+---
+title: Wonderland names
+category: fiction
+description: "Places, creatures, courts, artifacts, and distinctive names from Lewis Carroll's Alice books"
+---
+bandersnatch
+borogoves
+bread-and-butterfly
+caucus race
+cheshire cat
+chessboard country
+croquet ground
+dodo
+dormouse
+duchess's house
+gryphon
+hearts court
+jabberwock
+jubjub bird
+king of hearts
+knave of hearts
+looking-glass house
+mad tea party
+march hare
+mock turtle
+mome raths
+mushroom
+queen of hearts
+rabbit hole
+red king
+red queen
+slithy toves
+the pool of tears
+the railway
+the tulgey wood
+tweedledum and tweedledee
+walrus and carpenter
+white king
+white knight
+white queen
+white rabbit
+wonderland


### PR DESCRIPTION
## Why this change is needed

The fiction catalogue is weighted towards science fiction, which limits variety when composing prompts for fantasy, animation, games, comics and childrens stories. This expansion adds broad, source-backed vocabulary from 105 different fictional worlds.

## What changed

- Added 35 literary and childrens fantasy lists.
- Added 35 games, tabletop and comics lists.
- Added 35 animation, anime and contemporary fantasy lists.
- Added 4,336 canonical prompt terms across places, peoples, creatures, factions, institutions, artifacts, powers and defining names.
- Kept generated indexes out of the commit, as required by AGENTS.md and the repository contribution workflow.

## Why this approach

Exhaustive is scoped to durable, prompt-distinctive world vocabulary. Large or ongoing franchises can contain thousands of minor NPCs, attacks and equipment items; including all of them would add noise and become stale. Each list instead covers the canonical setting anchors that distinguish that world. Bounded films and novels are enumerated at their natural size rather than padded with generic nouns.

Three disjoint research lanes recorded sources and continuity choices for every world. Each researcher then audited a different lane. That second pass removed aliases, misspellings, unsupported terms, adaptation leaks and production titles, and filled substantive omissions. The research record is archived at https://github.com/fofr-foffee/research-requests/tree/main/reports/2026-07-22-fiction-world-prompt-lists.

## Verification

- npm run lint
- npm run sanitise and npm run build completed locally; the expected generated-index diff was inspected, then restored per AGENTS.md.
- Corpus validator: 105 files, 4,336 terms, valid frontmatter, lowercase, sorted and deduplicated.
- 158 unique provenance URLs checked; stale references were replaced where alternatives existed.
- Cross-lane factual audit completed for all 105 lists.

Generated indexes are rebuilt after merge by the main-branch Build list artifacts workflow. A source-only contributor branch therefore produces an expected index diff if npm test runs its build pre-step; previous content PRs follow the same source-only pattern.