### PR TITLE
Expand object categories with 12,373 sourced items

### DIFF
--- a/lists/architecture/building-materials.yml
+++ b/lists/architecture/building-materials.yml
@@ -1,0 +1,76 @@
+---
+title: Building materials
+category: architecture
+description: "Masonry units, structural stock, and construction materials"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+adobe brick
+ashlar
+batten
+breeze block
+building block
+calcium-silicate brick
+capstone
+cinder block
+cleat
+clinker
+clinker block
+clinker brick
+cobble
+cobblestone
+coign
+coigne
+cope
+copestone
+coping
+coping stone
+cornerstone
+curbstone
+fingerboard
+firebrick
+flagstone
+flintlime brick
+foundation stone
+furring
+furring strip
+garboard
+garboard plank
+garboard strake
+gun rest
+gunnel
+gunwale
+hearthstone
+hone
+impost
+jackstraw
+kerbstone
+lag
+lath
+louver
+louvre
+matchboard
+millstone
+monolith
+oilstone
+pale
+paving stone
+picket
+sand-lime brick
+sett
+slat
+spillikin
+splat
+spline
+springer
+stela
+stele
+strake
+stretcher
+toothpick
+wale
+whetstone

--- a/lists/architecture/facilities-and-installations.yml
+++ b/lists/architecture/facilities-and-installations.yml
@@ -1,0 +1,211 @@
+---
+title: Facilities and installations
+category: architecture
+description: "Purpose-built sites, stations, terminals, and installations"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+aerodrome
+aid station
+air base
+air station
+air terminal
+air transportation system
+airdrome
+airfield
+airport
+airport terminal
+airstrip
+archive
+army base
+athenaeum
+atheneum
+athletic facility
+auxiliary airfield
+bank building
+base of operations
+broadcast station
+broadcasting station
+bus depot
+bus station
+bus terminal
+cafeteria facility
+central heating
+chancery
+cinder track
+circulating library
+coach station
+command post
+communication equipment
+communication system
+course
+deposit
+depositary
+depository
+depository library
+depot
+dirt track
+dressing station
+drive-in
+driving range
+drome
+drop
+dump
+electrical plant
+emplacement
+entrepot
+facility
+fiber-optic transmission system
+fibre-optic transmission system
+field
+field house
+filling station
+firebase
+firehouse
+firing range
+first-aid station
+flag stop
+flare path
+flight strip
+flying field
+forum
+fots
+garner
+garrison
+gas heat
+gas system
+gasoline station
+general headquarters
+ghq
+godown
+golconda
+golf course
+golf links
+golf range
+granary
+gun emplacement
+gymnasium
+headquarters
+heat
+heating
+heating plant
+heating system
+heliport
+highway system
+hq
+hub-and-spoke
+hub-and-spoke system
+installation
+landing field
+landing strip
+lending library
+lido
+links
+links course
+lost-and-found
+maildrop
+mass rapid transit
+meeting place
+menagerie
+military headquarters
+military installation
+military post
+natatorium
+naval installation
+navy base
+nest
+observation station
+outpost
+panel heating
+petrol station
+pillar box
+pillbox
+plumbing
+plumbing system
+police headquarters
+post
+postbox
+powder magazine
+powder store
+power grid
+power plant
+power station
+power system
+powerhouse
+practice range
+public transit
+racecourse
+racetrack
+raceway
+racing circuit
+radio beacon
+radio station
+railhead
+railroad station
+railroad terminal
+range
+rapid transit
+recreation facility
+recreational facility
+repertory
+repository
+rifle range
+rocket base
+rocket range
+sampling station
+science museum
+service station
+sewage system
+sewage works
+sewer system
+shooting gallery
+shooting range
+shore station
+short line
+source
+speedway
+sperm bank
+station
+station house
+steam heat
+steam heating
+storage warehouse
+storehouse
+strip
+substation
+subway station
+swimming bath
+target range
+television channel
+television station
+telferage
+telpherage
+terminal
+terminus
+test range
+track
+train depot
+train station
+transportation
+transportation system
+treasure house
+treasury
+truck stop
+tv channel
+tv station
+utility
+velodrome
+water
+water supply
+water system
+way station
+weapons emplacement
+whistle stop
+wind energy facility
+wind farm
+wind park
+zoological garden

--- a/lists/architecture/furnishings.yml
+++ b/lists/architecture/furnishings.yml
@@ -1,0 +1,249 @@
+---
+title: Furnishings
+category: architecture
+description: "Furniture, carpets, curtains, bedding, and room furnishings"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+appointment
+article of furniture
+baby bed
+baby's bed
+banquette
+barber chair
+bassinet
+bath chair
+bedframe
+bedroom furniture
+bedstead
+berth
+bishop's throne
+boston rocker
+box seat
+breakfast table
+broadloom
+brussels carpet
+built in bed
+bunk
+cafe curtain
+camp bed
+camp chair
+campstool
+captain's chair
+card catalog
+card catalogue
+card index
+card table
+carpeting
+carrycot
+cash bar
+cathedra
+cellaret
+chair of state
+checkout
+checkout counter
+chesterfield
+chiffonier
+china closet
+choir stall
+church bench
+clothes closet
+clothespress
+coat closet
+cocktail table
+commode
+communion table
+conference table
+corner cabinet
+cot
+council board
+council table
+counter
+cradle
+credence
+crib
+curtain
+cutty stool
+davenport
+deathbed
+deck chair
+dental chair
+dining-room furniture
+dining-room table
+dinner table
+divan
+divan bed
+double bed
+drafting table
+drape
+drapery
+drawing table
+drop curtain
+drop-leaf table
+drugget
+easy chair
+entertainment center
+escritoire
+etagere
+fauteuil
+feeding chair
+fighting chair
+filing cabinet
+fitment
+fitting
+flat bench
+floor lamp
+flying carpet
+folding chair
+footrest
+footstool
+four-poster
+furnishing
+furniture
+gaming table
+garden chair
+gateleg table
+gueridon
+hallstand
+hearthrug
+high table
+highboy
+highchair
+hospital bed
+kitchen table
+kurdistan
+lab bench
+laboratory bench
+lace curtain
+ladder-back chair
+lawn furniture
+lectern
+lord's table
+lounge chair
+lounger
+lowboy
+lower
+lower berth
+mantle
+marriage bed
+meat counter
+medicine cabinet
+medicine chest
+milk bar
+milking stool
+minibar
+morris chair
+motorized wheelchair
+murphy bed
+music stool
+musnud
+nammad
+net curtain
+notions counter
+numdah
+numdah rug
+office furniture
+operating table
+overstuffed chair
+oyster bar
+pall
+parsons table
+peacock-throne
+pedestal table
+penalty box
+piano stool
+piece of furniture
+pier table
+ping-pong table
+plank-bed
+platform bed
+platform rocker
+portiere
+pouf
+prayer mat
+prayer rug
+prie-dieu
+puff
+reading desk
+reading lamp
+reception desk
+reclining chair
+red carpet
+refectory table
+rolodex
+rya
+rya rug
+sack
+safety curtain
+salad bar
+scatter rug
+secretaire
+secretary
+sectional
+settee
+settle
+shag rug
+sheraton
+shoofly
+shower curtain
+sickbed
+side chair
+single bed
+sleeper
+sleigh bed
+snack bar
+snack counter
+sofa bed
+squab
+stair-carpet
+step stool
+straight chair
+student lamp
+studio couch
+sushi bar
+table lamp
+table-tennis table
+tablet-armed chair
+taboret
+tabouret
+tallboy
+tea table
+tete-a-tete
+theater curtain
+theatre curtain
+throne
+throw rug
+tilt-top table
+tip table
+tip-top table
+toilet table
+trestle table
+triclinium
+truckle
+truckle bed
+trundle bed
+tuffet
+twin bed
+upper
+upper berth
+vertical file
+vis-a-vis
+voyeuse
+wall unit
+wash-hand stand
+water bed
+wet bar
+wheelchair
+wilton
+wilton carpet
+window seat
+wing chair
+woodworking bench
+worktable
+writing desk
+writing table
+yacht chair

--- a/lists/architecture/openings.yml
+++ b/lists/architecture/openings.yml
@@ -1,0 +1,92 @@
+---
+title: Openings
+category: architecture
+description: "Hatches, apertures, windows, slots, necklines, and other constructed openings"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+air hole
+air horn
+aperture
+armhole
+blowhole
+breech
+bunghole
+buttonhole
+car window
+coin slot
+crack
+crew neck
+crew neckline
+decolletage
+ear hole
+embouchure
+embrasure
+eyehole
+fenestella
+finger hole
+fly
+fly front
+gap
+gun muzzle
+gunpoint
+hawse
+hawsehole
+hawsepipe
+hole
+inlet
+intake
+interstice
+judas
+keyhole
+keyhole neck
+keyhole neckline
+lacuna
+loophole
+lubber's hole
+lunette
+mail slot
+manhole
+mortice
+mortise
+mouth
+mouth hole
+mouthpiece
+nail hole
+neck
+neck opening
+neckline
+nozzle
+pass-through
+peephole
+perforation
+pinhole
+pinprick
+plughole
+porthole
+posthole
+puncture
+quarterlight
+rear of barrel
+rear of tube
+rear window
+showerhead
+siamese
+siamese connection
+slit
+slot
+smoke hole
+sound hole
+spark gap
+spout
+spyhole
+thumbhole
+ticket window
+v neck
+vent
+venthole
+wicket

--- a/lists/architecture/structures.yml
+++ b/lists/architecture/structures.yml
@@ -1,0 +1,1751 @@
+---
+title: Architecture
+category: architecture
+description: "Buildings, structural elements, shelters, and constructed spaces"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abatis
+abattis
+abattoir
+abbey
+abode
+abutment
+abutment arch
+academy
+accommodation
+accordion door
+acropolis
+adjoining room
+adobe house
+agora
+air-raid shelter
+airdock
+airframe
+airing cupboard
+airlock
+alcazar
+alehouse
+altar
+altarpiece
+amen corner
+anechoic chamber
+antechamber
+anteroom
+apadana
+apartment
+apartment building
+apartment house
+apiary
+apothecary's shop
+apse
+apsis
+arbor
+arbour
+arc-boutant
+architecture
+area
+arena theater
+armory
+armoury
+army hut
+art school
+artist's loft
+assembly hall
+assembly plant
+athanor
+attic
+auberge
+auditorium
+auto factory
+automat
+automobile factory
+automobile trunk
+aviary
+baby-walker
+baby's room
+back porch
+back room
+backpacking tent
+backstop
+baggage claim
+bagnio
+bailey
+bailey bridge
+bakehouse
+bakeshop
+ballpark
+ballroom
+balusters
+banister
+bannister
+barbacan
+barbershop
+barbette
+barbette carriage
+barbican
+barnyard
+barrack
+barrelhouse
+barricade
+barrier
+barroom
+bascule
+basement
+basin plug
+basket-handle arch
+bastille
+bastion fort
+bateau bridge
+bath plug
+bathing machine
+bathroom
+batter's box
+batwing
+bawdyhouse
+bay
+bazaar
+bazar
+beach house
+beacon
+beacon light
+beauty parlor
+beauty parlour
+beauty salon
+beauty shop
+bed and breakfast
+bedchamber
+bedlam
+bedroom
+bedsit
+bedsitter
+bedsitting room
+bee house
+beer garden
+beer hall
+bell arch
+bell foundry
+bell gable
+bell tent
+bell tower
+bell-type annealing furnace
+bell-type furnace
+belvedere
+bema
+bethel
+betting shop
+bi-fold door
+big top
+bilge well
+bill
+billet
+billiard hall
+billiard parlor
+billiard parlour
+billiard room
+billiard saloon
+bird sanctuary
+birdcage
+bistro
+bivouac
+blast furnace
+blockade
+blockage
+boarding
+boarding house
+boardroom
+boards
+bodega
+body
+bodywork
+bomb shelter
+bombproof
+booby hatch
+bookshop
+bookstall
+boot camp
+booth
+borstal
+boss
+bottle cork
+bottling plant
+boudoir
+boutique
+bow window
+bower
+box office
+brake cylinder
+branch
+brasserie
+brattice
+breakfast area
+breakfast nook
+breakwater
+breastwork
+breech closer
+breechblock
+brewpub
+brickkiln
+brickwork
+bridge
+brig
+brim
+broken arch
+broom closet
+brownstone
+bubble chamber
+buck
+bucket shop
+building complex
+building supply house
+building supply store
+bulkhead
+bullpen
+bullring
+bulwark
+bung
+bunker
+buntline coil
+burial chamber
+burial mound
+burial vault
+burn center
+business establishment
+business office
+bustle
+butcher shop
+butchery
+buttery
+buttressing
+byre
+cabana
+cabaret
+cabin class
+cache
+cafeteria
+caff
+caisson
+calk
+calkin
+call box
+call center
+call centre
+camber arch
+camera obscura
+camp
+campanile
+cannery
+cantilever bridge
+cantonment
+canvas tent
+capitol
+car door
+car factory
+caravan inn
+caravansary
+cardcastle
+cardhouse
+cardroom
+cargo area
+cargo deck
+cargo door
+cargo hatch
+cargo hold
+carport
+carrel
+carrell
+carriage house
+casement
+casement window
+casern
+casing
+casino
+casino-hotel
+catchment
+cathouse
+cattle grid
+cattle guard
+cattle pen
+cavity resonator
+cavity wall
+cellar
+cellarage
+cellblock
+cenotaph
+center
+central office
+centre
+chain store
+chainlink fence
+chamber
+chancel
+chancellery
+chandlery
+chantry
+chapterhouse
+charcuterie
+charnel
+charnel house
+charterhouse
+chase
+chassis
+checkroom
+chemical plant
+chemist's
+chemist's shop
+cheval-de-frise
+chevaux-de-frise
+chicane
+chicken coop
+chicken run
+chicken yard
+child's room
+chimney breast
+chimney corner
+choir
+choir loft
+chokey
+choky
+chophouse
+church
+church building
+church tower
+cinema
+cinerarium
+circus
+circus tent
+city university
+classroom
+clean room
+cleaners
+clearstory
+cliff dwelling
+climbing frame
+clinic
+clink
+clip joint
+cloakroom
+clog
+cloister
+closet
+closure
+clotheshorse
+clothing store
+cloud chamber
+clubhouse
+clubroom
+coach house
+coal house
+coaming
+coatroom
+cockloft
+cockpit
+cocktail lounge
+coffee bar
+coffee stall
+coffeehouse
+cofferdam
+cog
+coil
+cold-water flat
+collapsible shelter
+college
+columbarium
+command module
+commissary
+common room
+community center
+compartment
+complex
+compound
+computer store
+concert hall
+condo
+condominium
+confectionary
+confectionery
+conference center
+conference house
+conference room
+confessional
+connecting room
+conservatoire
+construction
+consulate
+contravallation
+control center
+control room
+control tower
+convent
+conventicle
+cookfire
+cookhouse
+coop
+corbel arch
+corbie gable
+corner
+corral
+correctional institution
+cottage tent
+cotton mill
+couchette
+council chamber
+countinghouse
+country house
+country store
+court
+courtroom
+covered bridge
+covered stadium
+cow pen
+cowbarn
+cowcatcher
+cowhouse
+cowshed
+crash barrier
+crazy house
+creche
+creep
+cremation chamber
+crematory
+crenelation
+crenellation
+cromlech
+crucible furnace
+cubby
+cubbyhole
+cubicle
+cuckoo's nest
+cuddy
+cupboard
+customhouse
+customshouse
+cutting room
+cybercafe
+cyclone cellar
+cyclopean masonry
+dacha
+dam
+dance hall
+dance palace
+darkroom
+day care center
+day nursery
+day school
+dead room
+dead-air space
+deanery
+death house
+death row
+deathtrap
+deck-house
+deckle
+defence
+defense
+defensive structure
+defilade
+deli
+delicatessen
+demi-bastion
+den
+departure lounge
+detached house
+detention camp
+detention cell
+detention centre
+detention home
+detention house
+detox
+diggings
+digs
+dike
+diminished arch
+diner
+dinette
+dining area
+dining room
+dining-hall
+dinner theater
+dinner theatre
+diplomatic building
+disco
+discotheque
+discount house
+discount store
+discounter
+dispensary
+display window
+disposal plant
+distillery
+dive
+diwan
+dock
+dockage
+docking facility
+dog pound
+dolmen
+domed stadium
+domicile
+domiciliation
+donjon
+doorcase
+doorframe
+dorm
+dorm room
+dormer window
+dormitory
+dormitory room
+dosshouse
+double door
+double glazing
+double-hung window
+drainplug
+drawing room
+dress shop
+dressing room
+drinking fountain
+drip
+drip mold
+drip mould
+dripstone
+drive-thru
+drop arch
+drugstore
+dry cleaners
+dry dock
+dry kiln
+dry masonry
+dry-stone wall
+dugout
+duomo
+duplex apartment
+duplex house
+durbar
+dwelling
+dwelling house
+earplug
+earth-closet
+earthwork
+eatery
+eating house
+eating place
+echo chamber
+economy class
+edifice
+efficiency apartment
+electric furnace
+electric-arc furnace
+elevator car
+embankment
+embroidery frame
+embroidery hoop
+emergency room
+emporium
+empty tomb
+encampment
+enclosure
+encumbrance
+engine room
+engineering
+entrance hall
+entrenchment
+entresol
+er
+erection
+escarp
+escarpment
+espalier
+espresso shop
+establishment
+estaminet
+exhibition area
+exhibition hall
+eyeshade
+fallout shelter
+false bottom
+family circle
+family room
+fan vaulting
+fanlight
+fantail
+farm building
+farmyard
+farthingale
+fastness
+fat farm
+feedlot
+fencing
+field hospital
+field hut
+field tent
+fieldwork
+fife rail
+fipple
+fire door
+fire tower
+firebox
+fireplace
+fireroom
+fireside
+firetrap
+firewall
+firing chamber
+first balcony
+first class
+first floor
+fix-it shop
+fixer-upper
+flange
+flashboard
+flashboarding
+flat
+flat arch
+flatlet
+fleabag
+fleapit
+floating bridge
+floating dock
+floating dry dock
+flophouse
+florist shop
+flower store
+fluke
+fly tent
+flyover
+fo'c'sle
+fold
+folding door
+food market
+food shop
+football stadium
+footbridge
+footstall
+forecastle
+forecourt
+forge
+fortification
+foundation
+foundling hospital
+foundry
+four-centered arch
+fowl run
+foxhole
+fraise
+frame
+framework
+framing
+frat house
+fraternity house
+free house
+french door
+french window
+friary
+friction prop
+friction yielding prop
+front porch
+front room
+full bastion
+fundament
+funeral chapel
+funeral church
+funeral home
+funeral parlor
+funeral parlour
+funeral-residence
+funk hole
+funny farm
+funny house
+furket
+furnace
+furnace room
+fuselage
+gable end
+gable wall
+galley
+gambling casino
+gambling den
+gambling hell
+gambling house
+game room
+gaming house
+gangboard
+gangplank
+gantry
+gaol
+garage
+garret
+gas furnace
+gas oven
+gasket coil
+gate
+gatehouse
+gauntry
+general store
+gildhall
+ginmill
+glass furnace
+glasshouse
+glebe house
+glory hole
+glove compartment
+goalmouth
+gondola
+gothic arch
+government building
+government office
+grape arbor
+grape arbour
+grate
+grave mound
+gravestone
+graving dock
+greasy spoon
+great hall
+green market
+greengrocery
+greenroom
+grill
+grille
+grillroom
+grillwork
+grocery
+groin
+ground floor
+ground level
+groundwork
+groyne
+guardrail
+guardroom
+guesthouse
+guestroom
+guide
+guildhall
+gulag
+gun carriage
+gun chamber
+gun enclosure
+gun room
+gun turret
+haberdashery
+haberdashery store
+habitation
+half-bastion
+half-dugout
+half-moon bastion
+hall
+hall of fame
+hall of residence
+handbarrow
+handrail
+hank
+harbor
+harbour
+hardware store
+hareem
+harem
+hash house
+hat shop
+hatch
+hatchback
+hatchback door
+haven
+hayloft
+haymow
+hayrack
+hayrig
+hazard
+head gate
+head shop
+headstone
+health club
+health facility
+health spa
+healthcare facility
+hedge
+hedgerow
+helix
+hen yard
+hencoop
+henhouse
+hideaway
+high altar
+hill
+hinderance
+hindrance
+hippodrome
+hitch
+hoarding
+hogan
+hold
+holding cell
+holding paddock
+holding pen
+holding yard
+hole plug
+home base
+home office
+home room
+home theater
+home theatre
+homestead
+honky-tonk
+hoodmold
+hoodmould
+hoosegow
+hoosgow
+hornwork
+horse barn
+horseshoe arch
+hospice
+hospital room
+hospital ward
+hostel
+hostelry
+hot spot
+hotel room
+hotel-casino
+hothouse
+house of cards
+house of correction
+house of detention
+house of god
+house of ill repute
+house of prayer
+house of worship
+hovel
+hull
+hunting lodge
+hurdle
+hut
+hutch
+hutment
+hydraulic brake cylinder
+hyperbaric chamber
+hypermarket
+ice
+ice hockey rink
+ice rink
+icehouse
+iglu
+imaret
+impediment
+incinerator
+incumbrance
+indian lodge
+indoor garden
+industrial plant
+inglenook
+inn
+insane asylum
+institution
+interference
+interior door
+internment camp
+intrenchment
+iron foundry
+ironmonger
+ironmonger's shop
+jail
+jail cell
+jailhouse
+jakes
+jet bridge
+jetty
+jobcentre
+john
+jook
+jook house
+jook joint
+joss house
+juke
+juke house
+juke joint
+jungle gym
+junk shop
+jury box
+keel arch
+keep
+khan
+kiln
+kiosk
+kirk
+kitchen
+kitchenette
+knob
+knobble
+kraal
+kremlin
+laager
+labor camp
+labour camp
+lady chapel
+lager
+lake dwelling
+lamasery
+laminar flow clean room
+lamination
+lancet arch
+lancet window
+land office
+landing
+landing place
+larder
+latticework
+lav
+layby
+lazar house
+lazaret
+lazarette
+lazaretto
+lean-to tent
+lecture room
+left-luggage office
+levee
+lever tumbler
+lichgate
+life office
+lift bridge
+liftgate
+limb
+limekiln
+line of defence
+line of defense
+little theater
+little theatre
+livery stable
+living accommodations
+living quarters
+living room
+loan office
+lobe
+lock chamber
+lock-gate
+locker
+locker room
+lockup
+lodge
+lodging
+lodging house
+lodgings
+loft
+log cabin
+loge
+loo
+lookout
+lookout station
+loony bin
+lounge
+louvered window
+lug
+luggage compartment
+lumber room
+lumbermill
+lunchroom
+lyceum
+lychgate
+madhouse
+main office
+maisonette
+maisonnette
+mall
+manor
+manor hall
+manse
+mansion house
+mantelet
+mantlet
+manufactory
+manufactured home
+manufacturing plant
+maquiladora
+marina
+market
+market square
+marketplace
+mart
+martello tower
+masjid
+masonry
+master bedroom
+master cylinder
+maternity hospital
+maternity ward
+matting
+mcmansion
+meat house
+meat market
+meat safe
+mechanical yielding prop
+medical building
+meetinghouse
+megalith
+megalithic structure
+memorial
+memorial tablet
+menhir
+mens store
+mental home
+mental hospital
+mental institution
+mercantile establishment
+mess
+mess hall
+messuage
+metalworks
+mezzanine floor
+microbrewery
+mihrab
+military hospital
+military quarters
+mill
+milldam
+millinery
+ministry
+minster
+mint
+mobile canteen
+mobile home
+mole
+mooring mast
+mooring tower
+moorish arch
+morgue
+morning room
+mortuary
+motel
+motel room
+motor hotel
+motor inn
+motor lodge
+mound
+mountain tent
+mounting
+movable barrier
+movie house
+movie theatre
+mow
+mudguard
+mudhif
+muffle
+mukataa
+multiplex
+munition
+music hall
+music school
+musjid
+musket rest
+nacelle
+narthex
+national monument
+nave
+newsroom
+nick
+nightspot
+nissen hut
+nogging
+nook
+novelty shop
+nunnery
+nursery
+nursing home
+nut house
+oasis
+oast
+oast house
+observation dome
+observation tower
+obstacle
+obstructer
+obstruction
+obstructor
+occlusion
+oeil de boeuf
+off-licence
+office block
+office building
+officer's mess
+offset
+ogee arch
+oil burner
+oil furnace
+oil refinery
+open fireplace
+open-air market
+open-air marketplace
+open-hearth furnace
+opera
+opera house
+operating room
+operating theater
+operating theatre
+or
+oracle
+orchestra pit
+organ loft
+oriel
+orphanage
+orphans' asylum
+oubliette
+outbuilding
+outfitter
+outhouse
+outlet
+outwork
+overcrossing
+overhang
+oxbow
+oxbridge
+oxeye
+pack tent
+package store
+packing plant
+packinghouse
+pad
+paddock
+paling
+palisade
+pannier
+panopticon
+pantheon
+pantry
+paper mill
+parlor
+parlour
+parsonage
+particle detector
+partition
+party wall
+parvis
+passe-partout
+patisserie
+pave
+pawnbroker's shop
+peak
+peanut gallery
+pelmet
+penal colony
+penal facility
+penal institution
+penitentiary
+perfumery
+peristyle
+pesthouse
+pet shop
+petroleum refinery
+pharos
+phrontistery
+picket fence
+picture gallery
+picture palace
+picture window
+pied-a-terre
+pier arch
+pigeon loft
+pigpen
+pigsty
+pile dwelling
+pilot
+pilothouse
+pin tumbler
+pinfold
+pinhead
+piston chamber
+pit
+pithouse
+pitprop
+pivoting window
+pizza parlor
+pizza shop
+pizzeria
+place of business
+place of worship
+plant
+plaque
+playpen
+playroom
+plenum
+plinth
+plug button
+pneumatic caisson
+pointed arch
+pokey
+poky
+polling booth
+pontoon bridge
+poolroom
+poorhouse
+pop tent
+pop-up
+porch
+portal tomb
+post and lintel
+post exchange
+postern
+posthouse
+pot furnace
+pothouse
+pound
+pow camp
+power pylon
+praetorium
+prefab
+presbytery
+presence chamber
+presidio
+press box
+press gallery
+pressure cabin
+pretorium
+priory
+prison camp
+prison cell
+prison farm
+prison house
+prisoner of war camp
+privet hedge
+privy
+projection
+prompt box
+prompter's box
+prong
+proscenium
+proscenium arch
+proscenium wall
+protective embankment
+psychiatric hospital
+public house
+public square
+public works
+pull-in
+pull-off
+pull-up
+pump house
+pump room
+pump well
+pumping station
+pup tent
+purdah
+px
+pylon
+pyramidal tent
+quad
+quadrangle
+quartering
+quarters
+quartz battery
+quartz mill
+rabbit hutch
+radiator grille
+radio chassis
+raft foundation
+rail fence
+railing
+railroad bed
+railroad flat
+rampant arch
+rampart
+ranch house
+rathole
+rathskeller
+reading room
+rec room
+reception room
+recess
+recovery room
+recreation room
+rectory
+recycling plant
+redbrick university
+redoubt
+refectory
+refinery
+reform school
+reformatory
+refuge
+refugee camp
+religious residence
+remise
+repair shed
+repair shop
+reredos
+research center
+research facility
+residence
+residence hall
+resistance furnace
+resonating chamber
+resort hotel
+rest area
+rest home
+rest house
+rest stop
+retail store
+retaining wall
+retreat
+retrenchment
+rettery
+reverberatory furnace
+revolving door
+ribbing
+ribbon development
+rink
+ritz
+roadbed
+roadblock
+roadhouse
+rodeo
+rolling mill
+roman arch
+roman basilica
+roman building
+rood screen
+room
+roomette
+rooming house
+rooms
+rope bridge
+rotisserie
+round arch
+round top
+row house
+rowlock arch
+ruin
+rumpus room
+sacristy
+safe house
+safehold
+safety rail
+saleroom
+sales booth
+sales outlet
+salesroom
+salon
+saloon
+saltbox
+saltworks
+sanatarium
+sanctuary
+sand trap
+sandwich board
+sanitarium
+sash window
+sawbuck
+sawdust saloon
+sawmill
+scarp
+scheme arch
+school system
+schoolhouse
+schoolroom
+scoinson arch
+sconcheon arch
+scoreboard
+screen door
+scriptorium
+scullery
+sealskin tent
+seawall
+second balcony
+second class
+second-hand store
+segmental arch
+semi-circular bastion
+semicircular arch
+semidetached house
+sepulcher
+sepulchre
+sepulture
+seraglio
+serail
+service club
+service department
+set-back
+setoff
+settlement house
+seven wonders of the ancient world
+seven wonders of the world
+sewage disposal plant
+sewing room
+shack
+shaft furnace
+shambles
+shanty
+shed
+sheep pen
+sheepcote
+sheepfold
+shelter
+shelter tent
+shelterbelt
+shingle
+ship's galley
+shipping office
+shipping room
+shoe shop
+shooting box
+shooting lodge
+shop
+shop window
+shopping center
+shopping centre
+shot tower
+shouldered arch
+show window
+shower bath
+shower room
+shower stall
+showroom
+sibley tent
+sick berth
+sickbay
+sickroom
+side chapel
+sidewall
+sign
+signal box
+signal tower
+signboard
+silo
+single dwelling
+sink plug
+sitting room
+skating rink
+skeen arch
+skein
+skeletal frame
+skene arch
+skew arch
+ski lodge
+skybox
+slabbing mill
+slammer
+slate fence
+slaughterhouse
+sleeping accommodation
+sleeping room
+sliding door
+sliding window
+slipway
+slop chest
+slopseller's shop
+slopshop
+small stores
+smelter
+smeltery
+smokehouse
+smoking room
+snake fence
+snake pit
+snake-rail fence
+snap brim
+snowbank
+snug
+snuggery
+socle
+sod house
+soddy
+solar house
+solar trap
+solarium
+solid bastion
+souk
+soundboard
+soundbox
+sounding board
+spa
+span
+spark chamber
+spark counter
+speakeasy
+specialty store
+speed bump
+spile
+spiral
+splash guard
+split-rail fence
+sporting house
+sports arena
+sports stadium
+spot
+sprag
+sprocket
+squad room
+squinch
+squirrel cage
+stable
+stabling
+stacks
+stall
+stalls
+stamp battery
+stamp mill
+stamping mill
+standing stone
+star fort
+star fortress
+star-shaped fortress
+starting gate
+starting stall
+stash house
+stassano furnace
+state prison
+statehouse
+stately home
+stateroom
+steam bath
+steam chest
+steam room
+steel arch bridge
+steel factory
+steel mill
+steel plant
+steelworks
+steerage
+still
+stillroom
+stockade
+stockroom
+stockyard
+stoep
+stokehold
+stokehole
+stone wall
+stonework
+stoop
+stoppage
+stopper
+stopple
+storage area
+storage locker
+storage room
+storage space
+storeroom
+storey
+storm cellar
+storm door
+storm sash
+storm window
+story
+stowage
+straight arch
+strip mall
+strongroom
+structure
+student center
+student lodging
+student residence
+student union
+studio
+studio apartment
+study hall
+stuffing box
+stumbling block
+stupa
+sty
+substructure
+sudatorium
+sudatory
+sugar refinery
+suite
+summerhouse
+sun deck
+sun lounge
+sun parlor
+sun parlour
+sun porch
+sunroom
+suntrap
+supermarket
+superstructure
+supper club
+supply closet
+supporting structure
+supporting tower
+surgery
+suspension bridge
+sweat room
+sweatshop
+swing door
+swinging door
+tabernacle
+taffrail
+tailboard
+tailgate
+tampax
+tampion
+tampon
+tank
+tank furnace
+tap
+taphouse
+taproom
+tea parlor
+tea parlour
+teashop
+teepee
+telco building
+telecom hotel
+telephone booth
+telephone box
+telephone kiosk
+television room
+tenement
+tenement house
+tennis camp
+tenon
+tenter
+tepee
+terraced house
+terrarium
+test room
+testing room
+textile mill
+theater
+theater in the round
+third class
+three-centered arch
+threshing floor
+thriftshop
+ticket booth
+ticket office
+tilt barrier
+tine
+tipi
+tithe barn
+tobacco shop
+tobacconist
+tobacconist shop
+toilet
+tokamak
+tolbooth
+toll bridge
+tollbar
+tollbooth
+tollgate
+tollhouse
+tombstone
+tompion
+toolhouse
+toolshed
+tooth
+top
+tope
+tornado cellar
+totem pole
+tourist class
+tourist court
+tower
+tower block
+toyshop
+trace italienne
+tract house
+tract housing
+trading post
+trailer camp
+trailer park
+training school
+transept
+transom window
+trap
+trap door
+trefoil arch
+treillage
+trestle
+trestle bridge
+trestlework
+tribune
+trimmer arch
+trumpet arch
+trunk
+truss bridge
+tub stopper
+tuck shop
+tudor arch
+tumulus
+tupek
+tupik
+turkish bath
+turnaround
+turnstile
+tv room
+two-man tent
+umbrella tent
+underframe
+understructure
+upper balcony
+vacation home
+vacuum chamber
+valance
+valance board
+vapor bath
+vapor lock
+vapour bath
+vapour lock
+vaudeville theater
+vaudeville theatre
+vaulting
+verandah
+vestry
+vicarage
+virginia fence
+visor
+vivarium
+vizor
+volary
+volute
+voting booth
+waiting area
+waiting room
+walk-in
+walk-up
+walk-up apartment
+walker
+wall tent
+war room
+ward
+wardroom
+water closet
+water hazard
+water jump
+wattle
+ways
+weapons platform
+weir
+wellhead
+wheelhouse
+white room
+wholesale house
+whorl
+wicket door
+wicket gate
+wickiup
+widow's walk
+wigwam
+wikiup
+wilson cloud chamber
+wind tunnel
+windbreak
+window frame
+window sash
+wine cellar
+wine maker
+winery
+wing
+withdrawing room
+witness box
+witness stand
+woodshed
+work camp
+workroom
+works
+worm fence
+yard
+youth hostel
+zikkurat
+zikurat
+zimmer
+zimmer frame

--- a/lists/fashion/footwear-type.yml
+++ b/lists/fashion/footwear-type.yml
@@ -1,0 +1,94 @@
+---
+title: Footwear
+category: fashion
+description: "Shoes, boots, slippers, and specialized footgear"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+ankle boot
+arctic
+baby shoe
+balmoral
+blucher
+boot
+bootee
+bootie
+bowling shoe
+brogan
+brogue
+buskin
+calceus
+carpet slipper
+chopine
+chukka
+chukka boot
+clodhopper
+combat boot
+congress boot
+congress gaiter
+congress shoe
+cowboy boot
+desert boot
+espadrille
+flipper
+footgear
+footwear
+gaiter
+galosh
+ghillie
+gillie
+golosh
+gum boot
+gumshoe
+gym shoe
+half boot
+hessian
+hessian boot
+high heels shoe
+high-heeled shoe
+hip boot
+huarache
+jackboot
+jodhpur
+jodhpur boot
+jodhpur shoe
+loafer
+mocassin
+moccasin
+mule
+overshoe
+oxford
+patten
+platform
+plimsoll
+riding boot
+rubber boot
+running shoe
+sabot
+saddle oxford
+saddle shoe
+sandal
+scuff
+scuffer
+ski boot
+slingback
+slipper
+sneaker
+spectator
+spectator pump
+talaria
+tennis shoe
+thigh boot
+thong
+top boot
+waders
+walking shoe
+wedgie
+wellington
+wellington boot
+wooden shoe
+work shoe

--- a/lists/fashion/personal-care.yml
+++ b/lists/fashion/personal-care.yml
@@ -1,0 +1,109 @@
+---
+title: Personal-care objects
+category: fashion
+description: "Toiletries, cosmetics, grooming aids, and bathing products"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+after-shave
+after-shave lotion
+antiperspirant
+araroba
+baby powder
+baked blush
+bath foam
+bath glove
+bath mitt
+bath oil
+bath powder
+bath salts
+bath scrubber
+bay rum
+blush
+blusher
+body butter
+body lotion
+brilliantine
+bronzer
+bronzing powder
+bubble bath
+chrysarobin
+cold cream
+cologne
+cologne water
+compact powder
+cosmetic
+cream
+cream cleanser
+creme cleanser
+deodourant
+depilator
+depilatory
+dusting powder
+eau de cologne
+eau de toilette
+emollient
+epilating wax
+essence
+eyebrow pencil
+eyeshadow
+eyeshadow palette
+face cream
+face powder
+foam bath
+foaming bath
+foot file
+greasepaint
+hair gel
+hair grease
+hair mousse
+hair oil
+hair spray
+hair tonic
+hairdressing
+hand cream
+hand lotion
+kohl
+lanolin
+lip rouge
+lip-gloss
+lipstick
+lotion
+mascara
+mousse
+nail enamel
+nail polish
+nail varnish
+nard
+ointment
+pachouli
+patchouli
+patchouly
+pomade
+pomatum
+potpourri
+powder
+rose water
+rouge
+shaving cream
+shaving foam
+shaving soap
+shower glove
+shower mitt
+shower scrubber
+spikenard
+sun blocker
+sunblock
+talcum
+talcum powder
+toilet articles
+toilet powder
+toilet water
+toiletry
+toner
+vanishing cream
+war paint

--- a/lists/fashion/textile.yml
+++ b/lists/fashion/textile.yml
@@ -1,0 +1,298 @@
+---
+title: Textiles
+category: fashion
+description: "Fabrics, cloths, weaves, lace, canvas, and textile materials"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+aba
+acetate rayon
+aertex
+bagging
+baize
+balbriggan
+balloon sail
+bandanna
+batiste
+bedford cord
+belting
+bib
+bobbin lace
+bombazine
+book cloth
+boucle
+broadcloth
+brussels lace
+buckram
+bunting
+cambric
+camel's hair
+camelhair
+camlet
+camo
+canton crepe
+canton flannel
+canvass
+cerecloth
+challis
+chambray
+chamois cloth
+cheesecloth
+chicken wire
+chinchilla
+chino
+cleaning cloth
+cloth
+cobweb
+cotton flannel
+courtelle
+crape
+crepe de chine
+crepe marocain
+cretonne
+crinoline
+crossjack
+dacron
+diamante
+diaper
+dimity
+dishrag
+doeskin
+double knit
+duck
+duffel
+duffle
+dungaree
+durable press
+dust sheet
+dustcloth
+duster
+dustrag
+end
+etamin
+etamine
+fabric
+face towel
+fag end
+faille
+fiber
+fibre
+filet
+fillet
+flannelette
+flying jib
+fore staysail
+fore-and-aft sail
+fore-and-aft topsail
+fore-topmast staysail
+fore-topsail
+foresail
+frieze
+fustian
+gabardine
+gaff topsail
+gaff-headed sail
+gaffsail
+gauze
+gauze bandage
+gore
+gossamer
+grogram
+grosgrain
+ground cloth
+groundsheet
+guimpe
+gunny
+gusset
+hair
+haircloth
+hairnet
+hand towel
+hankey
+hankie
+hanky
+harris tweed
+headsail
+homespun
+hopsack
+hopsacking
+horsehair
+huck
+huckaback
+imitation leather
+inner jib
+inset
+jaconet
+jean
+jib
+khaddar
+khadi
+khaki
+lame
+lateen
+lateen sail
+leatherette
+lining
+linsey-woolsey
+lint
+longyi
+lugsail
+lungi
+lungyi
+macintosh
+mackinaw
+mackintosh
+macrame
+main course
+main-topsail
+mainsail
+marocain
+marseille
+material
+mesh
+meshing
+meshwork
+mizen
+mizzen
+mizzen course
+moire
+moleskin
+monk's cloth
+moquette
+moreen
+motley
+mousseline de sole
+nainsook
+nankeen
+narrow wale
+netting
+network
+ninon
+oddment
+oilcloth
+olive drab
+organdie
+organdy
+orlon
+outer jib
+panting
+paper towel
+pasty
+pepper-and-salt
+percale
+permanent press
+petrolatum gauze
+piece of cloth
+piece of material
+pillow lace
+pilot cloth
+pique
+placket
+plush
+pocket-handkerchief
+point lace
+pongee
+poplin
+press of canvas
+press of sail
+quilting
+rag
+remainder
+remnant
+rep
+repp
+roller towel
+russet
+sackcloth
+sacking
+safety net
+sail
+sailcloth
+samite
+sarcenet
+sarsenet
+sateen
+satinet
+satinette
+save-all
+screening
+scrim
+serge
+shag
+shantung
+sheet
+sheeting
+shirting
+shirttail
+shoulder patch
+shred
+silesia
+silk serge
+skysail
+snood
+spanker
+spark arrester
+sparker
+spinnaker
+sponge cloth
+spritsail
+square sail
+stammel
+staysail
+stockinet
+stockinette
+suede cloth
+suiting
+swan's down
+swatch
+tag
+tag end
+tammy
+tapa
+tapis
+tappa
+tarpaulin
+tatter
+terry
+terry cloth
+terylene
+textile
+ticking
+topgallant sail
+topsail
+toweling
+towelling
+trousering
+tucker
+twill
+ultrasuede
+upholstery material
+valenciennes
+valenciennes lace
+veiling
+velcro
+velour
+velours
+velveteen
+vicuna
+viscose rayon
+viyella
+vulcanized fiber
+wash-and-wear
+watered-silk
+waterproof
+webbing
+whipcord
+wide wale
+wincey
+winceyette
+wiping cloth
+wire cloth
+wirework
+woolen
+woollen
+worsted

--- a/lists/thing/articles-and-parts.yml
+++ b/lists/thing/articles-and-parts.yml
@@ -1,0 +1,65 @@
+---
+title: Tableware and articles
+category: thing
+description: "Tableware, serving pieces, and manufactured articles"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+article of commerce
+barbecue fork
+breakable
+butter knife
+carving fork
+chinaware
+chopstick
+crockery
+cut glass
+cutlery
+dessert plate
+dinner plate
+dinner service
+dinner set
+dinnerware
+dishware
+eating utensil
+eggcup
+fish knife
+flatware
+glassware
+glasswork
+holloware
+hollowware
+knickknack
+laboratory glassware
+metalware
+notion
+ovenware
+paper plate
+place setting
+riband
+ribband
+salad fork
+salad plate
+service
+soup plate
+spork
+steak knife
+steel plate
+table knife
+table service
+tablefork
+tableware
+tea service
+tea set
+tinware
+toasting fork
+tole
+venetian glass
+ware
+willow-pattern
+willowware
+woodenware

--- a/lists/thing/containers.yml
+++ b/lists/thing/containers.yml
@@ -1,0 +1,644 @@
+---
+title: Containers
+category: thing
+description: "Vessels, receptacles, cases, packaging, and storage objects"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+aerosol
+aerosol bomb
+aerosol can
+aerosol container
+air bag
+airbrush
+airmailer
+alembic
+alms box
+alms dish
+alms tray
+ammunition chest
+amphora
+ampoule
+ampul
+ampule
+ampulla
+ash bin
+ash-pan
+ashcan
+ashtray
+atomiser
+atomizer
+attache
+attache case
+audiocassette
+autoclave
+auxiliary boiler
+bag
+baggage
+bain-marie
+bale
+ballot box
+bandbox
+baptismal font
+baptistery
+baptistry
+barrel
+basin
+basket
+bath
+bathing tub
+bathtub
+beaker
+beanbag
+bedpan
+beehive
+beer barrel
+beer bottle
+beer can
+beer glass
+beer keg
+beer mug
+bellarmine
+belt bag
+bidet
+billfold
+bin liner
+birdbath
+bladder
+body bag
+boiler
+bone-ash cup
+book bag
+bota
+bottle bank
+box
+brandy glass
+brandy snifter
+bread-bin
+breadbasket
+breadbox
+breast pocket
+bundle
+burlap bag
+burn bag
+bushel basket
+butt
+butt pack
+butter churn
+butter dish
+caddy
+cafeteria tray
+caldron
+canister
+cannikin
+cannister
+canopic jar
+canopic vase
+canteen
+capsule
+carafe
+carboy
+cardcase
+cargo container
+carpetbag
+carrier bag
+carry-on
+carryall
+carton
+case
+cashbox
+cask
+casket
+casserole
+cassette
+cat box
+catchall
+catsup bottle
+cauldron
+cedar chest
+censer
+cereal bowl
+cereal box
+chalice
+chamberpot
+champagne flute
+cheese tray
+cheeseboard
+chest
+churn
+cigar box
+cigarette case
+circular file
+clamshell
+clothes basket
+clothes hamper
+clutch bag
+coal scuttle
+coalbin
+coalhole
+cockpit locker
+cocktail shaker
+cocotte
+coffee can
+coffee cup
+coffee mug
+coffee urn
+coffeepot
+coffer
+coffin
+coin bank
+coin box
+collection plate
+compact
+compositor's case
+container
+cookie jar
+cooky jar
+coquille
+corncrib
+crate
+cream pitcher
+creamer
+creel
+crewet
+crock
+crucible
+cruet
+cruse
+cupel
+cuspidor
+cylinder
+cylix
+decanter
+deedbox
+demijohn
+demitasse
+deposit box
+dessert spoon
+dewar
+dewar flask
+dice box
+dice cup
+digester
+dime
+dime bag
+dinner bucket
+dinner pail
+diplomatic pouch
+dipper
+dish
+dishpan
+dispatch box
+dispatch case
+dispenser
+display case
+ditty bag
+dixie
+dixie cup
+doggie bag
+doggy bag
+donkey boiler
+double-magnum
+drawer
+drawstring bag
+dredging bucket
+dressing case
+drinking glass
+drinking vessel
+drip pan
+drip pot
+duffel bag
+duffle bag
+dust bag
+dustbin
+dutch oven
+earthenware jar
+emesis basin
+empty
+erlenmeyer flask
+etui
+evening bag
+ewer
+eyebath
+eyecup
+fanny pack
+feed bunk
+feedbag
+feeding bottle
+finger bowl
+firkin
+fish tank
+fishbowl
+flagon
+flask
+flour bin
+fluidized bed boiler
+flute glass
+font
+food hamper
+footbath
+footlocker
+form
+frail
+fuel pod
+gamebag
+garbage
+garbage can
+garment bag
+gas holder
+gas tank
+gas-washing bottle
+gasbag
+gasoline tank
+gasometer
+gladstone
+gladstone bag
+glasses case
+goblet
+goldfish bowl
+golf bag
+gourd
+grab bag
+grace cup
+grapple
+gravy boat
+gravy holder
+greybeard
+grip
+gripsack
+grocery bag
+gun case
+gunnysack
+hamper
+hand luggage
+handbag
+handbasin
+handbasket
+hatbox
+haversack
+hay bale
+highball glass
+hip bath
+hip pocket
+hipflask
+hive
+hod
+hogshead
+holdall
+hope chest
+hopper
+hot-water bag
+hot-water bottle
+human remains pouch
+ice bag
+ice pack
+iced-tea spoon
+icetray
+imperial
+in-basket
+in-tray
+inhalator
+inhaler
+ink bottle
+inkpot
+inkstand
+inkwell
+jamjar
+jampot
+jar
+jeroboam
+jewel casket
+jorum
+jug
+keg
+ketchup bottle
+kibble
+kitbag
+knapsack
+kylix
+ladle
+laundry basket
+lavabo
+laver
+lazy susan
+letter box
+letter case
+liqueur glass
+litter basket
+litterbin
+lockbox
+locket
+longbeard
+lota
+loving cup
+magnetic bottle
+magnum
+mail pouch
+mailbag
+mailer
+manger
+marine museum
+marmite
+mason jar
+matchbox
+matrix
+mazer
+measure
+measuring cup
+melting pot
+metal drum
+milk can
+mite box
+mixing bowl
+mold
+money box
+moneybag
+monstrance
+mould
+moustache cup
+muffin case
+muffin cup
+muller
+mummy bag
+mustache cup
+nebuchadnezzar
+nebuliser
+nebulizer
+nosebag
+notecase
+nursing bottle
+oilcan
+ossuary
+ostensorium
+out-basket
+out-tray
+overnight bag
+overnight case
+overnighter
+pack
+package
+packing box
+packing case
+packsack
+pail
+paintball
+paintbox
+pannikin
+paper bag
+paper cup
+parcel
+parfait glass
+parts bin
+patch pocket
+pencil box
+pencil case
+penny bank
+pepper box
+pepper pot
+pepper shaker
+pepper spray
+percolator
+personnel pouch
+petri dish
+petrol tank
+phial
+pickle barrel
+pig bed
+piggy bank
+pill bottle
+pipe bowl
+pitcher
+pix
+pix chest
+planter
+plastic bag
+playbox
+poacher
+pocket
+pocket flask
+pocketbook
+pod
+poke
+pony
+poor box
+pop bottle
+porringer
+portfolio
+portmanteau
+postbag
+pottle
+potty
+pouch
+powder compact
+powder flask
+powder horn
+powder keg
+pressure cooker
+punch bowl
+punnet
+pyx
+pyx chest
+pyxis
+quiver
+ragbag
+ramekin
+ramequin
+receptacle
+record cover
+record sleeve
+refractory pot
+register
+reliquary
+reservoir
+retort
+roll-on
+rosin bag
+round-bottom flask
+rucksack
+rummer
+runcible spoon
+sachet
+saddlebag
+safe-deposit
+safe-deposit box
+safety deposit box
+safety-deposit
+salad bowl
+saltcellar
+saltshaker
+salver
+samovar
+sandbag
+sarcophagus
+satchel
+sauceboat
+saucepot
+savings bank
+schoolbag
+scoop
+scyphus
+sea chest
+seabag
+seed tray
+seidel
+septic tank
+serving dish
+sewing basket
+shadow box
+shaker
+sheaf
+shoebox
+shook
+shopping basket
+shot glass
+shoulder bag
+showcase
+sick bag
+silent butler
+sitz bath
+six-pack
+skep
+slash pocket
+slinger ring
+slop basin
+slop bowl
+slop jar
+slop pail
+smelling bottle
+snifter
+snuffbox
+socket
+soda bottle
+soda can
+soup bowl
+soup ladle
+soupspoon
+specimen bottle
+spittoon
+sponge bag
+sporran
+spray
+spray can
+sprayer
+steam boiler
+steeper
+stein
+steriliser
+sterilizer
+stockpot
+storage ring
+storage tank
+stoup
+strongbox
+sugar bowl
+sugar shell
+sugar spoon
+suitcase
+swag
+sweat bag
+tablespoon
+tankard
+tea bag
+tea caddy
+tea chest
+tea maker
+tea tray
+tea urn
+teacup
+teakettle
+teapot
+teaspoon
+thermos
+thermos bottle
+thermos flask
+thimble
+thunder mug
+thurible
+tidy
+till
+time capsule
+tin can
+tinderbox
+tobacco pouch
+toby
+toby fillpot jug
+toby jug
+toilet bag
+toilet bowl
+toilet kit
+tool bag
+tool cabinet
+tool case
+tool chest
+toolbox
+tote
+toy box
+toy chest
+trash barrel
+trash bin
+travel kit
+traveling bag
+travelling bag
+tray
+treasure chest
+trophy case
+tub
+tuck box
+tucker-bag
+tumbler
+tun
+tureen
+typesetter's case
+urceole
+urn
+vacuum bag
+vacuum bottle
+vacuum flask
+valise
+vat
+vest pocket
+vial
+videocassette
+vitrine
+voider
+waist pack
+warming pan
+wash-hand basin
+washbasin
+washbowl
+washpot
+washtub
+wastebin
+wastepaper basket
+watch case
+watch pocket
+water butt
+water jacket
+water jug
+water tank
+water tower
+watering can
+watering pot
+waterskin
+wedding chest
+weekender
+whiskey bottle
+whiskey jug
+wicker basket
+window box
+window envelope
+wine barrel
+wine bottle
+wine bucket
+wine cask
+wine cooler
+wineglass
+wineskin
+wooden spoon
+workbag
+workbasket
+workbox

--- a/lists/thing/coverings.yml
+++ b/lists/thing/coverings.yml
@@ -1,0 +1,233 @@
+---
+title: Coverings
+category: thing
+description: "Covers, coatings, wraps, bedding, and protective layers"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acrylic paint
+adhesive bandage
+afghan
+antifouling paint
+antimacassar
+artificial skin
+band aid
+bandage
+barndoor
+bed clothing
+bed covering
+bedclothes
+bedcover
+bedding
+bedroll
+bedspread
+bitumastic
+blackwash
+blanket
+blindfold
+bootleg
+bosom
+bottlecap
+bubble
+burial garment
+calcimine
+cap
+capeline bandage
+casein
+casein paint
+cataplasm
+cellophane
+cerement
+chafing gear
+chalice cloth
+cling film
+cloak
+cloth covering
+coat of paint
+coating
+coattail
+color wash
+colour wash
+comfort
+compress
+compression bandage
+concealment
+continental quilt
+cosy
+counterpane
+cover plate
+covering
+coverlet
+covert
+cozy
+crazy quilt
+cuff
+dag
+dolman sleeve
+dressing
+duvet
+earflap
+earlap
+earmuff
+eiderdown
+elastic bandage
+elastoplast
+elbow
+emulsion
+emunctorium
+enamel
+encaustic
+exhaust hood
+eyepatch
+fig leaf
+file folder
+finger
+finger paint
+finish coat
+finishing coat
+fixative
+flap
+flat coat
+floor cover
+floor covering
+fly sheet
+four-tailed bandage
+french polish
+french polish shellac
+gift wrapping
+gilding
+gilt
+gold plate
+havelock
+house paint
+imbrication
+immovable bandage
+instep
+jag
+japan
+knee
+lacquer
+lap
+lap covering
+lapel
+lappet
+lapping
+latex
+latex paint
+leg
+lid
+long sleeve
+mackinaw blanket
+manta
+mat
+matchbook
+mattress cover
+medical dressing
+mercy seat
+metal plating
+mustard plaster
+oblique bandage
+oil
+oil color
+oil colour
+oil paint
+overcoat
+overcoating
+overlap
+overlapping
+paddle box
+paint
+pant leg
+parqueterie
+parquetry
+patch
+patchwork quilt
+photographic emulsion
+pigment
+planking
+plaster bandage
+plaster cast
+plastic wrap
+plating
+pocket flap
+poster color
+poster colour
+poster paint
+poultice
+primer
+primer coat
+priming
+priming coat
+purificator
+purificatorium
+quilt
+quilted bedspread
+radiator cap
+raglan sleeve
+rainfly
+range hood
+record jacket
+revere
+revers
+roller bandage
+rubber-base paint
+saran wrap
+scarf bandage
+screwtop
+security blanket
+shellac
+shellac varnish
+shirtsleeve
+shoji
+short sleeve
+shoulder
+shroud
+silver plate
+sinapism
+skirt
+sleeve
+slipcover
+spiral bandage
+spray paint
+spread
+stalking-horse
+surgical dressing
+suspensory
+suspensory bandage
+swathe
+swathing
+tea cosy
+tea cozy
+tempera
+tent flap
+tent-fly
+throw
+toe
+tourniquet
+triangular bandage
+trouser cuff
+trouser leg
+trunk lid
+turnup
+twist-off cap
+twist-off lid
+undercoat
+underseal
+upholstery
+varnish
+veneer
+veneering
+verdigris
+water-base paint
+waterproofing
+welcome mat
+whitewash
+winding-clothes
+winding-sheet
+wrap
+wrapper
+wrapping

--- a/lists/thing/crafted-objects.yml
+++ b/lists/thing/crafted-objects.yml
@@ -1,0 +1,579 @@
+---
+title: Crafted objects
+category: thing
+description: "Artworks, representations, recordings, plans, and handmade creations"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abstract art
+abstraction
+abstractionism
+adumbration
+aerial mosaic
+album
+alto relievo
+alto rilievo
+anaglyph
+anamorphism
+anamorphosis
+angiocardiogram
+angiogram
+animalization
+applique
+aquatint
+architectural plan
+art
+art informel
+art object
+arteriogram
+arthrogram
+artificial flower
+audiogram
+autograph album
+autoradiograph
+autotype
+babygram
+backcloth
+backdrop
+background
+backstitch
+backup
+bas relief
+basso relievo
+basso rilievo
+baste
+basting
+basting stitch
+beefcake
+bird-scarer
+bitmap
+black and white
+blanket stitch
+block diagram
+blowup
+body of work
+brainchild
+bromoil
+bullfight
+bust
+buttonhole stitch
+by-product
+cabinetwork
+cameo
+caning
+carbon
+carbon copy
+carving
+cast
+casting
+cat scan
+chain stitch
+chart
+cheesecake
+chef-d'oeuvre
+chiaroscuro
+chinoiserie
+choropleth map
+chromolithograph
+cityscape
+classic
+clay sculpture
+clip art
+clone
+closeup
+coffee-table book
+collage
+coloring book
+commercial art
+composition
+computer backup
+computer graphic
+computer graphics
+conformal projection
+conic projection
+conical projection
+contact print
+contour map
+copy
+corrida
+cosmography
+counterfeit
+counterpart
+creation
+crewelwork
+crochet
+crochet stitch
+crocheting
+crop
+cross-stitch
+cutaway
+cutaway drawing
+cutaway model
+cutout
+cutwork
+cyberart
+cyclorama
+cylinder block
+daguerreotype
+darn
+daub
+daybook
+death mask
+decoupage
+delineation
+deliverable
+depiction
+diaglyph
+diagram
+diary
+diorama
+diptych
+display
+distemper
+doodle
+double crochet
+double stitch
+draft
+drawing
+drawnwork
+drip painting
+duplicate
+duplication
+ecce homo
+echogram
+effigy
+electronic image
+elevation
+embossment
+embroidery
+embroidery stitch
+encephalogram
+end product
+engine block
+enlargement
+equal-area map projection
+equal-area projection
+exposure
+fake
+fake book
+fancywork
+fashion plate
+figurehead
+figurine
+fine art
+finger-painting
+fitspo
+floor plan
+folio
+folk art
+follow-up
+forgery
+freestyling
+french knot
+fresco
+fruit
+garter stitch
+gather
+gathering
+gem
+genre
+genre painting
+glyph
+glyptic art
+glyptics
+glyptography
+god
+golden calf
+gouache
+graphic
+graphic art
+graphics
+graven image
+gravure
+grisaille
+gros point
+grotesque
+ground plan
+half cross stitch
+half-length
+half-relief
+handcraft
+handicraft
+handiwork
+handwork
+hardback
+hardcover
+headshot
+heliogravure
+hemming-stitch
+hemstitch
+hemstitching
+herm
+high relief
+hologram
+holograph
+homolosine projection
+horatianism
+horizontal section
+horoscope
+hysterosalpingogram
+icon
+iconography
+identikit
+identikit picture
+idol
+ikon
+illumination
+illustration
+image
+imitation
+improvisation
+informel
+innovation
+inspiration
+instagay
+intaglio
+intravenous pyelogram
+invention
+ironwork
+ivp
+job
+joinery
+joss
+juggernaut
+kitsch
+knit
+knit stitch
+knitting
+knitting stitch
+knitwork
+knockoff
+lacework
+lacquerware
+landscape
+landscape painting
+lantern slide
+latergram
+lay figure
+lazy daisy stitch
+leatherwork
+ledger
+life mask
+likeness
+limning
+line drawing
+lithoglyptics
+lockstitch
+longshot
+low relief
+lymphangiogram
+machine stitch
+magic realism
+magnification
+magnum opus
+mammogram
+manakin
+manikin
+mannequin
+mannikin
+map projection
+marionette
+masking
+masking piece
+master
+master copy
+masterpiece
+mate
+mechanical drawing
+mend
+mercator projection
+mercator's projection
+metalwork
+mezzo-relievo
+mezzo-rilievo
+mezzotint
+microdot
+micrograph
+microprint
+military art
+millwork
+miniature
+mobile
+mock-up
+model
+modeling
+modelling
+modernism
+modification
+molding
+monochrome
+montage
+moulding
+mug shot
+myelogram
+naive art
+naumachia
+naumachy
+naval chart
+navigational chart
+needlecraft
+needlepoint
+needlepoint embroidery
+needlework
+nomogram
+nomograph
+novel
+novillada
+objectification
+objet d'art
+oeuvre
+oil painting
+olympian zeus
+op art
+openwork
+order book
+original
+orrery
+orthomorphic projection
+output
+outsider art
+outturn
+overcast
+overcasting
+overhand stitch
+overprint
+painting
+panorama
+paperback
+paperback book
+paste-up
+pastiche
+patchwork
+pen-and-ink
+pentimento
+period piece
+petit point
+phlebogram
+phonograph album
+photo
+photocopy
+photograph
+photograph album
+photographic print
+photogravure
+photolithograph
+photomicrograph
+photomontage
+photomosaic
+pic
+picot
+picture book
+piece of work
+pieta
+pilot chart
+plain
+plain stitch
+plan
+plastic art
+plat
+pneumoencephalogram
+pocket edition
+pointillism
+polychrome
+polyconic projection
+portrait
+portrayal
+postiche
+postmodernism
+potemkin village
+presentation
+primitivism
+print
+product
+production
+proof
+purl
+purl stitch
+pyelogram
+quadruplicate
+radiogram
+radiograph
+radiophoto
+radiophotograph
+record album
+reflection
+reflexion
+relief
+relief map
+relievo
+remake
+remaking
+rendering
+replica
+replication
+representation
+reproduction
+restoration
+rilievo
+road map
+rod puppet
+roentgenogram
+rough drawing
+roughcast
+rubbing
+running stitch
+saddle stitch
+sand painting
+sanson-flamsteed projection
+satin stitch
+scan
+scarecrow
+scarer
+scene
+scenery
+schematic
+schematic drawing
+scrabble
+scrapbook
+scribble
+scrimshaw
+sculptural relief
+sculpture
+seascape
+self-portrait
+self-taught art
+semblance
+semi-abstraction
+serigraph
+set piece
+sewing
+sewing stitch
+sewing-machine stitch
+shadowgraph
+sham
+shell stitch
+silhouette
+silk screen print
+silkscreen
+silverpoint
+silverwork
+similitude
+simulacrum
+simulation
+single crochet
+single stitch
+sinusoidal projection
+sketch
+sketch block
+sketch map
+sketch pad
+sketchbook
+skiagram
+skiagraph
+slip stitch
+smocking
+snapshot
+snellen chart
+snowman
+soft-cover
+soft-cover book
+softback
+softback book
+sonogram
+spectacle
+spectrogram
+spectrograph
+sphinx
+spin-off
+stabile
+stage set
+stamp album
+standee
+station of the cross
+statuette
+stereoscopic photograph
+stereoscopic picture
+stick figure
+still life
+stitch
+stitchery
+stock image
+stock photograph
+stockinette stitch
+straw man
+study
+surprint
+synthetism
+tacking
+tailor's tack
+tanka
+tatting
+telephoto
+telephotograph
+tent stitch
+term
+terminal figure
+throughput
+time exposure
+tobacco product
+tomogram
+tormenter
+tormentor
+toy
+tracing
+transparency
+triplicate
+triptych
+trompe l'oeil
+turnery
+turnout
+twin
+venn diagram
+venn's diagram
+venogram
+ventriloquist's dummy
+vernacular art
+vertical section
+video art
+view
+viewgraph
+vignette
+virtu
+visible speech
+volume
+wall painting
+warhorse
+wash
+wash drawing
+watercolor
+watercolour
+waterscape
+wax figure
+waxwork
+weather chart
+weather map
+wedding picture
+whipping
+whipstitch
+whipstitching
+wicker
+wickerwork
+wind rose
+wing flat
+wiring diagram
+woodcarving
+woodwork
+work
+work in progress
+work of art
+workpiece
+x ray
+x-ray photograph
+x-ray picture
+xerox copy
+yield
+zodiac

--- a/lists/thing/decorations.yml
+++ b/lists/thing/decorations.yml
@@ -1,0 +1,333 @@
+---
+title: Decorations
+category: thing
+description: "Ornaments, adornments, insignia, trim, and decorative objects"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+adornment
+aglet
+aiglet
+aigret
+aigrette
+aiguillette
+american flag
+ankle bracelet
+anklet
+annulet
+antefix
+architectural ornament
+argyll
+armilla
+armorial bearing
+arms
+arras
+astragal
+bandelet
+bandelette
+banding
+bandlet
+bangle
+banner
+baseboard
+battle flag
+bauble
+bay wreath
+bead
+bead and quirk
+beading
+beadwork
+bear claw
+beauty spot
+bend
+bend dexter
+bijou
+black flag
+blackjack
+blazon
+blazonry
+bling
+bling bling
+boule
+boulle
+bouquet
+boutonniere
+braid
+braiding
+breastpin
+broach
+brooch
+buhl
+bulla
+cachet
+calvary cross
+cap band
+cavetto
+celtic cross
+centerpiece
+centrepiece
+chaplet
+charge
+check
+christmas tree
+cigar band
+circlet
+coat of arms
+cockade
+collar
+colophon
+colors
+colours
+confederate flag
+conge
+congee
+cordon
+coronal
+corsage
+crest
+crocket
+cross
+cross of calvary
+cross of lorraine
+crown
+crown jewel
+crucifix
+cufflink
+cuspidation
+cyma
+cyma recta
+cyma reversa
+cymatium
+daisy chain
+damascene
+decal
+decalcomania
+decor
+decoration
+design
+dog collar
+dogstooth check
+dossal
+dossel
+drop earring
+ear hook earring
+ear wrap
+earcuff
+eardrop
+earring
+echinus
+egg-and-anchor
+egg-and-dart
+egg-and-tongue
+embellishment
+emblem
+encrustation
+engagement ring
+ensign
+epaulet
+epaulette
+epergne
+falderol
+fallal
+fan tracery
+fanion
+fess
+fesse
+festoon
+festoonery
+filagree
+filigree
+fillagree
+finial
+flag of truce
+fleur-de-lys
+floral arrangement
+flounce
+flower arrangement
+flower chain
+folderal
+foliage
+foliation
+frill
+frog
+frontlet
+furbelow
+garland
+garnish
+gaud
+gauffer
+gewgaw
+gimcrack
+gimcrackery
+goffer
+gold braid
+gorgerin
+graffiti
+graffito
+great seal
+greek cross
+greek fret
+handstamp
+hanging
+hatband
+heraldic bearing
+heraldry
+herringbone pattern
+hood ornament
+houndstooth check
+incrustation
+inlay
+interior decoration
+jabot
+jerusalem cross
+jewel
+jewellery
+jewelry
+jolly roger
+kakemono
+key pattern
+lambrequin
+latin cross
+laurel
+laurel wreath
+lavalier
+lavaliere
+lavalliere
+lei
+linocut
+lorraine cross
+lunula
+maltese cross
+mandala
+marqueterie
+marquetry
+miniver
+mopboard
+motif
+motive
+mourning ring
+neckband
+necking
+necklet
+nonsense
+nosegay
+novelty
+old glory
+open weave
+ordinary
+oriflamme
+ornament
+ornamentation
+overlay
+ovolo
+panache
+papal cross
+passementerie
+patriarchal cross
+pattern
+pectoral
+pectoral medallion
+pendant earring
+pennant
+pennon
+pennoncel
+pennoncelle
+penoncel
+peplum
+pirate flag
+plain weave
+plume
+pommel
+pompon
+posy
+precious stone
+pyrograph
+quarter round
+quirk bead
+quirk molding
+quirk moulding
+rickrack
+ricrac
+ringlet
+rood
+rood-tree
+rosemaling
+rosette
+roundel
+saltire
+satin weave
+scarfpin
+scatter pin
+screen saver
+seal
+seal ring
+sequin
+set decoration
+sgraffito
+shoulder board
+shoulder mark
+signet
+signet ring
+skirting board
+skull and crossbones
+solitaire
+soutache
+spangle
+sprig
+square and rabbet
+st. andrew's cross
+st. anthony's cross
+stamp
+standard
+star-spangled banner
+stars and bars
+stars and stripes
+stickpin
+strand
+streamer
+subbase
+surbase
+sword knot
+taffeta weave
+tail fin
+tapestry
+tassel
+tattoo
+tau cross
+tetraskele
+tetraskelion
+thumb
+tie clip
+tie tack
+tiepin
+tore
+torus
+totem
+tracery
+tricolor
+tricolour
+trim
+trimming
+trinket
+triskele
+triskelion
+trumpery
+twill weave
+union
+union flag
+union jack
+vermiculation
+waft
+wall hanging
+weave
+wedding band
+wedding ring
+white flag
+wind bell
+wind chime
+wreath
+yellow jack

--- a/lists/thing/devices.yml
+++ b/lists/thing/devices.yml
@@ -1,0 +1,3858 @@
+---
+title: Devices and instruments
+category: thing
+description: "Mechanical, electrical, optical, musical, scientific, and technical devices"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+a battery
+abbe condenser
+abbe vertical metroscope
+abney level
+absolute encoder
+accelerator
+accelerometer
+accommodating iol
+accommodating lens implant
+accordion
+accumulator
+accumulator register
+achromatic lens
+ack-ack
+ack-ack gun
+acorn tube
+acoustic delay line
+acoustic device
+acoustic gramophone
+acoustic guitar
+acoustic storage
+acoustic waveguide
+actinometer
+action
+action mechanism
+active matrix screen
+active subwoofer
+actuator
+adapter
+adaptor
+add-in
+adder
+addressing machine
+addressograph
+aeolian harp
+aeolian lyre
+aerial
+aerofoil
+aerogenerator
+afterburner
+agglomerator
+aileron
+air cleaner
+air conditioning
+air filter
+air gun
+air hammer
+air pump
+air rifle
+air spring
+air thermometer
+airbrake
+aircraft engine
+airfoil
+airplane propeller
+airscrew
+aladdin's lamp
+alarm
+alarm system
+alcohol thermometer
+alcohol-in-glass thermometer
+algometer
+alidad
+alidade
+allen screw
+alligator clip
+alphanumeric display
+altazimuth
+alternator
+altimeter
+amati
+american organ
+ammeter
+ammonia clock
+analog clock
+analog computer
+analog watch
+analog-digital converter
+analog-to-digital converter
+analogue computer
+analyser
+analytical balance
+analyzer
+anastigmat
+anastigmatic lens
+anchor
+anchor light
+and circuit
+and gate
+andiron
+android
+anemoclinometer
+anemograph
+anemometer
+aneroid
+aneroid barometer
+angioscope
+angle bracket
+angle iron
+angle vise
+anglo-german concertina
+ankle brace
+ankus
+annunciator
+anode
+anovulant
+answering machine
+antenna
+anti-sway bar
+anti-torque rotor
+antiaircraft
+antiaircraft gun
+appliance
+applicator
+applier
+aqualung
+arbalest
+arbalist
+arc lamp
+arc light
+arch support
+archaeological planning frame
+arm
+armature
+armrest
+arquebus
+array
+arrester
+arrester hook
+arrow
+arthroscope
+artificial heart
+artificial horizon
+artificial joint
+artificial kidney
+artificial pacemaker
+asdic
+aspergill
+aspersorium
+asphyxiator
+aspirator
+assagai
+assault rifle
+assegai
+assembly
+astatic coils
+astatic galvanometer
+astrolabe
+astronomical telescope
+asynchronous motor
+atherodyde
+athodyd
+atlas
+atmometer
+atom smasher
+atomic weapon
+attenuator
+attic fan
+audio
+audio cd
+audio compact disc
+audio recording
+audiometer
+audiotape
+auriscope
+auroscope
+auto-changer
+autocue
+autofocus
+autoinjector
+autoloader
+automated teller
+automated teller machine
+automatic
+automatic choke
+automatic drive
+automatic firearm
+automatic gun
+automatic pilot
+automatic pistol
+automatic rifle
+automatic teller
+automatic teller machine
+automatic transmission
+automatic weapon
+automaton
+automobile battery
+automobile engine
+automobile horn
+autopilot
+auxiliary engine
+auxiliary pump
+auxiliary storage
+ax head
+axe head
+axial flow turbine
+axial turbine
+axis
+axis of rotation
+b battery
+b-flat clarinet
+baby grand
+baby grand piano
+baby's dummy
+back
+back brace
+backbench
+backboard
+backhoe
+backrest
+backscratcher
+backseat
+backstay
+backsword
+bacteria bed
+bagger
+bagpipe
+bait
+balalaika
+balance
+balance wheel
+baling press
+balk
+ball and chain
+ball bearing
+ball valve
+ballast
+ballast resistor
+ballcock
+ballista
+ballistic galvanometer
+ballistocardiograph
+balloon seat
+baluster
+banderilla
+bandoneon
+banjo
+bar magnet
+bar printer
+barbeque
+baritone
+baritone horn
+barograph
+barrel knot
+barrel organ
+barrette
+barretter
+base
+bass
+bass clarinet
+bass drum
+bass fiddle
+bass horn
+bass viol
+basset horn
+basset oboe
+bassoon
+bathometer
+bathymeter
+battery charger
+batting machine
+battle sight
+baulk
+bayonet
+bb
+bb gun
+bb shot
+bbs
+beam balance
+beam scale
+bearing
+bearing wall
+beating-reed instrument
+becket bend
+beckman thermometer
+bedpost
+bedspring
+beeper
+bell push
+bell seat
+bellows
+bellpull
+bellyband
+belt buckle
+bench clamp
+bench hook
+bench lathe
+bench press
+bessemer converter
+betatron
+bevatron
+bevel gear
+bicycle clip
+bicycle parking rack
+bicycle pump
+bicycle rack
+bicycle seat
+bicycle stand
+bicycle wheel
+bier
+bifocals
+big board
+big dipper
+big hand
+bike parking rack
+bike stand
+bilge keel
+bilge pump
+billiard marker
+bimetallic strip
+binocular microscope
+bioarm
+biochip
+biological weapon
+bioscope
+bioweapon
+biprism
+birch rod
+bird feeder
+bird shot
+birdcall
+birth control device
+bistable relay
+bite plate
+bitt
+bitt pin
+blackwall hitch
+blanching machine
+blank revolver
+blasting cap
+blinker
+block and tackle
+blood knot
+blow molding machine
+blow moulding machine
+blowback
+blower
+blunderbuss
+board rule
+boat whistle
+boatswain's chair
+bobbin
+bobby pin
+body plethysmograph
+boehm flute
+bofors gun
+bollard
+bollock
+bolometer
+bolt
+bolt thrower
+bolus hook
+bomb calorimeter
+bomb rack
+bombard
+bombardon
+bombsight
+bones
+bongo
+bongo drum
+booby trap
+book binding machine
+book matches
+bookend
+boomerang
+booster
+booster cable
+booster rocket
+booster unit
+bootjack
+boron chamber
+boron counter tube
+bosun's chair
+bottle capper
+bouncing betty
+bourdon
+bow and arrow
+bowed stringed instrument
+bowknot
+bowl chopper
+bowl cutter
+bowline
+bowline knot
+box beam
+box girder
+box spring
+brace
+braces
+bracing
+bracket
+brad
+brake
+brake band
+brake pad
+brake shoe
+brake system
+brakes
+brand
+brasier
+brass instrument
+brass knuckles
+brass knucks
+brass monkey
+brazier
+break seal
+breaker
+breathalyser
+breathalyzer
+breathing apparatus
+breathing device
+breathing machine
+breechloader
+bren
+bren gun
+brick machine
+brick-making machine
+brick-molding machine
+bricole
+bridge circuit
+bridged-t
+bridgework
+briefcase computer
+broaching machine
+broad arrow
+broadcaster
+brochette
+bronchoscope
+browning automatic rifle
+browning machine gun
+brushing machine
+bubble jet printer
+bubblejet
+bubbler
+bucket seat
+buckle
+buckshot
+buffer storage
+buffer store
+buffing wheel
+bug
+buggy whip
+bugle
+bulb
+bulb syringe
+bull fiddle
+bull's-eye
+bulldog clip
+bullet
+bulletin board system
+bullock block
+bumper
+bumper guard
+bun divider
+bun rounder
+buret
+burette
+burglar alarm
+burp gun
+bursting explosive
+busbar
+butt shaft
+butterfly valve
+button accordion
+buzz saw
+buzzer
+bypass capacitor
+bypass condenser
+c battery
+c flute
+cadmium cell
+caesium clock
+calcium light
+calculating machine
+calender
+caller id
+calliope
+calliper
+calorimeter
+cam
+camera lens
+camera lucida
+camera tripod
+candelabra
+candelabrum
+candle holder
+candlestick
+candy thermometer
+cane
+cangue
+cannonball
+cantilever
+cantle
+cap screw
+capacitance
+capacitive sensor
+capacitor
+capacitor microphone
+capacitor mike
+capping machine
+capstan
+car battery
+car horn
+car mirror
+car seat
+car wheel
+carabiner
+carbine
+carbon arc
+carbon arc lamp
+carbon filter
+carbonator
+carburetor
+carburettor
+card
+cardiograph
+cardioid microphone
+cardioid mike
+carillon
+carousel
+carpenter's rule
+carpet loom
+carpet tack
+carriage bolt
+carrick bend
+carrick bitt
+carrousel
+cartridge clip
+cartridge ejector
+cartridge extractor
+cartridge fuse
+cartridge holder
+cartridge remover
+cartwheel
+caryatid
+cascabel
+cascade transformer
+cash dispenser
+cash machine
+cassegrainian telescope
+castanets
+caster
+castor
+cat's-paw
+catafalque
+catalytic converter
+catapult
+catch
+catch pen
+catching pen
+cathode
+cathode-ray tube
+catling
+cauterant
+cautery
+cavalry sword
+cd
+cd drive
+cd-r
+cd-rom
+cd-rom drive
+cd-wo
+celesta
+cell
+cello
+cembalo
+cement mixer
+centigrade thermometer
+centrifugal pump
+cervical cap
+cfl
+chain printer
+chains
+changer
+chanter
+character printer
+character-at-a-time printer
+charge-exchange accelerator
+charger
+cheese press
+chemical balance
+chemical weapon
+chemnitzer concertina
+chess clock
+cheval glass
+chime
+chimneypiece
+chin rest
+chinese lantern
+chip
+choke
+choke coil
+choking coil
+chordophone
+chorus pedal
+chronograph
+chronometer
+chronoscope
+chuck
+chum
+church bell
+chute-the-chute
+cider mill
+ciderpress
+cigar lighter
+cigarette holder
+cigarette lighter
+cine projector
+circle
+circuit
+circuit board
+circuit breaker
+circuit card
+cither
+cithern
+citole
+cittern
+clack
+clack valve
+clapper
+clapper valve
+clappers
+clarinet
+clarion
+clark cell
+clark standard cell
+clasp
+clavichord
+clavier
+claw
+claw clip
+claxon
+claymore mine
+clepsydra
+clevis
+click
+client
+clinch
+clinical thermometer
+clinometer
+clip
+clip lead
+clip-on
+clockwork
+closed circuit
+closeup lens
+clothes hanger
+clothes peg
+clothespin
+clout
+clout nail
+clove hitch
+club head
+clutch
+coal cutter
+coal tongs
+coaster brake
+coat button
+coat hanger
+coax
+coax cable
+coaxial cable
+cobalt machine
+cobbler's last
+cockcroft and walton accelerator
+cockcroft and walton voltage multiplier
+cockcroft-walton accelerator
+cockcroft-walton voltage multiplier
+coelostat
+coffee filter
+coffee grinder
+coffee mill
+cogwheel
+coil spring
+coin machine
+cold cathode
+collator
+collector
+collet
+collet chuck
+collider
+collimator
+colonoscope
+color television tube
+color tube
+color tv tube
+colorimeter
+colour television tube
+colour tube
+colour tv tube
+colposcope
+colt
+colter
+column
+comber
+combination lock
+combine
+comforter
+commutator
+compact disc
+compact disc read-only memory
+compact disc recordable
+compact disc write-once
+compact disk
+compact fluorescent light
+compact mirror
+compander
+compass card
+compound lens
+compound microscope
+compressor
+computer circuit
+computer display
+computer keyboard
+computer memory
+computer monitor
+computer screen
+computer storage
+computing device
+computing machine
+concave lens
+concert grand
+concert piano
+concertina
+concrete mixer
+concrete vibrator
+condensation pump
+condenser
+condenser microphone
+condenser mike
+condensing turbine
+conducting wire
+conductor
+cone clutch
+cone friction clutch
+constraint
+contact lens
+contact microphone
+contact mike
+contrabass
+contrabassoon
+contrafagotto
+contraption
+contrivance
+control
+control board
+control circuit
+control grid
+control panel
+control surface
+controller
+convector
+convenience
+converging lens
+converter
+convertor
+convex lens
+coolant system
+cooling
+cooling system
+cooling tower
+copyholder
+cor anglais
+corbel
+corbel step
+corbie-step
+core blower
+core memory
+core shooter
+core shooting machine
+corer
+corker
+corner post
+cornet
+corrective
+corrugated fastener
+cosmotron
+cottar
+cotter
+cotter pin
+cotton gin
+cottrell precipitator
+coude system
+coude telescope
+coulisse
+coulter
+counter tube
+coupler
+coupling
+cover song
+cover version
+cowbell
+cowhide
+cpu board
+crane
+craniometer
+crease
+creasing machine
+creese
+crimper
+cringle
+cromorne
+crookes radiometer
+crookes tube
+cross thwart
+crossbar
+crossbeam
+crossbench
+crosspiece
+crosstie
+crow step
+crown lens
+crownwork
+crt
+crt screen
+cruet-stand
+cruise control
+crumhorn
+crusher
+cryocautery
+cryometer
+cryoscope
+cryostat
+cryptograph
+crystal counter
+crystal microphone
+crystal mike
+crystal oscillator
+crystal pickup
+crystal rectifier
+cucking stool
+cuckoo clock
+culdoscope
+cullender
+cultivator
+culverin
+cupid's bow
+curet
+curette
+curler
+current collector
+currycomb
+cursor
+cutlas
+cutoff
+cyclotron
+cylinder lock
+cylinder press
+cylinder separator
+cymbal
+cymograph
+daisy print wheel
+daisy wheel
+daisywheel printer
+dampener
+damper
+damper block
+dark glasses
+dark lantern
+dark-field microscope
+dart
+dart thrower
+dash-pot
+dashboard
+dasymeter
+dat
+data converter
+data link
+data multiplexer
+data processor
+davit
+davy lamp
+dc motor
+deaf-aid
+death bell
+death chair
+death chamber
+death knell
+death seat
+declinometer
+decoder
+decoy
+dedicated file server
+deflector
+defroster
+deicer
+delay line
+delayed action
+delayed blowback
+delimber
+dematting comb
+demister
+demodulator
+demulen
+denitrator
+densimeter
+densitometer
+dental appliance
+dental handpiece
+dental implant
+dental plate
+denture
+depressor
+depth finder
+depth gage
+depth gauge
+dermatome
+derrick
+derringer
+desktop
+desktop computer
+detector
+detent
+detonating device
+detonating fuse
+detonator
+device
+dialog box
+dialysis machine
+dialyzer
+diapason
+diapason stop
+diaphanoscope
+diaphone
+diaphragm
+diathermy machine
+dicer
+dickey-seat
+dickie-seat
+dicky-seat
+diesel
+diesel engine
+diesel hammer
+diesel motor
+diesel pile hammer
+diestock
+differential
+differential analyzer
+differential gear
+diffraction grating
+diffuser
+diffusing screen
+diffusion pump
+diffusor
+digger
+digital audiotape
+digital clock
+digital computer
+digital display
+digital plethysmograph
+digital scanner
+digital voltmeter
+digital-analog converter
+digital-to-analog converter
+digitiser
+digitizer
+dilater
+dilator
+dimmer
+dinner bell
+diode
+dip
+dip circle
+dip switch
+dipole
+dipole antenna
+dipped-beam headlamp
+dipstick
+direct injection diesel
+direct injection diesel engine
+directional antenna
+directional microphone
+directional mike
+dirt sifter
+disc brake
+disc drive
+disc harrow
+discharge lamp
+dish aerial
+dish antenna
+disk brake
+disk cache
+disk clutch
+disk controller
+disk drive
+disk harrow
+diskette
+display adapter
+display adaptor
+display board
+display panel
+disrupting explosive
+distributer
+distributor
+distributor cam
+dive brake
+diverging lens
+divider
+dna chip
+dobereiner's lamp
+dog
+dog-iron
+dongle
+donkey engine
+donkey pump
+door latch
+doorbell
+doorjamb
+doorknocker
+doorlock
+doornail
+doorpost
+doorsill
+doorstep
+doorstop
+doorstopper
+doppler radar
+dosemeter
+dosimeter
+dot printer
+double bass
+double bassoon
+double reed
+double-reed instrument
+doubler
+douche
+douche bag
+dough sheeter
+dowel
+dowel pin
+drafting instrument
+drag-cup motor
+dragnet
+dragunov
+drain basket
+drawing machine
+drawing pin
+dredge
+dress hanger
+dress rack
+drift net
+drive line
+drive line system
+driving beam headlamp
+driving wheel
+drone pipe
+drop forge
+drop hammer
+drop press
+dropper
+drum brake
+drum memory
+drum monitor
+drum printer
+drum sander
+dry battery
+dry cell
+dry fly
+dry-bulb thermometer
+dual inline package switch
+dual scan display
+dubbing
+duck shot
+ducking stool
+dulciana
+dulcimer
+dumbwaiter
+dumdum
+dumdum bullet
+dumpy level
+duodiode
+durometer
+dvd
+dynamic loudspeaker
+dynamic microphone
+dynamic speaker
+dynamo
+dynamometer
+ear trumpet
+early warning radar
+earphone
+earpiece
+easel
+echelon
+echo sounder
+echocardiograph
+echoencephalograph
+echograph
+eductor-jet pump
+effects unit
+egg candler
+egg timer
+eightpenny nail
+ejection seat
+ejector
+ejector seat
+elastic band
+elastic device
+electric battery
+electric bell
+electric cell
+electric circuit
+electric clock
+electric cord
+electric drill
+electric eye
+electric fire
+electric hammer
+electric heater
+electric lamp
+electric light
+electric meter
+electric motor
+electric organ
+electric switch
+electric thermometer
+electric typewriter
+electric-discharge lamp
+electric-light bulb
+electrical cable
+electrical circuit
+electrical condenser
+electrical converter
+electrical device
+electrical distributor
+electrical fuse
+electrical relay
+electrical shunt
+electrical switch
+electro-acoustic transducer
+electrocardiograph
+electrode
+electrodynamometer
+electroencephalograph
+electrograph
+electrolytic
+electrolytic capacitor
+electrolytic cell
+electrolytic condenser
+electromagnet
+electromagnetic delay line
+electromagnetic transducer
+electromechanical device
+electromechanical transducer
+electrometer
+electromyograph
+electron accelerator
+electron gun
+electron microscope
+electron multiplier
+electron tube
+electronic balance
+electronic bulletin board
+electronic computer
+electronic converter
+electronic device
+electronic drum set
+electronic instrument
+electronic musical instrument
+electronic organ
+electronic stylus
+electronic transistor
+electronic voltmeter
+electrophorus
+electroscope
+electrostatic generator
+electrostatic machine
+electrostatic precipitator
+electrostatic printer
+emergency
+emergency brake
+emery wheel
+emitter
+encephalograph
+endoscope
+energiser
+energizer
+energy-saving light
+energy-saving light bulb
+engine
+enginery
+english cavalry saddle
+english concertina
+english horn
+english saddle
+enovid
+entanglement
+enteroscope
+epee
+epicyclic gear
+epicyclic gear train
+epicyclic train
+epidiascope
+epitrochoidal engine
+eprom
+equatorial
+erasable programmable read-only memory
+erecting prism
+ergometer
+eriometer
+escape
+escape valve
+escape wheel
+escapement
+esophagoscope
+ethernet cable
+eudiometer
+euphonium
+evaporative cooler
+evaporometer
+excavator
+exercise device
+exercycle
+exhaust fan
+exhaust valve
+expander
+expansion bolt
+explosive device
+external drive
+external storage
+external-combustion engine
+extinguisher
+extirpator
+extractor
+eye dropper
+eyeglass
+eyeglasses
+eyelet
+eyepiece
+face pack
+factory whistle
+fae
+fahrenheit thermometer
+fail-safe
+fairlead
+fairy light
+false teeth
+fan
+fan blade
+fanjet
+fanjet engine
+farm machine
+fascia
+fastener
+fastening
+fathometer
+feedback circuit
+feedback loop
+feeder
+fence charger
+fence energizer
+fencing sword
+fender
+ferris wheel
+ferule
+fet
+fetoscope
+fetter
+fiber optic cable
+fiber optic microphone
+fiberscope
+fibre optic cable
+fiddle
+field coil
+field glass
+field glasses
+field lens
+field magnet
+field winding
+field-effect transistor
+field-emission microscope
+fife
+fifth wheel
+figure eight
+figure loom
+figure of eight
+figured-fabric loom
+filament
+filature
+file server
+filling
+film advance
+film projector
+filter
+filter bed
+filter press
+filter tip
+fin
+finder
+fine-tooth comb
+fine-toothed comb
+finger cymbals
+fipple flute
+fipple pipe
+fire alarm
+fire bell
+fire extinguisher
+fire ship
+fire tongs
+firearm
+firedog
+firelock
+firing mechanism
+firing pin
+first
+first gear
+fish lure
+fisherman's bend
+fisherman's knot
+fisherman's lure
+fisheye lens
+fishing net
+fishnet
+fixed disk
+fixed storage
+fixed-gear drivetrain
+fixing
+flack
+flagellum
+flageolet
+flak
+flambeau
+flamethrower
+flaps
+flare
+flash memory
+flasher
+flashlight battery
+flat knot
+flat panel display
+flatbed press
+flatwork ironer
+flax brake
+flex harrow
+flexible harrow
+flexible sigmoidoscope
+flight indicator
+flight simulator
+flintlock
+flip-flop
+flipagram
+float-type rain gage
+float-type rain gauge
+floating mine
+flocculator
+flood
+flood lamp
+floodgate
+floodlight
+floor joist
+floppy
+flour mill
+flow meter
+flue pipe
+flue stop
+fluegelhorn
+flugelhorn
+fluid drive
+fluid flywheel
+fluorescent lamp
+fluorescent screen
+flute
+flux applicator
+fluxmeter
+fly frame
+fly press
+flying drainpipe
+flytrap
+flywheel
+foetoscope
+foghorn
+foglamp
+foil
+food elevator
+foot
+foot brake
+foot rule
+football tee
+foothold
+footing
+footlights
+force pump
+forceps
+foreground
+forestay
+forte-piano
+forty-five
+four-stroke engine
+four-stroke internal-combustion engine
+four-wheel drive
+fourpenny nail
+fowling piece
+fpd
+frame buffer
+francis turbine
+franking machine
+free-reed
+free-reed instrument
+freewheel
+freight elevator
+french horn
+fresnel lens
+friction clutch
+friction match
+front bench
+front projector
+front-projection tv
+fruit machine
+fuel cell
+fuel filter
+fuel gauge
+fuel indicator
+fuel-air explosive
+fulcrum
+full beam headlamp
+full metal jacket
+full-wave rectifier
+fumigator
+fuse
+fuse indicator regulator
+fuse setter
+fusee
+fusee drive
+fusil
+fuze
+fuze setter
+fuzee
+gad
+gadget
+gadgetry
+gag
+gage
+galilean telescope
+gallous
+galvanic battery
+galvanic cell
+galvanic pile
+galvanometer
+gamba
+gangsaw
+garand
+garand rifle
+garotte
+gas engine
+gas fixture
+gas gage
+gas gauge
+gas gun
+gas heater
+gas lamp
+gas meter
+gas pump
+gas thermometer
+gas turbine
+gas-discharge lamp
+gas-discharge tube
+gasket
+gasoline bomb
+gasoline engine
+gasoline gage
+gasoline gauge
+gasoline pump
+gastroscope
+gat
+gatepost
+gatling gun
+gauge
+gaussmeter
+gear
+gear lever
+gear mechanism
+gear wheel
+geared wheel
+gearing
+gearmotor
+gearset
+gearshift
+gearstick
+geartrain
+geiger tube
+geiger-muller counter
+geiger-muller tube
+gem clip
+gene chip
+generator
+gibbet
+gig mill
+gill net
+gimbal
+gin
+girandola
+girandole
+girder
+gismo
+gittern
+gizmo
+glass eye
+glockenspiel
+glow lamp
+glow tube
+glowstick
+gnomon
+goad
+goalpost
+goggles
+golf-club head
+gong
+gordian knot
+governor
+grab
+graduate
+graduated cylinder
+grain blower
+grain cleaner
+gran casa
+grand
+grand piano
+grandfather clock
+granny
+granny knot
+granulator
+granulator machine
+grape
+grapeshot
+grapnel
+grapnel anchor
+grating
+gravimeter
+gravity meter
+grease gun
+gregorian telescope
+grind organ
+grinder
+grinding wheel
+gristmill
+grommet
+groover
+ground bait
+ground tackle
+ground-emplaced mine
+groundwater pump
+grummet
+guarnerius
+gudgeon pin
+guest
+guitar pick
+gun microphone
+gun mike
+gun worm
+gunlock
+gunsight
+gunstock
+guy
+guy cable
+guy rope
+guy wire
+gyro
+gyro horizon
+gyrocompass
+gyroscope
+gyrostabiliser
+gyrostabilizer
+hackbut
+haematocrit
+haemostat
+hagbut
+hair clamp
+hair claw
+hair clip
+hair curler
+hair slide
+hairgrip
+hairpin
+hairspring
+half hitch
+hammerhead
+hammond organ
+hand
+hand brake
+hand calculator
+hand glass
+hand mirror
+hand organ
+hand pump
+hand scanner
+hand vise
+hand-held computer
+hand-held microcomputer
+handbell
+handbow
+handcuff
+handgun
+handlock
+handloom
+handrest
+handwheel
+hanger
+hard disc
+hard disk
+harmonica
+harmonium
+harp
+harpoon log
+harpsichord
+harquebus
+harrow
+harvester
+hasp
+hatpin
+hatrack
+hauncher
+haunching machine
+hautbois
+hautboy
+hawaiian guitar
+hawser bend
+hay conditioner
+haymaker
+head gasket
+header
+headlamp
+headlight
+headphone
+headrest
+headset
+headstay
+headstock
+heart valve
+heart-lung machine
+heat engine
+heat exchanger
+heat lamp
+heat sink
+heater
+heating pad
+heckelphone
+helicon
+heliometer
+helm
+hematocrit
+hemodialyzer
+hemostat
+herschelian telescope
+heterodyne oscillator
+hibachi
+high
+high beam headlamp
+high gear
+high hat
+high-hat cymbal
+high-pass filter
+high-warp loom
+hinging post
+hitching post
+hob
+hobber
+hobbing machine
+hobble
+hobby knife
+hobnail
+hodometer
+hodoscope
+hoist
+holder
+holdfast
+holding device
+home computer
+home theater projector
+homing device
+honing machine
+hood latch
+hook and eye
+hooter
+hop pole
+hop-picker
+horizontal stabiliser
+horizontal stabilizer
+horizontal tail
+horn
+horn button
+hornpipe
+horologe
+horse pistol
+horsewhip
+host
+hot pad
+hot seat
+hot-water heater
+hot-water tank
+hotbox
+houdah
+hour hand
+hourglass
+houselights
+howdah
+humanoid
+hunter
+hunting crop
+hunting watch
+hunting whip
+hurdy gurdy
+hurricane lamp
+hurricane lantern
+hydraulic brake
+hydraulic brakes
+hydraulic motor
+hydraulic press
+hydraulic pump
+hydraulic ram
+hydraulic system
+hydraulic transmission
+hydraulic transmission system
+hydroelectric turbine
+hydrogen electrode
+hydrokinetic engine
+hydrometer
+hygrodeik
+hygrometer
+hygroscope
+hypercoaster
+hypo
+hypodermic
+hypodermic syringe
+hypsometer
+i-beam
+ice tongs
+iconoscope
+idle pulley
+idle wheel
+idler pulley
+ied
+igniter
+ignition
+ignition coil
+ignition interlock
+ignition key
+ignition lock
+ignition switch
+ignition system
+ignitor
+image orthicon
+image scanner
+impact printer
+impeller
+implant
+impression
+imprint
+improvised explosive device
+impulse relay
+impulse turbine
+incandescent lamp
+incline
+inclined plane
+inclinometer
+indented cylinder
+indented cylinder separator
+index register
+indicator
+indicator electrode
+indicator lamp
+inductance
+induction accelerator
+induction coil
+induction motor
+inductor
+inflater
+inflator
+information processing system
+infrared lamp
+injector
+inside caliper
+instrument
+instrument of punishment
+instrument panel
+intake valve
+integrated circuit
+integrator
+intercom speaker
+interface
+interferometer
+interlock
+internal drive
+internal-combustion engine
+interocular lens implant
+interrupter
+intraocular lens
+inverter
+iol
+ion engine
+ion pump
+ionization chamber
+ionization tube
+ipad
+iris
+iris diaphragm
+iron boot
+iron collar
+iron heel
+iron lung
+irons
+island dispenser
+jack-o'-lantern
+jacket
+jacket crown
+jackhammer
+jacklight
+jacquard loom
+jamb
+jarvik artificial heart
+jarvik heart
+jaw
+jet engine
+jew's harp
+jeweler's glass
+jeweler's loupe
+jeweler's vise
+jeweller's vise
+jig
+joggle
+john lennon eyeglasses
+joist
+journal bearing
+jukebox
+jump seat
+jumper cable
+jumper lead
+jumper stay
+junction rectifier
+junction transistor
+kalashnikov
+karabiner
+katharometer
+kazoo
+keel
+keelson
+keep relay
+kenotron
+keratoscope
+kerosene heater
+kerosene lamp
+kerosine heater
+kerosine lamp
+kerr cell
+kettledrum
+keyboard buffer
+keyboard instrument
+keyboard shelf
+keyboard tray
+keypad
+khukuri
+kick start
+kick starter
+kicksorter
+kiley
+kindjal
+kinescope
+kinetoscope
+king post
+kingbolt
+kirpan
+kitchen match
+klavier
+klaxon
+klieg light
+klystron
+knee brace
+knitting machine
+knocker
+knot
+knout
+knuckle duster
+knuckles
+knucks
+konimeter
+koto
+kris
+krummhorn
+kundt's tube
+kylie
+kymograph
+l-beam
+labial pipe
+lacemaking machine
+ladder-back
+lag bolt
+lag screw
+lagerphone
+lally
+lally column
+laminating machine
+lamppost
+lancet
+land mine
+landing flap
+landing gear
+landing net
+landing skid
+lantern pinion
+lantern wheel
+laparoscope
+lapping machine
+laptop computer
+laryngoscope
+laser
+laser interferometer
+lashing
+last
+latch
+latching relay
+latchkey
+laugh track
+launcher
+lcd
+lead-acid accumulator
+lead-acid battery
+lead-in
+leaf spring
+leash
+leclanche cell
+led
+leiden jar
+lennon specs
+lens
+lens implant
+lens system
+lense
+lever lock
+lever scale
+leyden jar
+licorice stick
+lidar
+lie detector
+lift
+lift pump
+lifting device
+light
+light arm
+light ballast
+light circuit
+light filter
+light fitting
+light fixture
+light machine gun
+light microscope
+light pen
+light source
+light-emitting diode
+lighting circuit
+lightning arrester
+lightning conductor
+lightning rod
+lightstick
+limelight
+limiter
+limnimeter
+linac
+linchpin
+line
+line printer
+line-at-a-time printer
+linear accelerator
+linear-quadratic-gaussian controller
+link trainer
+linkup
+linotype
+linotype machine
+lintel
+lion-jaw forceps
+liquid crystal display
+lister cultivator
+little hand
+lo/ovral
+lobster pot
+local memory
+local oscillator
+lochaber ax
+lock washer
+lockring
+loestrin
+log
+logic element
+logic gate
+long seax
+longcase clock
+looking glass
+loom
+loop
+loop knot
+lorgnette
+loud hailer
+loudspeaker
+loudspeaker system
+loupe
+love knot
+lovers' knot
+low
+low beam headlamp
+low gear
+low-pass filter
+low-warp-loom
+lp
+lqg controller
+lucifer
+luger
+luggage carrier
+luggage rack
+luminaire
+luminescent screen
+lure
+lute
+lynchpin
+lyre
+m-1 rifle
+machete
+machine bolt
+machine gun
+machine pistol
+machine rifle
+machine screw
+machine tool
+machinery
+machining center
+machinist's vise
+machmeter
+mag tape
+magazine rack
+magic eye
+magic lantern
+magnet
+magnetic bubble memory
+magnetic compass
+magnetic core memory
+magnetic disc
+magnetic disk
+magnetic drum
+magnetic head
+magnetic mine
+magnetic needle
+magnetic stripe
+magnetic tape
+magneto
+magneto-dynamic microphone
+magneto-optical disc
+magnetoelectric machine
+magnetograph
+magnetometer
+magnetostrictive speaker
+magnetron
+magnifier
+magnus hitch
+mailsorter
+main beam headlamp
+main rotor
+mainframe computer
+mainspring
+mainstay
+maksutov telescope
+male plug
+manacle
+mandola
+mandolin
+mangonel
+manometer
+mantel
+mantelpiece
+mantlepiece
+mantrap
+maraca
+marimba
+marine mine
+mariner's compass
+mason's level
+mass spectrograph
+mass spectrometer
+master key
+match
+matchet
+matchlock
+matrix printer
+matthew walker
+matthew walker knot
+mauser
+maxim gun
+maximum and minimum thermometer
+maypole
+measuring device
+measuring instrument
+measuring rod
+measuring stick
+measuring system
+meat grinder
+meat thermometer
+mechanical device
+mechanical man
+mechanical piano
+mechanical press
+mechanism
+medical instrument
+meeting beam headlamp
+melody pipe
+membrane filter
+membranophone
+memory
+memory board
+memory cache
+memory chip
+memory device
+menorah
+mercury barometer
+mercury cell
+mercury thermometer
+mercury-in-glass clinical thermometer
+mercury-in-glass thermometer
+mercury-vapor lamp
+merry-go-round
+metal screw
+metal spinning lathe
+metalworking vise
+meter
+meterstick
+metrestick
+mic
+microbalance
+microchip
+microcircuit
+microcomputer
+microdevice
+microfinishing machine
+microhoning machine
+micrometer
+micrometer caliper
+micrometer gauge
+micronor
+microphotometer
+microprocessor
+microprocessor chip
+microsensor
+microtome
+microwave diathermy machine
+microwave linear accelerator
+microwave radar
+mike
+mileometer
+miller
+milliammeter
+milling machine
+milling machinery
+millivoltmeter
+millwheel
+milometer
+mine
+mine detector
+minicalculator
+minicomputer
+minute gun
+minute hand
+mixing faucet
+mod con
+modicon
+modillion
+module
+moistener
+moldboard
+molecular pump
+molotov cocktail
+monitor speaker
+monitoring device
+monocle
+monocular microscope
+monofocal iol
+monofocal lens implant
+monostable relay
+monotype
+monotype caster
+monotype keyboard
+mooring anchor
+mother board
+motor
+motor horn
+mouldboard
+mouse
+mouse button
+mouse-tooth forceps
+mousetrap
+mouth bow
+mouth harp
+mouth organ
+movement
+movie projector
+moving-coil galvanometer
+moving-coil loudspeaker
+moving-coil microphone
+muffler
+multifocal iol
+multifocal lens implant
+multiplexer
+multiprocessor
+musette
+musette pipe
+mushroom anchor
+music rack
+music stand
+musical box
+musical instrument
+musket
+musket ball
+mute
+muzzle
+muzzle loader
+n-type semiconductor
+nail
+nand circuit
+nand gate
+nanomachine
+napier's bones
+napier's rods
+nasal aspirator
+nasal syringe
+navigation light
+navigational instrument
+neck brace
+needle bearing
+negative feedback circuit
+neon induction lamp
+neon lamp
+neon tube
+nephoscope
+nest egg
+network bridge
+newel
+newel post
+newtonian reflector
+newtonian telescope
+nicad
+nickel-cadmium accumulator
+nickel-iron accumulator
+nickel-iron battery
+nickelodeon
+nicol prism
+night bell
+night latch
+night-light
+node
+noisemaker
+non-dedicated file server
+non-volatile storage
+nondirectional antenna
+nor-q-d
+noria
+norinyl
+norlestrin
+nose flute
+nosepiece
+nosewheel
+notebook
+notebook computer
+nuclear rocket
+nuclear weapon
+number cruncher
+nut and bolt
+o ring
+oarlock
+object glass
+object lens
+objective
+objective lens
+oboe
+oboe d'amore
+oboe da caccia
+obturator
+ocarina
+octant
+ocular
+odd-leg caliper
+odometer
+oedometer
+oesophagoscope
+off-axis reflector
+offset press
+ohmmeter
+oil filter
+oil heater
+oil lamp
+oil pump
+oilstove
+oled
+omnidirectional antenna
+on-off switch
+onager
+one-armed bandit
+open circuit
+open sight
+opera glasses
+operating microscope
+ophthalmoscope
+optical condenser
+optical device
+optical disc
+optical disk
+optical instrument
+optical lens
+optical maser
+optical prism
+optical pyrometer
+optical scanner
+optical telescope
+or circuit
+or gate
+orchestral bells
+organ
+organ pipe
+organ stop
+organic light-emitting diode
+organiser
+organizer
+orograph
+orthicon
+orthodontic braces
+orthoscope
+oscillator
+otoscope
+outboard
+outboard motor
+outrigger
+outside caliper
+outside mirror
+oven thermometer
+overdrive
+overhand knot
+overmantel
+override
+ovocon
+ovral
+ovrette
+ovulen
+oximeter
+oxygen mask
+p-n-p transistor
+p-type semiconductor
+pacemaker
+pacifier
+packsaddle
+paddlewheel
+padlock
+page printer
+page turner
+page-at-a-time printer
+pair of tongs
+pair of virginals
+pandean pipe
+panel
+panel light
+panga
+panic button
+panoramic sight
+panpipe
+pantograph
+paper fastener
+paper feed
+paper jogger
+parabolic mirror
+parabolic reflector
+parabolograph
+paraboloid reflector
+parallel circuit
+parallel interface
+parallel port
+paramagnet
+pari-mutuel machine
+parking brake
+parlor grand
+parlor grand piano
+parlour grand
+parlour grand piano
+partial denture
+partisan
+partizan
+passing beam headlamp
+passive matrix display
+passive subwoofer
+passkey
+patchcord
+patent log
+paternoster
+paving machine
+pavior
+paviour
+pawl
+pc
+pc board
+pda
+peacekeeper
+peacemaker
+pedestal
+pedometer
+peeler
+peep sight
+peg
+pegleg
+pellet
+pelvimeter
+pen mouse
+pendulum clock
+pendulum watch
+penile implant
+penlight
+pennywhistle
+pentode
+pepper grinder
+pepper mill
+perch
+percussion cap
+percussion instrument
+percussive instrument
+periscope
+permanent magnet
+perpetual motion machine
+personal digital assistant
+personal organiser
+personal organizer
+petard
+petcock
+petrol bomb
+petrol engine
+petrol gage
+petrol gauge
+petrol pump
+phillips screw
+phone cord
+phone jack
+phone plug
+phonograph
+phonograph needle
+phonograph record
+phonograph recording
+photocathode
+photocell
+photochromic eyeglasses
+photochromic eyewear
+photochromic glasses
+photocoagulator
+photoconductive cell
+photoelectric cell
+photoflood
+photoheliograph
+photovoltaic cell
+piano accordion
+piano action
+piano damper
+piano keyboard
+pianoforte
+pianola
+pibgorn
+piccolo
+pick-me-up
+pickup
+pickup arm
+picture tube
+piece
+pier glass
+pier mirror
+piezometer
+pilaster
+pile driver
+piling
+piling hammer
+pillar
+pillion
+pillow block
+pilot lamp
+pince-nez
+pincurl clip
+pinger
+pinion
+pinion and crown wheel
+pinion and ring gear
+pintle
+pipe
+pipe clamp
+pipe organ
+pipe rack
+pipe vise
+pipet
+pipette
+pipework
+pistol
+pistol grip
+piston
+piston ring
+pistonphone
+pitch pipe
+pitfall
+pitot
+pitot head
+pitot tube
+pitot-static tube
+pivot
+plane seat
+plane table
+planet gear
+planet wheel
+planetary gear
+planimeter
+planing machine
+planner
+planning frame
+plaster machine
+plastering machine
+plastic blow molding machine
+plastic blow moulding machine
+plate and frame filter press
+plate compactor
+plate filter press
+plate rack
+platinum thermometer
+platter
+player piano
+plectron
+plectrum
+plethysmograph
+plotter
+ploughshare
+plowshare
+plug fuse
+plug-in
+plunger
+plutonium pit
+plutonium trigger
+pluviometer
+pneumatic hammer
+pocket lighter
+pocket mirror
+pocket watch
+pocketcomb
+point-contact diode
+pointer
+polarimeter
+polariscope
+pole weapon
+polearm
+poleax
+poleaxe
+polisher
+polishing machine
+polygraph
+pom-pom
+poniard
+poppet
+poppet valve
+port
+portable
+portable circular saw
+portable computer
+portable saw
+portrait lens
+positioner
+post horn
+postage meter
+potential divider
+potentiometer
+pothook
+potter's wheel
+pound net
+power brake
+power cable
+power cord
+power hammer
+power line
+power loom
+power meter
+power pack
+power saw
+power shovel
+power steering
+power takeoff
+power tool
+power train
+power-assisted steering
+precipitator
+precision rifle
+predictor
+press
+press stud
+pressure gage
+pressure gauge
+preventative
+preventive
+primary
+primary cell
+primary coil
+primary winding
+print buffer
+printed circuit
+printer cable
+printing machine
+printing press
+prism
+prism spectroscope
+probe
+proctoscope
+prod
+projectile
+prolonge knot
+prompter
+prop
+propeller
+propellor
+proportional counter
+proportional counter tube
+prosthesis
+prosthetic device
+proton accelerator
+proton synchrotron
+psaltery
+psychrometer
+pto
+pull
+pull chain
+pullback
+pulley
+pulley-block
+pulse counter
+pulse generator
+pulse height analyzer
+pulse timing circuit
+pump
+pump action
+punch press
+punkah
+purse seine
+push
+push button
+push-down storage
+push-down store
+put-put
+pyrometer
+pyrometric cone
+pyroscope
+pyrostat
+quadrant
+quaker gun
+quarrel
+quartz lamp
+quartz oscillator
+queen post
+quern
+quipu
+quirt
+qwerty keyboard
+rabbit ears
+rachet
+rack
+rack and pinion
+radar
+radial engine
+radiation pyrometer
+radiator
+radio aerial
+radio antenna
+radio detection and ranging
+radio interferometer
+radio reflector
+radio telescope
+radiolocation
+radiometer
+radiomicrometer
+radius
+rafter
+railroad tie
+rain gage
+rain gauge
+rain stick
+ram disk
+ramjet
+ramjet engine
+ramp
+random memory
+random-access memory
+range pole
+rangefinder
+ranging pole
+rapper
+ratan
+ratch
+ratchet
+ratchet wheel
+rattan
+rattrap
+rayleigh disk
+reaction engine
+reaction turbine
+reaction-propulsion engine
+read-only memory
+read-only memory chip
+read-only storage
+read/write head
+read/write memory
+readout
+real storage
+reaper
+reaper binder
+rear lamp
+rear light
+rearview mirror
+reaumur thermometer
+reciprocating engine
+record
+record changer
+recorder
+recording
+rectifier
+rectifier diode
+rectifying tube
+rectifying valve
+reduction gear
+reed
+reed instrument
+reed organ
+reed pipe
+reed stop
+reef knot
+reel
+reflecting telescope
+reflectometer
+reflector
+refracting telescope
+refractometer
+refrigeration system
+regulator
+reinforcement
+relay
+release
+relief valve
+remote
+remote control
+removable disk
+rendering machine
+repeater
+repeating firearm
+repulsor
+repulsorlift
+repulsorlift engine
+reset
+reset button
+resistance pyrometer
+resistance thermometer
+resistor
+resonant circuit
+rest
+restorative
+restraint
+resuscitator
+retainer
+retarded blowback
+retractor
+retrorocket
+reverse
+reverse gear
+reversing thermometer
+revolver
+rheometer
+rheostat
+rhinoscope
+rib
+riddle
+ride
+rider plate
+ridge
+ridgepole
+riding bitt
+riding crop
+riding lamp
+riding light
+rifle
+rifle ball
+riot gun
+riser
+rivet
+riveter
+riveting machine
+rivetter
+robot pilot
+rochon prism
+rocker
+rocket
+rocket engine
+rod
+roller bearing
+roller coaster
+roller ironer
+roller ski
+rolling hitch
+rom
+roof rack
+rooftree
+room light
+roost
+rotary
+rotary actuator
+rotary converter
+rotary encoder
+rotary engine
+rotary harrow
+rotary press
+rotary wing
+rotating mechanism
+rotor
+rotor blade
+rotor coil
+rotor head
+rotor shaft
+roulette
+round
+round shot
+roundabout
+roving frame
+rowel
+rowlock
+rubber band
+rubber bullet
+rudder
+rudder blade
+rudderpost
+rudderstock
+rule
+rumble
+rumble seat
+rundle
+rung
+runner
+running light
+rush candle
+rushlight
+saber
+saber saw
+sackbut
+saddle
+saddle seat
+safe
+safety
+safety arch
+safety catch
+safety device
+safety fuse
+safety lamp
+safety match
+safety valve
+sailor's breastplate
+salinometer
+samisen
+sander
+sandglass
+sash fastener
+sash lock
+saturday night special
+sausage maker
+sausage stuffer
+sawdust stove
+sawed-off shotgun
+sawing machine
+sax
+saxhorn
+saxophone
+scaler
+scalpel
+scantling
+scape
+scattergun
+schmidt camera
+schmidt telescope
+school bell
+scientific instrument
+scintillation counter
+sclerometer
+sconce
+scourge
+scramasax
+scramaseax
+scramsax
+scratcher
+scratchpad
+screen background
+screw
+screw eye
+screw log
+screw press
+screw propeller
+screw thread
+scribing block
+scroll saw
+scsi
+scuba
+scutching machine
+sea anchor
+seal bomb
+sealing wax
+searchlight
+searing iron
+seat
+seax
+second
+second gear
+second hand
+secondary
+secondary cell
+secondary coil
+secondary storage
+secondary winding
+sector
+security
+security measure
+security system
+seed cleaner
+seed sprouter
+seeker
+segway
+segway ht
+segway human transporter
+seine
+selector
+selector switch
+selenium cell
+self-feeder
+self-loader
+self-registering thermometer
+self-starter
+semiautomatic
+semiautomatic firearm
+semiautomatic pistol
+semiconductor
+semiconductor device
+semiconductor diode
+semiconductor unit
+sensing element
+sensor
+serial port
+serial printer
+series circuit
+service elevator
+set gun
+setscrew
+seventy-eight
+sextant
+shackle
+shades
+shaft encoder
+shamisen
+shaper
+shaping machine
+shawm
+sheath pile
+sheep bell
+sheepshank
+sheet anchor
+sheet bend
+sheet pile
+sheet piling
+shelf
+shelf bracket
+shepherd's pipe
+shift register
+shifter
+shim
+shirt button
+shiv
+shock
+shock absorber
+shoe
+shoe bomb
+shoehorn
+shoemaker's last
+shoetree
+shofar
+shooting iron
+shooting stick
+shop bell
+shophar
+shore
+shoring
+shortwave diathermy machine
+shot
+shotgun
+shotgun microphone
+shotgun mike
+shoulder vise
+shunt
+shunt circuit
+shunt dc motor
+shunt wound dc motor
+shutting post
+shuttle
+side arm
+side drum
+side sill
+side-fill monitor
+sidelight
+sidesaddle
+sieve
+sifter
+sight setting
+sights
+sigmoidoscope
+signaling device
+silencer
+silicon chip
+sill
+simple machine
+simple microscope
+simplex machine
+simulator
+single-reed instrument
+single-reed woodwind
+siren
+sitar
+six-gun
+six-shooter
+sixpenny nail
+size stick
+skeg
+skeleton key
+skewer
+ski
+ski binding
+ski jump
+ski rack
+skid
+slapstick
+slasher
+sleigh bell
+slide action
+slide fastener
+slide rule
+slide valve
+sliding seat
+slip clutch
+slip friction clutch
+slipknot
+slipstick
+slit lamp
+slow match
+slow-burning stove
+slug
+sluice valve
+sluicegate
+small computer system interface
+small-arm
+smoke alarm
+smoothbore
+smoother
+snap
+snap fastener
+snap ring
+snare
+snare drum
+snatch block
+sniper rifle
+snow thrower
+snowshoe
+soda carbonator
+soda maker
+sodium-vapor lamp
+sodium-vapour lamp
+soil sifter
+solar array
+solar battery
+solar cell
+solar collector
+solar dish
+solar furnace
+solar heater
+solar panel
+solar telescope
+solebar
+solenoid
+solid propellant rocket
+solid-fuel rocket
+solid-propellant motor
+sonar
+sonic delay line
+sonic depth finder
+sonograph
+sonometer
+sordino
+sorter
+soshnik
+sound recording
+sound spectrograph
+sounder
+soundtrack
+source of illumination
+sourdine
+sousaphone
+space rocket
+spandau
+spare
+spark coil
+spark plug
+sparking plug
+speaker system
+speaker unit
+speaking trumpet
+spear thrower
+specs
+spectacles
+spectrometer
+spectrophotometer
+spectroscope
+speculum
+speech synthesizer
+speed frame
+speed indicator
+speedometer
+spermatocide
+spermicide
+spherometer
+sphygmomanometer
+spice rack
+spicemill
+spider web
+spider's web
+spigot
+spike arrester
+spike microphone
+spike mike
+spike suppressor
+spindle
+spinet
+spinner
+spinning frame
+spinning jenny
+spinning machine
+spinning wheel
+spiral spring
+spirit lamp
+spirograph
+spirometer
+spit
+spitball
+splicer
+splint
+spoiler
+spoke
+sponge filter
+spool
+spotlight
+spray gun
+spreader
+spreader beam
+spring
+spring balance
+spring gun
+spring scale
+sprocket wheel
+sprouter
+spur gear
+spur wheel
+spyglass
+square knot
+squawk box
+squawker
+squeeze box
+squelch
+squelch circuit
+squelcher
+squirrel-cage motor
+stabiliser
+stabilitron
+stabilizer
+stabilizer bar
+stack
+stacker crane
+stactometer
+staddle
+stage monitor
+stair
+stake
+stalagmometer
+stalogometer
+stamper
+stamping machine
+stanchion
+standard cell
+standard transmission
+standing press
+staple
+stapling machine
+starter motor
+starting motor
+static magnet
+static tube
+stator
+stator coil
+statoscope
+stave
+stay
+stay relay
+steam ejector
+steam engine
+steam injector
+steam jet ejector
+steam organ
+steam shovel
+steam turbine
+steam whistle
+steel drum
+steel guitar
+steel trap
+steelyard
+steering gear
+steering linkage
+steering mechanism
+steering system
+steering wheel
+stem-winder
+stemmer
+sten gun
+stenograph
+step
+step-down transformer
+step-up transformer
+stepper
+stepping motor
+stereoscope
+sternpost
+stethoscope
+stick shift
+sticker
+stiffener
+stile
+stiletto
+stilt
+stirrup
+stirrup iron
+stirrup pump
+stock
+stock saddle
+stock ticker
+stockhorn
+stoker
+stomach pump
+stone splitter
+stone splitting machine
+stool pigeon
+stopcock
+stopper knot
+stopping
+stopwatch
+storage
+storage battery
+storage cell
+storage device
+store
+storm lamp
+storm lantern
+stove
+stove bolt
+strad
+stradavarius
+straight fairlead
+straight pin
+straightener
+strain gage
+strain gauge
+strainer
+strap
+streamer fly
+street lamp
+strengthener
+striker
+string
+string bass
+stringed instrument
+stringer
+strip lighting
+strobe
+strobe light
+stroboscope
+stroke delimber
+structural member
+strut
+stub nail
+stud
+stun baton
+stun gun
+stylus printer
+sub-assembly
+submachine gun
+submersible groundwater pump
+subtracter
+subtractor
+suction blower
+suction cup
+suction pump
+sueding machine
+sump pump
+sun gear
+sun heater
+sundial
+sunglass
+sunlamp
+sunray lamp
+supercharger
+supercomputer
+superconducting supercollider
+superfinishing machine
+supply chamber
+support
+support column
+suppresser
+suppressor
+surface
+surface condenser
+surface gage
+surface gauge
+surge suppressor
+surgeon's knot
+surgical instrument
+surgical knife
+surgical suction pump
+surgical vacuum pump
+surveying instrument
+surveyor's instrument
+surveyor's level
+swaging machine
+sweatbox
+sweep hand
+sweep-second
+sweet potato
+swinging post
+switch
+swivel
+swivel pin
+synchrocyclotron
+synchroflash
+synchroniser
+synchronizer
+synchronoscope
+synchronous converter
+synchronous motor
+synchroscope
+synchrotron
+synthesiser
+syringe
+syrinx
+system clock
+t-network
+t-scope
+t-square
+tablet computer
+tabor
+tabor pipe
+tabour
+tabulating machine
+tabulator
+tach
+tacheometer
+tachistoscope
+tachograph
+tachometer
+tachymeter
+tacker
+taffrail log
+tail lamp
+tail rotor
+taillight
+tailplane
+tailstock
+take-up
+takeoff booster
+takeoff rocket
+talking book
+tam-tam
+tambour
+tambourine
+tank circuit
+tannoy
+tape drive
+tape recording
+tape transport
+tapeline
+taper
+taping
+tawse
+taximeter
+tea-strainer
+teaser
+teething ring
+telamon
+telegraph line
+telegraph pole
+telegraph post
+telegraph wire
+telemeter
+telephone bell
+telephone cord
+telephone dial
+telephone jack
+telephone plug
+telephone pole
+telephone receiver
+telephone wire
+telephoto lens
+teleprinter
+teleprompter
+telescope sight
+telescopic sight
+telethermometer
+teletype machine
+teletypewriter
+television antenna
+television pickup tube
+television tube
+television-camera tube
+telex
+telex machine
+tenor drum
+tenoroon
+tenpenny nail
+tensimeter
+tensiometer
+tent peg
+tenterhook
+tesla coil
+test paper
+tether
+tetrode
+textile machine
+the boot
+theater light
+theodolite
+thermal resistor
+thermel
+thermionic tube
+thermionic vacuum tube
+thermionic valve
+thermistor
+thermocompressor
+thermocouple
+thermocouple junction
+thermoelectric thermometer
+thermograph
+thermogravimeter
+thermohydrometer
+thermometer
+thermometrograph
+thermopile
+thermoregulator
+thermostat
+third gear
+thole
+tholepin
+thompson submachine gun
+thrasher
+three-dimensional radar
+three-point switch
+three-way switch
+thresher
+threshing machine
+threshold
+threshold element
+threshold gate
+throstle
+throttle
+throttle valve
+throw stick
+throwing board
+throwing stick
+thrust bearing
+thruster
+thumbtack
+thunderer
+thwart
+ticker
+ticket-stamping machine
+tickler coil
+tidemark
+tie
+tie beam
+tie rack
+tie-in
+tieback
+tiller
+tilter
+timber
+timber hitch
+timbrel
+time-delay measuring instrument
+time-delay measuring system
+time-fuse
+time-switch
+timekeeper
+timepiece
+timer
+timpani
+tin whistle
+tine harrow
+tine weeder
+tintack
+tintometer
+toastrack
+tocsin
+toehold
+toggle
+toggle bolt
+toggle switch
+tom-tom
+tommy gun
+tone arm
+tongs
+tongue
+tongue depressor
+tonograph
+tonometer
+toothed wheel
+tornado lantern
+torque converter
+torsion balance
+totalisator
+totaliser
+totalizator
+totalizer
+touch screen
+touring ski
+towel horse
+trace detector
+traction trebuchet
+trainer
+trammel
+trammel net
+transcription
+transducer
+transistor
+transit
+transit declinometer
+transit instrument
+transmission
+transmission line
+transmission system
+transmitting aerial
+transom
+transponder
+transporter
+transverse flute
+trave
+traverse
+trawl
+trawl net
+tread
+treadmill
+treadwheel
+treble recorder
+trebuchet
+trebucket
+treenail
+trenail
+trench knife
+trephine
+triangle
+tricolor television tube
+tricolor tube
+tricolour television tube
+tricolour tube
+trigon
+trimmer
+trimmer joist
+trimming capacitor
+triode
+trip
+triphammer
+tripod
+tripper
+trivet
+troll
+trombone
+trouser clip
+true lover's knot
+truelove knot
+trump
+trumpet
+trundle
+trunnel
+truss
+tuba
+tuck
+turbine
+turbofan
+turbofan engine
+turbogenerator
+turbojet engine
+turing machine
+turk's head
+turnbuckle
+turncock
+turning and boring mill
+turnspit
+turret clock
+tv-antenna
+tweeter
+twenty-two
+twenty-two pistol
+twenty-two rifle
+two-by-four
+tympan
+tympani
+tympanum
+typesetting machine
+typewriter
+typewriter carriage
+typewriter keyboard
+udometer
+uke
+ukulele
+ultramicroscope
+ultrasonic flaw detector
+ultrasonic pulse analyzer
+ultrasonic pulse velocity tester
+ultrasound scanner
+ultraviolet lamp
+ultraviolet source
+undercarriage
+universal
+universal joint
+upright
+upright piano
+uzi
+vacuum gage
+vacuum gauge
+vacuum pump
+vacuum tube
+vaginoscope
+valve
+valve-in-head engine
+van de graaff generator
+vane
+vaporiser
+vaporizer
+variable resistor
+variable-pitch propeller
+variometer
+vascular conduit
+vascular prosthesis
+vdu
+vending machine
+venetian mirror
+ventilator
+venturi tube
+verey pistol
+vernier
+vernier caliper
+vernier micrometer
+vernier scale
+vertical
+vertical fin
+vertical flute
+vertical stabiliser
+vertical stabilizer
+vertical tail
+very pistol
+vibes
+vibraharp
+vibraphone
+vibrating reed
+vibratory hammer
+vibratory pile hammer
+vibratory plate compactor
+vice
+victrola
+video
+video display
+video recording
+videodisc
+videodisk
+videotape
+viewer
+viewfinder
+vigil candle
+vigil light
+viol
+viola
+viola d'amore
+viola da braccio
+viola da gamba
+violin
+violoncello
+virginal
+virtual memory
+virtual storage
+viscometer
+viscosimeter
+visual display unit
+voix celeste
+volatile storage
+voltage divider
+voltage regulator
+voltaic battery
+voltaic cell
+voltaic pile
+voltmeter
+volumeter
+volute spring
+von neumann machine
+voting machine
+vouge
+vox angelica
+vox humana
+vulcaniser
+vulcanizer
+wagon wheel
+waist anchor
+wall bracket
+wall clock
+wall plate
+wankel engine
+wankel rotary engine
+warmer
+warning bell
+warning device
+warper
+warping machine
+washer
+waste baler
+watch key
+water back
+water clock
+water cooler
+water filter
+water gage
+water gate
+water gauge
+water glass
+water heater
+water level
+water meter
+water mill
+water pump
+water ski
+waterwheel
+wattmeter
+waveguide
+wax light
+weapon
+weapon of mass destruction
+weapon system
+weather radar
+weathercock
+weatherglass
+weathervane
+weaver's hitch
+weaver's knot
+web
+weighbridge
+weighing machine
+weldment
+western concert flute
+western saddle
+weston cell
+wet cell
+wet fly
+wet-bulb thermometer
+whaling gun
+wheatstone bridge
+wheel and axle
+wheel fiddle
+wheel lathe
+wheel lock
+wheel spoke
+wheelwork
+whirler
+whirligig
+whistle
+wide-angle lens
+widget
+wiggle nail
+wimshurst machine
+winch
+winchester
+winchester drive
+wind gage
+wind gauge
+wind generator
+wind harp
+wind instrument
+wind tee
+wind turbine
+wind vane
+winder
+windlass
+windmill
+window lock
+windowsill
+windscreen wiper
+windshield wiper
+windsor eyeglasses
+windsor knot
+windsor spectacles
+windsors
+winepress
+wiper
+wiper blade
+wiper motor
+wire gage
+wire gauge
+wire matrix printer
+wire printer
+wiring
+withe
+wmd
+wollaston prism
+wood vise
+wooden leg
+woodscrew
+woodwind
+woodwind instrument
+woodworking vise
+woofer
+workhorse
+workstation
+worm
+worm gear
+worm wheel
+wrist pin
+wristwatch
+writing arm
+x-or circuit
+x-ray tube
+xerographic printer
+xor gate
+xylometer
+xylophone
+yagi
+yagi aerial
+yard donkey
+yard measure
+yarder
+yardstick
+yataghan
+zamboni
+zapper
+zarf
+zenerdiode
+zero
+zill
+zip
+zip fastener
+zip gun
+zither
+zithern
+zoom lens

--- a/lists/thing/equipment.yml
+++ b/lists/thing/equipment.yml
@@ -1,0 +1,621 @@
+---
+title: Equipment
+category: thing
+description: "Specialized apparatus, installations, kits, and operational gear"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acoustic modem
+adsorber
+aerator
+air jacket
+air search radar
+apishamore
+apparatus
+appurtenance
+artificial satellite
+astronomy satellite
+atmoradiograph
+atomic pile
+atomic reactor
+audio amplifier
+audiovisual
+audiovisual aid
+autoalarm
+automation
+auxiliary equipment
+backlighting
+badminton equipment
+balance beam
+ball
+ballistic capsule
+ballistic pendulum
+bar bit
+bar mask
+barbell
+bard
+bars
+baseball bat
+baseball equipment
+baseball glove
+baseball mitt
+basketball backboard
+basketball equipment
+basketball hoop
+bathyscape
+bathyscaph
+bathyscaphe
+bathysphere
+batting cage
+beam
+billiard ball
+billiard table
+bird
+birdcage mask
+birdie
+bishop
+bitewing
+black
+black box
+blister pack
+blowlamp
+blowtorch
+blue chip
+bocce ball
+bocci ball
+boccie ball
+boiling water reactor
+boob tube
+booster amplifier
+booster station
+bowling ball
+bowling equipment
+bowling pin
+box camera
+box kodak
+boxing equipment
+boxing glove
+brassie
+breeches buoy
+breeder reactor
+bridle
+bridoon
+bromide paper
+brooder
+bubble pack
+bunsen
+bunsen burner
+burner
+bwr
+cage
+calorisator
+calorizator
+candid camera
+candlepin
+caparison
+cardiac monitor
+carpenter's kit
+cascade liquefier
+cassette recorder
+cat cracker
+cat scanner
+catalytic cracker
+catcher's mask
+cathode-ray oscilloscope
+cd burner
+cellphone
+cellular phone
+cellular telephone
+central processing unit
+central processor
+centrifuge
+chain reactor
+chappe telegraph
+checker
+chemical reactor
+chequer
+chess piece
+chessman
+chinese puzzle
+chromatograph
+cinch
+cine-camera
+cine-film
+circuitry
+clapperboard
+clay pigeon
+climber
+climbing equipment
+climbing iron
+clock pendulum
+clock radio
+coffey still
+communications satellite
+compact-disk burner
+compound pendulum
+computer peripheral
+computerized axial tomography scanner
+cork jacket
+cpu
+crampon
+crampoon
+cricket ball
+cricket bat
+cricket equipment
+cro
+croquet ball
+croquet equipment
+croquet mallet
+crown jewels
+crystal detector
+crystal set
+cue ball
+curb bit
+curling stone
+cytophotometer
+data input device
+defecator
+desk phone
+developer
+dial phone
+dial telephone
+direction finder
+discus
+disinfector
+diving bell
+drill rig
+drilling platform
+drilling rig
+driver
+driving iron
+drogue
+drogue chute
+drogue parachute
+duckpin
+dumbbell
+duplicator
+eight ball
+electrical system
+electron lens
+electronic equipment
+electronic fetal monitor
+electronic foetal monitor
+electronic scanner
+engine cooling system
+enlarger
+episode
+equipment
+etna
+exerciser
+exercising weight
+exposure meter
+extension
+extension phone
+facsimile
+facsimile machine
+fancam
+fast reactor
+fax
+fetal monitor
+field hockey ball
+figure skate
+film
+fire control radar
+first base
+first-aid kit
+fishing gear
+fishing rig
+fishing tackle
+five iron
+flash
+flash camera
+flash lamp
+flashbulb
+flashgun
+flotation device
+fluoroscope
+foetal monitor
+footage
+foucault pendulum
+free weight
+freeze-dryer
+french telephone
+fuel system
+fusion reactor
+game
+game equipment
+gas bracket
+gas burner
+gas jet
+gas maser
+gas ring
+gas-cooled reactor
+girth
+glove
+goal
+goggle box
+golf ball
+golf club
+golf equipment
+golf tee
+golfcart
+goniometer
+gumshield
+gun pendulum
+gym mat
+gymnastic apparatus
+gymnastic horse
+hackamore
+halter
+hame
+handball
+handset
+harness
+headgear
+headpin
+heart monitor
+heat pump
+hectograph
+heliograph
+heliotype
+heterodyne receiver
+high bar
+hockey skate
+hockey stick
+home plate
+hoop
+horizontal bar
+horse
+horse blanket
+horsecloth
+housing
+hughes telegraph
+i/o device
+ice ax
+ice axe
+ice skate
+impedimenta
+in-line skate
+incubator
+input device
+input/output device
+instillator
+iphone
+jackstones
+jammer
+jigsaw puzzle
+job-oriented terminal
+kingpin
+kipp's apparatus
+kit
+lacrosse ball
+lander
+layette
+lem
+liebig condenser
+life belt
+life buoy
+life preserver
+life ring
+life support
+life vest
+life-support system
+lifesaver
+light meter
+lighting
+link-attached station
+link-attached terminal
+liquid metal reactor
+lithograph
+lithograph machine
+long horse
+long iron
+lumber
+lunar excursion module
+lunar module
+mae west
+magnetic recorder
+mainframe
+man
+marching order
+maser
+mashie
+mashie niblick
+materiel
+medicine ball
+memory apparatus
+mess kit
+metal wood
+meteorological satellite
+metronome
+microfiche
+microfilm
+midiron
+mimeo
+mimeograph
+minisub
+minisubmarine
+mitt
+mnemometer
+mobile phone
+motion-picture camera
+motion-picture film
+movie camera
+movie film
+multichannel recorder
+naval equipment
+naval radar
+negative
+niblick
+nine iron
+ninepin
+ninepin ball
+nuclear reactor
+number one wood
+object ball
+off-line equipment
+offshore rig
+oilrig
+one iron
+optical bench
+optical telegraph
+orbiter
+orthochromatic film
+oscillograph
+outfit
+output device
+oxyacetylene torch
+packaging
+paintball gun
+panchromatic film
+paper tape reader
+parachute
+parallel bars
+paraphernalia
+parasail
+pasteuriser
+pasteurizer
+pawn
+pay-station
+pelham
+pendulum
+peripheral
+peripheral device
+pet scanner
+photocopier
+photoflash
+photographic camera
+photographic equipment
+photographic film
+photographic material
+photographic paper
+photometer
+photostat
+photostat machine
+phototelegraph
+physical pendulum
+pile
+pilot burner
+pilot light
+pin table
+pinball machine
+pine-tar rag
+ping-pong ball
+piolet
+pitcher's mound
+pitching wedge
+piton
+playback
+playground ball
+point-and-shoot camera
+poker chip
+polaroid camera
+polo ball
+polo mallet
+polo stick
+pommel horse
+pool ball
+pool table
+portrait camera
+positive
+positron emission tomography scanner
+preserver
+pressurized water reactor
+pricket
+processor
+punch bag
+punchball
+punched paper tape reader
+punched tape reader
+punching bag
+punching ball
+purifier
+push-button radio
+putter
+putting iron
+puzzle
+pwr
+quaffle
+quoit
+racing skate
+racquetball
+radio compass
+radio receiver
+radio set
+radio transmitter
+radio-gramophone
+radio-phonograph
+radiophone
+radiotelephone
+radiotherapy equipment
+reactor
+receiver
+receiving set
+receiving system
+recording equipment
+recording machine
+reflex camera
+reflux condenser
+reformer
+regalia
+relay link
+relay station
+relay transmitter
+remote station
+remote terminal
+rescue equipment
+rigging
+robotics equipment
+rock-climbing equipment
+roentgenoscope
+roll
+roll film
+roller skate
+rollerblade
+roneo
+roneograph
+roofing
+rook
+roulette ball
+roulette wheel
+rugby ball
+saddle blanket
+saddlecloth
+saddlery
+sand wedge
+satellite
+satellite receiver
+satellite transmitter
+saucer
+scintigraph
+scintiscanner
+scope
+scrambler
+scrubber
+second base
+semaphore
+semaphore telegraph
+sender
+sensitometer
+separator
+sequenator
+sequence
+sequencer
+set
+setup
+seven iron
+sewing kit
+shooter
+short iron
+short-stop
+short-stop bath
+shuttlecock
+side horse
+simple pendulum
+skate
+skittle
+skittle ball
+skittle pin
+snaffle
+snaffle bit
+snooker table
+soccer ball
+soda fountain
+softball
+sound camera
+sound film
+space capsule
+space laboratory
+space platform
+space shuttle
+space station
+space vehicle
+spacecraft
+spaceship
+spark transmitter
+speakerphone
+speed skate
+spike
+sports equipment
+sputnik
+spy satellite
+squash ball
+stable gear
+stall bar
+starfighter
+starship
+stock-in-trade
+stop bath
+superhet
+superheterodyne receiver
+surface search radar
+tackle
+tangram
+tape deck
+tape machine
+tape player
+tape reader
+tape recorder
+target
+taw
+teaching aid
+technology
+tee
+telegraph
+telegraphy
+telephone
+telephone extension
+telephone set
+television camera
+television equipment
+television monitor
+television receiver
+television set
+television transmitter
+telly
+tennis ball
+tenpin
+test equipment
+thermal reactor
+thermonuclear reactor
+third
+third base
+titrator
+tomograph
+tool kit
+torch
+trampoline
+transmitter
+trapping
+tuner
+tv camera
+tv monitor
+tv set
+two iron
+ultracentrifuge
+uneven bars
+uneven parallel bars
+vaulting horse
+via ferrata set
+video equipment
+videocassette recorder
+volleyball net
+water wings
+water-cooled reactor
+weather satellite
+whirling table
+white
+wiffle
+wiffle ball
+wire recorder
+wireless telephone
+wrestling mat
+x-ray film
+xerographic copier
+xerox
+xerox machine
+yoke

--- a/lists/thing/implements.yml
+++ b/lists/thing/implements.yml
@@ -1,0 +1,868 @@
+---
+title: Implements
+category: thing
+description: "Hand tools, utensils, controls, and practical implements"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abradant
+abrader
+abrading stone
+accelerator pedal
+adjustable spanner
+adz
+adze
+agateware
+allen key
+allen wrench
+alligator wrench
+alpenstock
+archimedean drill
+ard
+ard plough
+ax
+axe
+axe-hammer
+axle
+axle bar
+axletree
+backsaw
+backspace
+backspace key
+backspacer
+badminton racket
+badminton racquet
+baking form
+baking mold
+baking mould
+baking tray
+ballpen
+ballpoint
+ballpoint pen
+barge pole
+barong
+baster
+bastinado
+bat
+baton
+battle-ax
+battledore
+beading plane
+bearing rein
+beater
+beetle
+belaying pin
+bender
+besom
+bevel
+bevel square
+billy
+billy club
+billystick
+biro
+bit
+blackboard eraser
+blade
+blade bit
+blanking die
+blanking punch
+blind axle
+block plane
+bludgeon
+blunt file
+boat hook
+boat paddle
+bodkin
+bolo
+bolo knife
+bolt cutter
+bone china
+boom
+bootstrap
+bore bit
+borer
+bottle screw
+bottlebrush
+bowie knife
+bowsprit
+box end wrench
+box wrench
+brace wrench
+brake pedal
+branding iron
+bread knife
+breast drill
+bricklayer's hammer
+bristle brush
+broad hatchet
+broadax
+broadaxe
+bucksaw
+buff
+buffer
+bull tongue
+bulldog wrench
+bullnose
+bullnosed plane
+bumper jack
+bur
+burin
+burnisher
+burnishing tool
+burr
+burr drill
+butcher knife
+buttonhook
+caber
+cake mold
+cake mould
+cake tin
+camshaft
+candlesnuffer
+cant dog
+cant hook
+cap opener
+carpenter's hammer
+carpenter's level
+carpenter's mallet
+carpenter's plane
+carpenter's saw
+carpenter's square
+carpet beater
+carpet sweeper
+carriage wrench
+carving knife
+case knife
+cattle brush
+center bit
+centre bit
+ceramic ware
+chafing dish
+chain tongs
+chain wrench
+chalk
+chamfer bit
+chamfer plane
+charcoal
+checkrein
+cheekpiece
+cheese cutter
+cheese knife
+cheese plane
+cheese slicer
+chin strap
+china
+chinning bar
+chisel
+chopper
+chopper knife
+chopping knife
+church key
+cigar cutter
+circular plane
+clasp knife
+claw hatchet
+clayware
+cleaning device
+cleaning equipment
+cleaning implement
+cleaning pad
+cleaver
+clincher
+clipper
+cloisonne
+clothes tree
+clothesbrush
+clutch pedal
+coal shovel
+coat stand
+coat tree
+combination plane
+command key
+common ax
+common axe
+compass plane
+compass saw
+compound lever
+connecting rod
+control key
+control rod
+control stick
+cooker
+cookie cutter
+cookie sheet
+cooking pan
+cooking utensil
+cookware
+copperware
+core
+core bit
+core drill
+corkscrew
+cosh
+counterbore
+countersink
+countersink bit
+cow brush
+crackle china
+crackleware
+crank
+crank handle
+crankshaft
+crayon
+crescent wrench
+crimping pliers
+crochet hook
+crochet needle
+crock pot
+crook
+cross bit
+crosscut handsaw
+crosscut saw
+crosse
+crotchet
+croupier's rake
+crown saw
+crupper
+crutch
+cue
+cue stick
+cup hook
+cutoff saw
+cutter
+cutting implement
+cutting tool
+cyclostyle
+dado plane
+darning needle
+dayton ax
+dayton axe
+dead axle
+deadbolt
+delft
+dentist's drill
+dibber
+dibble
+disc plough
+disc plow
+distaff
+ditch spade
+divining rod
+dog hook
+dog wrench
+dolphin striker
+double boiler
+double saucepan
+double-bitted ax
+double-bitted axe
+double-furrow plough
+double-furrow plow
+doubletree
+dovetail plane
+dovetail saw
+dowser
+dowsing rod
+drawbar
+drawing chalk
+drawknife
+drawshave
+drilling bit
+dripping pan
+driveshaft
+driving axle
+drove
+drove chisel
+drumstick
+dry mop
+dry point
+dustmop
+dutch hoe
+earthenware
+edge tool
+edger
+egg cracker
+eggbeater
+eggwhisk
+electric baking pan
+electric frying pan
+ellwand
+embroidery needle
+enamelware
+entrenching tool
+eolith
+eraser
+expansion bit
+expansive bit
+faience
+feed steamer
+felt tip
+felt-tip pen
+felt-tipped pen
+fence rail
+fencing stick
+fiddlestick
+fineliner
+fineliner pen
+fire hook
+fire iron
+fireman's ax
+fireman's axe
+firmer chisel
+fish slice
+fishgig
+fishhook
+fishing rod
+fishtail bit
+fizgig
+flagstaff
+flat file
+flat tip screwdriver
+flick-knife
+fly rod
+flyswat
+flyswatter
+folding saw
+food turner
+foot lever
+foot pedal
+fore plane
+fore-topmast
+foremast
+foreyard
+fountain pen
+fret
+frypan
+fusain
+gaff
+gang
+gang plough
+gang plow
+garden rake
+garden spade
+garden tool
+garden trowel
+gardening knife
+gas
+gas pedal
+gavel
+gimlet
+glass cutter
+gouge
+grab bar
+graniteware
+grappler
+grappling hook
+grappling iron
+grater
+graver
+graving tool
+grid
+griddle
+gridiron
+grindstone
+gun
+gun trigger
+hair trigger
+half hatchet
+hammer axe
+hand ax
+hand axe
+hand drill
+hand mixer
+hand mower
+hand shovel
+hand throttle
+hand tool
+handheld drill
+handlebar
+handspike
+harpoon
+hatchel
+hatchet
+hayfork
+heaver
+heckle
+hedge trimmer
+hex key
+hitching bar
+hitchrack
+hoof pick
+hook
+hook spanner
+hook wrench
+hunting knife
+hypodermic needle
+icepick
+icing syringe
+implement
+inbus key
+inbus wrench
+indian club
+ink eraser
+jack
+jack plane
+jackknife
+jackscrew
+jaws of life
+jemmy
+jibboom
+jigger
+jiggermast
+jim crow
+jimmy
+jointer plane
+jointing plane
+journal
+juice reamer
+jury mast
+kickstand
+kitchen utensil
+kitchenware
+knife blade
+knitting needle
+knobkerrie
+knobkerry
+lash
+latchet
+latchstring
+lathee
+lathi
+lawn tool
+lead pencil
+leading rein
+leather strip
+ledger board
+leister
+lever
+linoleum cutter
+linoleum knife
+linstock
+liquidiser
+liquidizer
+lister
+lister plough
+lister plow
+live axle
+locking pliers
+long plane
+long-handled spade
+lopper
+loud pedal
+lug wrench
+lumberman's saw
+lusterware
+magic marker
+mahlstick
+main yard
+main-topmast
+mainmast
+maiolica
+majolica
+malacca
+malacca cane
+mandril
+marlinespike
+marlingspike
+marlinspike
+martingale
+masher
+mason's trowel
+mast
+match plane
+matchstick
+mattock
+maul
+maulstick
+meat cleaver
+meat hook
+meat mixer
+metal saw
+microphone boom
+middle buster
+middlebreaker
+mincer
+mincing machine
+mitre box
+mizenmast
+mizzen-topmast
+mizzenmast
+moldboard plow
+monkey-wrench
+motor mower
+mouldboard plough
+mower
+moxa roll
+moxa stick
+multiple-furrow plough
+multiple-furrow plow
+nailbrush
+nailfile
+needle bar
+neolith
+nightstick
+noseband
+nut key
+nut tool
+nutcracker
+oar
+omelet pan
+omelette pan
+open-end wrench
+opener
+openside plane
+packing needle
+paddle
+pair of pincers
+pair of pliers
+pair of scissors
+pair of tweezers
+paleolith
+pancake turner
+paper cutter
+paper knife
+parang
+parer
+paring knife
+patty-pan
+peavey
+peavy
+pedal
+pencil eraser
+pencil sharpener
+penknife
+percussor
+pestle
+pick
+pick-mattock
+pickax
+picture rail
+pikestaff
+pilot bit
+pin wrench
+pincer
+pinch bar
+pingpong paddle
+pipe cleaner
+piston rod
+pitchfork
+pitsaw
+planetary mixer
+plasterer's float
+plastering trowel
+plate rail
+plessor
+plexor
+plough
+plow
+plumb level
+plumber's helper
+plumber's snake
+plyers
+pocketknife
+pointel
+pointing trowel
+pointrel
+poker
+pole
+pool cue
+pool stick
+popper
+posthole digger
+pottery
+pounder
+power mower
+pricker
+pruner
+pruning hook
+pruning knife
+pruning saw
+pruning shears
+pry
+pull-through
+pump-type pliers
+punch
+punch pliers
+puncher
+push broom
+quill
+quill pen
+rabbet plane
+racket
+racquet
+rail
+rails
+ram
+rammer
+ramrod
+rasp
+rat-tail file
+ratchet screwdriver
+ravehook
+razorblade
+reamer
+reap hook
+reaping hook
+red chalk
+rein
+return
+return key
+rib joint pliers
+ricer
+riding mower
+rigger
+rigger brush
+ripping bar
+ripping chisel
+ripsaw
+rivet clincher
+roach holder
+roaster
+rock bit
+rock drill
+rocker arm
+roller bit
+rotating shaft
+round file
+rounder
+router plane
+royal mast
+royal yard
+rubber eraser
+rug beater
+s wrench
+sable
+sable brush
+sable's hair pencil
+safety bolt
+safety lock
+safety razor
+salamander
+samian ware
+sandblaster
+sanguine
+sap
+saw set
+scauper
+scoop shovel
+scorper
+scouring pad
+scraper
+scratch awl
+scratch plough
+screw auger
+screw jack
+screw key
+screw wrench
+scribe
+scriber
+scrub brush
+scrub plane
+scrubbing brush
+scuffle
+scuffle hoe
+scythe
+secateurs
+seeder
+server
+set chisel
+set square
+sewing needle
+shaft
+shaping tool
+sharp
+sharpener
+shaver
+shaving brush
+shaving cutter
+shear
+shears
+sheath knife
+shepherd's crook
+shift
+shift key
+shillalah
+sickle
+single-furrow plough
+single-furrow plow
+singlestick
+sketcher
+ski pole
+skillet
+skimmer
+skyhook
+slate pencil
+sledge
+slice
+slice bar
+slicer
+slick
+slide bolt
+sliding bolt
+slip-joint pliers
+slug cutter
+smooth plane
+smoothing plane
+snake
+snips
+snuffer
+snuffers
+soap pad
+socket wrench
+soft pedal
+sokha
+space bar
+spade
+spade bit
+spanner
+spar
+spark lever
+sparkplug wrench
+spatula
+spider
+spinning rod
+spiral ratchet screwdriver
+split rail
+splitsaw
+spode
+spokeshave
+sponge mop
+sports implement
+sprit
+spud
+squash racket
+squash racquet
+squeegee
+squeezer
+staff
+stair-rod
+stand mixer
+star drill
+starter
+starting handle
+steel-wool pad
+stewing pan
+stewpan
+stick
+stick moxa
+stillson wrench
+stirrer
+stob
+stone drill
+stoneware
+stove poker
+straight flute
+straight razor
+straight-fluted drill
+straightedge
+street broom
+strickle
+strop
+stump spud
+style
+stylus
+supplejack
+sustaining pedal
+swab
+swage
+swagger stick
+swatter
+sweep
+sweep oar
+sweeper
+swingletree
+switchblade
+switchblade knife
+swizzle stick
+swob
+sword cane
+sword stick
+tab key
+table-tennis bat
+table-tennis racquet
+tack hammer
+tailor's chalk
+tamp
+tamper
+tamping bar
+tap wrench
+taper file
+tappet
+tappet wrench
+tea ball
+telegraph key
+tennis racquet
+terra sigillata
+thill
+thinning shears
+third rail
+threader
+tie rod
+tile cutter
+tin opener
+tire iron
+tire tool
+tonguing and grooving plane
+tonkin cane ski pole
+tonkin ski pole
+tool
+top-gallant yard
+topgallant
+topgallant mast
+topmast
+torsion bar
+towel bar
+towel rail
+trailing axle
+transmission shaft
+trap-and-drain auger
+treadle
+trenching spade
+trepan
+trigger
+truncheon
+tube wrench
+tuning fork
+turner
+tweezer
+twist bit
+twist drill
+two-furrow plough
+two-furrow plow
+two-handed saw
+two-man saw
+unbrako key
+unbrako wrench
+upholstery needle
+upset
+utensil
+valve rocker
+violin bow
+walking stick
+wand
+waterfinder
+wax crayon
+wedgwood
+weed puller
+weed remover
+weed-whacker
+weeder
+western ax
+western axe
+whiffletree
+whippletree
+whipsaw
+whisk
+whisk broom
+wimble
+wire cutter
+wok
+wood file
+woodworking plane
+wrecking bar
+writing implement
+zeta key
+zeta wrench

--- a/lists/thing/layers-and-blocks.yml
+++ b/lists/thing/layers-and-blocks.yml
@@ -1,0 +1,71 @@
+---
+title: Blocks and layers
+category: thing
+description: "Blocks, slabs, ingots, courses, layers, and compact forms"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+backing
+briquet
+briquette
+bullion
+butcher block
+butcher board
+butterfly nut
+cake
+chock
+chopping block
+crosshead
+cube
+damp course
+damp-proof course
+dice
+die
+domino
+five
+five-spot
+four
+four-spot
+hair space
+hex nut
+ice cube
+ingot
+inking pad
+interlayer
+kern
+layer
+locknut
+mount
+nog
+nut
+one-spot
+packing nut
+pig
+ply
+row
+row of bricks
+safety nut
+six
+six-spot
+slab
+space
+square block
+square nut
+stamp pad
+starting block
+stuffing nut
+swage block
+tessella
+tessera
+thumbnut
+tier
+tile
+top lift
+type
+wedge
+wing nut
+wing screw

--- a/lists/thing/objects-and-components.yml
+++ b/lists/thing/objects-and-components.yml
@@ -1,0 +1,401 @@
+---
+title: Objects and components
+category: thing
+description: "General artifacts, fittings, attachments, parts, and miscellaneous components"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+agal
+americana
+anachronism
+anchor chain
+anchor rope
+antiquity
+approach trench
+apron string
+armillary sphere
+artesian well
+attachment
+backbone
+baling wire
+ball-and-socket joint
+balsa raft
+barbed wire
+barbwire
+barrier strip
+bathroom fixture
+becket
+bicycle chain
+bidet tap
+bob
+bobber
+bobfloat
+bola
+bond
+bookmarker
+bootlace
+bore
+bore-hole
+bowstring
+brail
+breaker point
+broad gauge
+bungee
+bungee cord
+burden
+burthen
+butt hinge
+butt joint
+butt weld
+cable
+candlewick
+cap shroud
+carded yarn
+carling float
+catgut
+ceiling dome
+celestial globe
+cesspit
+cesspool
+chain
+chalkpit
+chandelier
+chatelaine
+chenille cord
+cistern
+clews
+clothesline
+coal mine
+coalpit
+comfort station
+communication trench
+cone
+conjunction
+connecter
+connection
+connective
+connector
+connexion
+contact
+contact arm
+copper mine
+cord
+cordage
+counterbalance
+counterpoise
+counterweight
+cut
+dead load
+decker
+delf
+dickey
+dickie
+dicky
+digital subscriber line
+distributor point
+ditch
+dovetail
+dovetail joint
+drainage ditch
+drawing string
+drawstring
+drill hole
+driven well
+dsl
+electrical contact
+electroplate
+equaliser
+equalizer
+excavation
+extra
+fell
+felled seam
+filoselle
+fire trench
+fish joint
+fishing line
+fixture
+flexible joint
+float
+floss
+fluorescent
+fluorescent fixture
+flush toilet
+flushless toilet
+fob
+foot joint
+fosse
+fount
+furrow
+futtock shroud
+gantlet
+gas well
+gash
+goldmine
+gravel pit
+ground cable
+guide rope
+gusher
+gut
+ha-ha
+halliard
+halyard
+handline
+hangman's halter
+hangman's rope
+harpoon line
+haw-haw
+hawser
+haywire
+headfast
+heaving line
+hempen necktie
+high wire
+hinge
+hinge joint
+hot line
+indirect lighting
+insert
+instrumentality
+instrumentation
+intermediate shroud
+ironware
+irrigation ditch
+joint
+joint hinge
+jumper
+junction
+junction barrier
+kitchen sink
+kite tail
+knuckle joint
+kon tiki
+lacing
+ladies' room
+land line
+laniard
+lanyard
+lap joint
+lariat
+lasso
+lastex
+latrine
+lavatory
+lead line
+lemon
+life raft
+lifeline
+ligament
+ligature
+lighting fixture
+lisle
+lisle thread
+live load
+load
+loading
+log line
+mainsheet
+makeweight
+marker
+marline
+means
+melange yarn
+men's
+men's room
+mineshaft
+miter joint
+mitre joint
+moat
+mongrel
+mooring
+mooring line
+mortise joint
+mortise-and-tenon joint
+mystification
+nap
+narrow gauge
+negative pole
+night-line
+oil well
+overburden
+overload
+p-n junction
+packthread
+painter
+paper chain
+paperweight
+party line
+pendant
+pendent
+phone line
+piano wire
+plumb
+plumb line
+plumb rule
+plumbing fixture
+plummet
+point
+pontoon
+pool
+positive pole
+potty chair
+potty seat
+powder room
+private line
+prolonge
+public convenience
+public lavatory
+public toilet
+purse string
+quarry
+rabbet joint
+raft
+railroad
+railroad siding
+railroad track
+railway
+rain barrel
+ratlin
+ratline
+ready-made
+reata
+reef line
+reef point
+reefing line
+relic
+restroom
+riata
+ridge rope
+ripcord
+root cellar
+rope
+rope yarn
+royal brace
+salt mine
+sash cord
+sash line
+sash weight
+scarf joint
+seam
+seizing
+sennit
+setline
+shirtfront
+shoelace
+shoestring
+short
+short circuit
+shot hole
+shoulder cord
+sidetrack
+siding
+silver mine
+sinker
+skip rope
+skipping rope
+slack
+slackline
+slip ring
+slit trench
+small stuff
+snap line
+snorter
+snow chain
+sound bow
+sounding lead
+sounding line
+sphere
+spiller
+splice
+splicing
+spot weld
+spouter
+spun silk
+spun yarn
+squeaker
+standard gauge
+standby
+static line
+stinker
+stone pit
+strap hinge
+streetcar track
+strip mine
+stripper
+stripper well
+subscriber line
+sulfur mine
+sulphur mine
+sump
+sunk fence
+superload
+surgical seam
+suture
+t hinge
+tack
+tangency
+tare
+tee hinge
+telephone circuit
+telephone line
+temporary hookup
+thermojunction
+thing
+tightrope
+tinsel
+tire chain
+toggle joint
+toilet facility
+toll line
+tongue and groove joint
+towing line
+towing rope
+towline
+towrope
+trace
+tramline
+tramway
+transmedium
+trawl line
+trench
+trip line
+trip wire
+trolling line
+trotline
+trunk line
+tube well
+twine
+urinal
+variation
+wading pool
+warp
+wash room
+washstand
+watch chain
+watch guard
+water faucet
+water tap
+wats
+wats line
+weather sheet
+weft
+weight
+weld
+well
+welt
+wick
+wildcat
+wildcat well
+wiper arm
+wire
+wobbler
+woof
+working
+workings
+worsted yarn
+yard marker
+yarn

--- a/lists/thing/padding-and-cushioning.yml
+++ b/lists/thing/padding-and-cushioning.yml
@@ -1,0 +1,58 @@
+---
+title: Padding and cushioning
+category: thing
+description: "Cushions, mattresses, pads, stuffing, and impact-absorbing objects"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+air cushion
+air mattress
+batting
+bed pillow
+beer mat
+bolster
+carpet pad
+curtain airbag
+cushion
+cushioning
+drip mat
+estradiol patch
+falsie
+feather bed
+gaddi
+hassock
+head restraint
+inflatable cushion
+kotex
+lilo
+long pillow
+mattress
+mattress pad
+mouse mat
+padding
+paillasse
+palliasse
+pincushion
+plastron
+potholder
+powderpuff
+rat
+rug pad
+sanitary napkin
+sanitary towel
+seat cushion
+side curtain airbag
+skin patch
+spring mattress
+stuffing
+table mat
+throw pillow
+tick
+transdermal patch
+underfelt
+underlay
+underlayment

--- a/lists/thing/protective-gear.yml
+++ b/lists/thing/protective-gear.yml
@@ -1,0 +1,232 @@
+---
+title: Protective gear
+category: thing
+description: "Armor, shields, guards, housings, canopies, and protective covers"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+aegis
+armet
+armguard
+armor plate
+armor plating
+armour
+armour plate
+astrodome
+baldachin
+barrel vault
+basinet
+beaver
+bell cot
+bell cote
+bell glass
+bell jar
+binding
+binnacle
+birdhouse
+blind
+blinder
+body armor
+body armour
+bonnet
+book binding
+bracer
+brake lining
+brassard
+brolly
+buckler
+bushing
+byrnie
+calash
+calash top
+caleche
+canopy
+casque
+casquet
+casquetel
+cataphract
+chain armor
+chain armour
+chamfron
+chanfron
+cladding
+cloche
+coat of mail
+cold frame
+columbary
+console
+corselet
+corslet
+cote
+cover
+cowl
+cowling
+crankcase
+crystal
+cubitiere
+cuisse
+cupola
+curb roof
+cylindrical lining
+deadlight
+distributor cap
+distributor housing
+doghouse
+dome
+dovecote
+dust cover
+egis
+epauliere
+escutcheon
+face guard
+face mask
+faceplate
+facing
+fallboard
+fencer's mask
+fencing mask
+ferrule
+finger plate
+fingerstall
+fire screen
+fireguard
+french roof
+frontstall
+full plate armour
+furnace lining
+gable roof
+gambrel
+gambrel roof
+gamp
+gas helmet
+gasmask
+gear case
+gearbox
+geodesic dome
+greave
+groined vault
+habergeon
+half binding
+heat shield
+heaume
+helmet
+henroost
+hip roof
+hipped roof
+holster
+hood
+horseshoe
+housetop
+hubcap
+jalousie
+jambeau
+journal box
+jousting armor
+jousting armour
+kennel
+knee piece
+lamp house
+lamp housing
+lean-to
+lens cap
+lens cover
+lower cannon
+mail
+mansard
+mansard roof
+marquee
+marquise
+mask
+mulch
+ocular helmet
+onion dome
+overlayer
+pallette
+parasol
+pavis
+pavise
+plate armor
+plate armour
+porte-cochere
+pressure dome
+protection
+protective cover
+protective covering
+radar dome
+radome
+refractory
+respirator
+revetement
+revetment
+ribbed vault
+ring armour
+ring-binder
+roller blind
+sabaton
+saddle roof
+saddleback
+saddleback roof
+salade
+sallet
+scabbard
+scale
+screen
+scutcheon
+sentry box
+shade
+sheath
+sheathing
+shell
+shell plating
+shielding
+shoulder holster
+shutter
+ski mask
+skirt of tasses
+slate roof
+smoke screen
+solleret
+splashboard
+splasher
+stone facing
+suit of armor
+suit of armour
+sun visor
+sunblind
+sunroof
+sunshade
+sunshine-roof
+tasse
+tasset
+tester
+testiere
+testudo
+thatch
+thatched roof
+three-quarter binding
+thumbstall
+tile roof
+toecap
+tuille
+upper cannon
+vambrace
+vault
+venetian blind
+vertical blind
+washboard
+watch crystal
+watch glass
+welder's mask
+whispering dome
+whispering gallery
+window blind
+window screen
+window shade
+windscreen
+windshield
+wing tip
+winker

--- a/lists/thing/routes-and-passageways.yml
+++ b/lists/thing/routes-and-passageways.yml
@@ -1,0 +1,367 @@
+---
+title: Routes and passageways
+category: thing
+description: "Roads, paths, ducts, corridors, ladders, and constructed ways"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+access
+access road
+accommodation ladder
+adit
+aerial ladder
+air duct
+air hose
+air passage
+air shaft
+air well
+air-intake
+airline
+airway
+aisle
+alley
+ambulatory
+amusement arcade
+approach
+aqueduct
+archway
+areaway
+arrival gate
+arterial road
+artery
+articulated ladder
+autobahn
+autostrada
+avenue
+back door
+back entrance
+back street
+backstairs
+beltway
+blind alley
+blowpipe
+blowtube
+boardwalk
+boulevard
+branch line
+breather
+briar
+briar pipe
+bridle path
+bridle road
+bus lane
+bypass
+bypath
+byroad
+byway
+calabash
+calabash pipe
+calean
+calumet
+canal
+cannula
+capillary
+capillary tube
+capillary tubing
+carriageway
+cart track
+cartroad
+catacomb
+catheter
+cattle trail
+catwalk
+causeway
+channel
+chicha
+chimney
+chimneypot
+chimneystack
+chromatography column
+chute
+clay pipe
+clearway
+cloaca
+coal chute
+companionway
+concourse
+conduit
+corridor
+cross street
+crosscut
+crossing
+crossover
+cul
+cul de sac
+cullis
+culvert
+dead end
+dead-end street
+deer trail
+departure gate
+detour
+discharge pipe
+divided highway
+doorway
+downcast
+drain
+drainpipe
+drift
+drilling pipe
+drinking straw
+drive
+driveway
+dual carriageway
+duckboard
+duct
+dudeen
+dutch door
+electric main
+elevator shaft
+emergency exit
+endotracheal tube
+entrance
+entranceway
+entree
+entry
+entryway
+escape hatch
+esplanade
+exhaust manifold
+exhaust pipe
+expressway
+exterior door
+fast lane
+fire hose
+fireplug
+fish ladder
+flagging
+flight
+flight of stairs
+flight of steps
+flue
+flume
+footpath
+free throw lane
+freeway
+front door
+front entrance
+frontage road
+fuel line
+funnel
+gallery
+gangway
+garden hose
+gas line
+gas main
+gateway
+ghat
+glacier mill
+grade separation
+gun barrel
+gutter
+half door
+hallway
+hatchway
+heading
+headrace
+high street
+highroad
+horse-trail
+hose
+hosepipe
+hubble-bubble
+hubbly-bubbly
+hydrant
+impasse
+indian trail
+industrial watercourse
+inlet manifold
+intake manifold
+interstate
+interstate highway
+jack ladder
+jacob's ladder
+kalian
+lamp chimney
+lane
+limbers
+local road
+local street
+loop-line
+main
+main drag
+main road
+main street
+manifold
+meerschaum
+mews
+millrace
+millrun
+monkey ladder
+motorway
+moulin
+mountain trail
+moving staircase
+moving stairway
+narghile
+nargileh
+nasotracheal tube
+oil pipeline
+one-way street
+opening
+outside door
+parkway
+paseo
+passage
+passageway
+path
+pathway
+peace pipe
+pelican crossing
+penny arcade
+penstock
+petrol line
+pilot ladder
+pipage
+pipe of peace
+pipeline
+piping
+piste
+pithead
+plug
+portage
+portal
+post road
+private road
+promenade
+race
+radiator hose
+rail line
+railroad tunnel
+railway line
+right of way
+ring road
+ringway
+riser main
+riser pipe
+riser pipeline
+road
+roadway
+room access
+rope ladder
+roundabout way
+route
+rue
+scaling ladder
+schnorchel
+schnorkel
+school crossing
+scupper
+scuttle
+sea ladder
+sea lane
+sea steps
+seaway
+servant's entrance
+service door
+service entrance
+service road
+sewer
+sewer line
+sewer main
+sewerage
+sheesha
+ship canal
+ship route
+shipway
+shisha
+shortcut
+side door
+side entrance
+side road
+side street
+siphon
+ski run
+ski trail
+skid road
+skittle alley
+skywalk
+slide
+slideway
+slip road
+sloping trough
+slow lane
+sluice
+sluiceway
+smokestack
+snorkel
+snorkel breather
+soil pipe
+sparge pipe
+speaking tube
+spill
+spillway
+spur
+spur track
+stage door
+staircase
+stairwell
+standpipe
+state highway
+steam line
+steam pipe
+stent
+steps
+stovepipe
+straw
+street
+superhighway
+syphon
+tailpipe
+tailrace
+test tube
+thoroughfare
+throat
+throughway
+thruway
+tobacco pipe
+toll road
+torpedo tube
+towing path
+towpath
+trade route
+traffic lane
+trail
+trough
+trunk road
+trunk route
+tube
+tubing
+tunnel
+turnoff
+turnpike
+two-way street
+upcast
+ventilation shaft
+venturi
+vomitory
+walk
+walk-through
+walkway
+waste pipe
+wasteweir
+water cannon
+water chute
+water main
+water pipe
+water tube
+watercourse
+waterspout
+waterway
+way
+well point
+zebra crossing

--- a/lists/thing/sheets-and-strips.yml
+++ b/lists/thing/sheets-and-strips.yml
@@ -1,0 +1,236 @@
+---
+title: Sheets, boards, and strips
+category: thing
+description: "Sheets, boards, bands, strips, panels, and flat manufactured pieces"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acetate disk
+adhesive plaster
+adhesive tape
+aluminium foil
+aluminum foil
+aquaplane
+armband
+armlet
+auto tire
+automobile tire
+backband
+baffle
+baffle board
+band
+beaver board
+blackboard
+board
+boilerplate
+brake disk
+breadboard
+bulletin board
+call-board
+car tire
+cellulose tape
+centerboard
+centreboard
+chaff
+chalkboard
+choker
+cincture
+clerical collar
+coin blank
+copperplate
+copperplate engraving
+court plaster
+cover glass
+cover slip
+cramp
+cramp iron
+cummerbund
+curtain ring
+cylinder head
+dado
+daggerboard
+deadeye
+disc
+disk
+diving board
+doorplate
+drafting board
+drainboard
+draining board
+drawing board
+drop keel
+drumhead
+duct tape
+endband
+engraving
+etching
+eton collar
+felloe
+felly
+fiberboard
+fibreboard
+fin keel
+fishplate
+flashing
+flat solid
+flat tire
+floorboard
+footboard
+formica
+friction tape
+garter
+gel
+gelatin
+girdle
+gold foil
+gusset plate
+gypsum board
+halftone
+halftone engraving
+hawk
+head
+headband
+headpiece
+headstall
+highboard
+hockey puck
+inkle
+insulating tape
+ironing board
+key ring
+kneading board
+kneeler
+l-plate
+lacunar
+lamella
+laminate
+leading
+license plate
+line block
+line engraving
+linecut
+masking paper
+masking tape
+masonite
+membrane
+microscope slide
+mock polo neck collar
+mock turtleneck collar
+mortarboard
+mourning band
+mullion
+nameplate
+napkin ring
+neck ruff
+nose ring
+notice board
+numberplate
+palette
+pallet
+pane
+pane of glass
+paneling
+panelling
+particle board
+pastry board
+peter pan collar
+phonograph recording disk
+photoengraving
+photographic plate
+planchet
+planchette
+plasterboard
+plastic film
+plastic laminate
+plate glass
+plate iron
+platen
+plessimeter
+pleximeter
+plyboard
+plywood
+pneumatic tire
+pneumatic tyre
+polaroid
+polo-neck collar
+prong collar
+puck
+quarter plate
+rabato
+radial
+radial tire
+radial-ply tire
+rebato
+recap
+reef
+retread
+roman collar
+rubber tire
+ruff
+ruffle
+sash
+scotch tape
+screed
+sellotape
+sheet glass
+sheet iron
+sheet metal
+sheetrock
+shoulder strap
+shrink-wrap
+sliding keel
+slip
+snow tire
+snowboard
+springboard
+steel engraving
+stencil
+sticking plaster
+storage-battery grid
+stovepipe iron
+subway token
+supporter
+sweatband
+tab
+taenia
+tailband
+tank iron
+tenia
+tin foil
+tin plate
+tire
+token
+towel ring
+trencher
+tubeless
+tubeless tire
+turtleneck collar
+typewriter ribbon
+tyre
+wagon tire
+wainscot
+wainscoting
+wainscotting
+waistband
+waistcloth
+wake board
+wall panel
+wallboard
+watch bracelet
+watchband
+watchstrap
+weather strip
+weather stripping
+weed
+window glass
+windowpane
+wood block
+wood engraving
+woodcut
+workboard
+wristband
+wristlet

--- a/lists/thing/surfaces.yml
+++ b/lists/thing/surfaces.yml
@@ -1,0 +1,197 @@
+---
+title: Surfaces and platforms
+category: thing
+description: "Decks, counters, stages, worktops, faces, and constructed surfaces"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+after part
+afterdeck
+ambo
+auction block
+awning deck
+backgammon board
+backstage
+bandstand
+bell deck
+bezel
+block
+boat deck
+boxing ring
+bridge deck
+broadside
+cant
+chamfer
+chequerboard
+chessboard
+clock dial
+clock face
+conning tower
+countertop
+cribbage board
+crow's nest
+curb
+curbing
+curbside
+cutting edge
+dais
+dance floor
+dartboard
+deck
+deckle edge
+dial
+downstage
+edge
+empennage
+facade
+face
+featheredge
+flatbed
+flight deck
+flooring
+fly floor
+fly gallery
+flybridge
+flying bridge
+footplate
+fore
+foredeck
+forestage
+foretop
+fourth deck
+freeboard deck
+front
+frontage
+frontal
+frontispiece
+gameboard
+go board
+gun deck
+horizontal surface
+hurricane deck
+hurricane roof
+kerb
+klein bottle
+knife edge
+landing deck
+landing stage
+lapboard
+larboard
+launch area
+launching pad
+launchpad
+leading edge
+lido deck
+lip
+lower deck
+macadam
+main deck
+meniscus
+microscope stage
+milling
+mise en scene
+miter
+mitre
+mobius strip
+monkey bridge
+monopoly board
+nearside
+nose
+nose cone
+obverse
+offstage
+ogive
+orlop
+orlop deck
+ouija
+ouija board
+overhead
+pargeting
+pargetry
+pargetting
+parquet
+parquet floor
+paved surface
+pavement
+paving
+pegboard
+perpendicular
+pier
+plasterwork
+podium
+poop
+poop deck
+prize ring
+projection screen
+promenade deck
+prow
+pulpit
+punchboard
+quarter
+quarterdeck
+quay
+razor edge
+rear
+rim
+road surface
+rostrum
+ruled surface
+running board
+runway
+scaffold
+second deck
+setting
+shelter deck
+shoe collar
+shopfront
+side
+silver screen
+skidpan
+skin
+soapbox
+soffit
+spandrel
+spandril
+splay
+stage
+stage setting
+stairhead
+stand
+starboard
+stem
+stern
+storefront
+stump
+sumo ring
+superficies
+tabletop
+tail
+tail assembly
+tarmac
+tarmacadam
+taxi strip
+taxiway
+theater stage
+theatre stage
+third deck
+thrust stage
+topside
+trailing edge
+truck bed
+turntable
+upper deck
+upper surface
+verso
+vertical surface
+weather deck
+wharf
+wharfage
+wide screen
+work surface
+wrestling ring
+writing board
+x-tail

--- a/lists/thing/systems.yml
+++ b/lists/thing/systems.yml
@@ -1,0 +1,177 @@
+---
+title: Systems
+category: thing
+description: "Networks, assemblies, technical systems, and integrated equipment"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+adp system
+adps
+anti-submarine rocket
+assemblage
+assembly line
+audio system
+automatic data processing system
+backup system
+basic point defense missile system
+bus network
+cable system
+cable television
+cable television service
+carbonation system
+closed loop
+closed-circuit television
+closed-loop system
+color television
+color television system
+color tv
+colour television
+colour television system
+colour tv
+computer network
+computer system
+computing system
+containment
+control system
+cyberspace
+data system
+door bell phone
+door phone
+drain system
+drainage system
+drainage well
+early warning system
+eds
+electronic network
+entryphone
+etd
+ethernet
+exhaust
+exhaust system
+explosive detection system
+explosive trace detection
+field-sequential color television
+field-sequential color television system
+field-sequential color tv
+field-sequential color tv system
+force feed
+force-feed lubricating system
+fuel injection
+fuel injection system
+geographic information system
+ghetto blaster
+gis
+global positioning system
+gps
+graticule
+ground control
+guidance device
+guidance system
+hi-fi
+high fidelity sound system
+hookup
+inertial guidance system
+inertial navigation system
+information superhighway
+information system
+intelnet
+intercom
+intercommunication system
+internet
+interphone
+intranet
+jam box
+jdam
+joint direct attack munition
+labyrinth
+lan
+linkage
+local area network
+lockage
+lubricating system
+maze
+mechanical system
+medline
+naval tactical data system
+navigational system
+net
+nitrous oxide injection system
+omnidirectional radio range
+omnidirectional range
+omnirange
+p.a. system
+pa
+phone system
+pressure feed
+pressure-feed lubricating system
+production line
+propulsion system
+public address system
+quadraphonic system
+quadraphony
+quadriphonic system
+radio link
+radiotelegraph
+radiotelegraphy
+recording system
+reproducer
+reseau
+resonator
+reticle
+reticulation
+reticule
+satellite television
+satellite tv
+scaffolding
+selsyn
+semaphore line
+servo
+servomechanism
+servosystem
+ship-towed long-range acoustic detection system
+shipboard system
+shutter telegraph chain
+solar thermal system
+sound system
+sprinkler system
+staging
+stereo
+stereo system
+stereophonic system
+stereophony
+storm drain
+storm sewer
+stormwater drain
+surface-to-air missile system
+surveillance system
+suspension
+suspension system
+synchro
+synchromesh
+system
+target acquisition system
+telecom equipment
+telecom system
+telecommunication equipment
+telecommunication system
+telephone system
+television system
+ventilating system
+ventilation
+ventilation system
+video ipod
+walky-talky
+wan
+wide area network
+wireless
+wireless fidelity
+wireless local area network
+wireless telegraph
+wireless telegraphy
+wlan
+world wide web
+www

--- a/lists/thing/toys-and-playthings.yml
+++ b/lists/thing/toys-and-playthings.yml
@@ -1,0 +1,70 @@
+---
+title: Toys and playthings
+category: thing
+description: "Dolls, puppets, games, novelty toys, and play objects"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+box kite
+cockhorse
+cork gun
+dandle board
+doll
+doll's house
+dolly
+glove doll
+glove puppet
+goat eye
+hand puppet
+hobby
+hobbyhorse
+humming top
+jumping jack
+kachina
+lego
+lego set
+meccano
+meccano set
+paper doll
+pea shooter
+peg top
+pinata
+pinwheel wind collector
+playground slide
+playhouse
+plaything
+popgun
+puppet
+rattle
+sand toy
+sandbox
+sandpile
+sandpit
+sawdust doll
+seesaw
+sliding board
+snowball
+sport kite
+squirt gun
+squirter
+stick horse
+stunt kite
+swing
+teddy
+teddy bear
+teeter
+teeter-totter
+teeterboard
+teetotum
+tension ring
+tilting board
+train set
+trapeze
+tree house
+wendy house
+whip top
+whipping top

--- a/lists/thing/weapons.yml
+++ b/lists/thing/weapons.yml
@@ -1,0 +1,144 @@
+---
+title: Weapons and munitions
+category: thing
+description: "Weapons, ammunition, ordnance, and military armaments"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+a-bomb
+aerial torpedo
+ammo
+ammunition
+antipersonnel bomb
+armament
+artillery
+artillery shell
+atom bomb
+atomic bomb
+ball cartridge
+balloon bomb
+bangalore torpedo
+bazooka
+belt
+belt ammunition
+belted ammunition
+big blue
+blank
+blank shell
+blockbuster
+blu-82
+bomb
+bombie
+bomblet
+bombshell
+briefcase bomb
+canister shot
+cannon
+car bomb
+cartouch
+cartouche
+cartridge
+case shot
+chemical bomb
+clean bomb
+cluster bomb
+cluster bomblet
+cruise missile
+daisy cutter
+defence system
+defense system
+depth bomb
+depth charge
+depth charge thrower
+dirty bomb
+dumb bomb
+dummy
+e-bomb
+field artillery
+field gun
+fire control system
+firebomb
+fission bomb
+four-pounder
+fragmentation bomb
+fuel-air bomb
+fugo
+fusion bomb
+gas bomb
+gas shell
+general-purpose bomb
+gp bomb
+gravity bomb
+grenade
+gunnery
+h-bomb
+hand grenade
+hardware
+harpoon gun
+heavy torpedo
+heavy weapon
+heavyweight torpedo
+high-angle gun
+homing torpedo
+howitzer
+hydrogen bomb
+implements of war
+incendiary
+incendiary bomb
+infernal machine
+laser-guided bomb
+letter bomb
+lgb
+long tom
+megaton bomb
+microwave bomb
+missile defence system
+missile defense system
+mortar
+naval gun
+naval missile
+naval weaponry
+neutron bomb
+one shot
+ordnance
+ordnance store
+package bomb
+parcel bomb
+penetration bomb
+pipe bomb
+plastic bomb
+plutonium bomb
+powder and shot
+remote-control bomb
+rifle grenade
+rocket launcher
+shotgun shell
+shrapnel
+smart bomb
+smoke bomb
+smoke grenade
+stench bomb
+stern chaser
+stink bomb
+submarine torpedo
+tank shell
+thermobaric bomb
+thermonuclear bomb
+time bomb
+torpedo
+tracer
+tracer bullet
+trench mortar
+unit of ammunition
+vacuum bomb
+volume-detonation bomb
+weaponry
+weapons system
+whizbang
+whizbang shell
+whizzbang
+wire-guided torpedo

--- a/lists/vehicle/transport.yml
+++ b/lists/vehicle/transport.yml
@@ -1,0 +1,636 @@
+---
+title: Transport
+category: vehicle
+description: "Vehicles, aircraft, vessels, rolling stock, and transport machinery"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abandoned ship
+abm
+aerial ladder truck
+aerial tramway
+aeroplane
+air-to-air missile
+air-to-ground missile
+air-to-surface missile
+airbus
+all-terrain bike
+alpine lift
+amphibian
+angledozer
+anti-aircraft cruiser
+antiballistic missile
+apc
+applecart
+armored combat vehicle
+armored personnel carrier
+armored vehicle
+armoured car
+armoured combat vehicle
+armoured personnel carrier
+armoured vehicle
+army tank
+articulated lorry
+assault gun
+attack aircraft
+attack aircraft carrier
+attack submarine
+auto
+autobus
+autogiro
+automobile
+automotive vehicle
+auxiliary research submarine
+baby buggy
+baby carriage
+baggage car
+ballistic missile
+bandwagon
+bareboat
+bark
+barouche
+barrage balloon
+barrow
+battle cruiser
+battlewagon
+beach buggy
+beach waggon
+beach wagon
+berlin
+bicycle-built-for-two
+bilevel car
+bilevel railcar
+birchbark
+birchbark canoe
+black maria
+blockade-runner
+bloodmobile
+boat train
+bobsled
+bobsleigh
+bogey
+bogie
+bogy
+boneshaker
+bookmobile
+bottom
+boxcar
+brilliant pebble
+brougham
+buckboard
+buffet car
+buggy
+bumboat
+bumper car
+buzz bomb
+cab
+cabin car
+cabin liner
+cable tramway
+caboose
+cabriolet
+camion
+camper trailer
+camping bus
+capital ship
+car carrier
+car train
+car transporter
+car-ferry
+carack
+caravan
+cargo liner
+cargo ships
+cargo vessel
+caroche
+cat
+caterpillar
+cattle boat
+cattle car
+cattleship
+chair car
+chairlift
+chaise
+charabanc
+chariot
+choo-choo
+chuck wagon
+clarence
+club car
+coach-and-four
+coal car
+coaster wagon
+cockleshell
+combat ship
+commuter
+commuter train
+compact car
+conestoga
+conestoga wagon
+container vessel
+convertible
+conveyance
+corsair
+coupe
+covered couch
+covered wagon
+craft
+crayer
+cruise liner
+cycle
+cycle rickshaw
+dandy
+deadhead
+delivery van
+derelict
+destroyer escort
+diesel locomotive
+diesel-electric
+diesel-electric locomotive
+diesel-hydraulic
+diesel-hydraulic locomotive
+dining car
+dining compartment
+dinkey
+dinky
+dirigible
+dodgem
+dog sleigh
+dogcart
+donkey cart
+doodlebug
+double-deck carriage
+double-deck railcar
+double-decker
+double-prop
+double-propeller plane
+dozer
+dragger
+drawing-room car
+dray
+dreadnaught
+drekkar
+droshky
+drosky
+dumpcart
+dumper
+dune buggy
+dustcart
+e-bike
+electric
+electric automobile
+electric locomotive
+electronic bicycle
+electronic bike
+equipage
+estate car
+exocet
+express
+express luxury liner
+ferryboat
+fighter
+fighter aircraft
+finisher
+fishing smack
+fishing vessel
+flagship
+flatcar
+flattop
+fleet ballistic missile submarine
+flying bomb
+fore-and-after
+forecarriage
+four-in-hand
+four-wheeler
+freight car
+freight liner
+freight train
+funny wagon
+garden cart
+gas guzzler
+gas-turbine ship
+gharry
+go-cart
+gondola car
+graf zeppelin
+ground-effect machine
+guard boat
+guard ship
+guard's van
+guided missile
+guided missile cruiser
+guided missile destroyer
+guided missile frigate
+gurney
+gyroplane
+hack
+hackney
+hackney carriage
+hackney coach
+half track
+hand truck
+handcar
+handcart
+hangar queen
+hansom
+hansom cab
+hardtop
+heap
+hearse
+heat-seeking missile
+heavier-than-air craft
+horse cart
+horse-drawn vehicle
+horsebox
+horsecar
+horseless carriage
+hospital train
+hot rod
+house trailer
+hoy
+hulk
+humvee
+hybrid
+icbm
+ice wagon
+ice yacht
+iceboat
+indiaman
+intercontinental ballistic missile
+iron horse
+jalopy
+jampan
+jaunting car
+jaunty car
+jeep
+jet
+jet plane
+jet-propelled plane
+jinrikisha
+jitney
+jolly
+jolly boat
+jumbojet
+junk
+kamikaze
+kite balloon
+knockabout
+ladder truck
+landau
+landrover
+launch
+laundry cart
+laundry truck
+lawn cart
+light cruiser
+lighter-than-air craft
+limber
+limited
+limo
+liner
+liner train
+litter
+loaner
+local
+locomotive
+locomotive engine
+lorry
+lounge car
+luge
+luggage van
+luxury liner
+machine
+mackinaw boat
+mail car
+mail train
+mailboat
+manpad
+marsh buggy
+merchant marine
+merchant ship
+merchant vessels
+meteorological balloon
+military plane
+military vehicle
+milk float
+milk wagon
+mine cage
+minelayer
+minibus
+minicab
+minicar
+minivan
+minuteman
+missile
+model t
+monocycle
+monoreme
+mosquito boat
+mosquito craft
+motor torpedo boat
+motor vehicle
+motorbike
+motorbus
+motorcar
+motortruck
+mountain bike
+moving van
+multiengine airplane
+multiengine plane
+multistage rocket
+narrow-body
+narrowbody aircraft
+nautilus
+nonsmoker
+nonsmoking car
+norfolk wherry
+nuclear submarine
+nuclear-powered ship
+nuclear-powered submarine
+off-roader
+oiler
+omnibus
+ordinary bicycle
+orthopter
+outboard motorboat
+oxcart
+pace car
+packet
+packet boat
+paddle-wheeler
+paddy wagon
+palace car
+palankeen
+palanquin
+panda car
+panel truck
+pantechnicon
+panzer
+parlor car
+parlour car
+passenger car
+passenger train
+passenger van
+passenger vehicle
+pastry cart
+patrol car
+patrol ship
+patrol wagon
+pedelec
+perambulator
+personnel carrier
+phaeton
+picket boat
+picket ship
+pickup truck
+pigboat
+pilot balloon
+pilot engine
+pilotless aircraft
+pirate
+pirate ship
+plane
+pleasure boat
+pleasure craft
+police boat
+police cruiser
+police van
+police wagon
+pontoon plane
+pony cart
+post chaise
+prairie schooner
+prairie wagon
+privateer
+propjet
+prowl car
+pt boat
+public transport
+pullman
+pullman car
+pung
+push-bike
+pushcart
+pushchair
+pusher
+race car
+raceabout
+racer
+racing boat
+racing car
+racing gig
+racing shell
+racing skiff
+racing yacht
+radio-controlled aircraft
+railcar
+railroad car
+railroad train
+railway car
+railway locomotive
+rattler
+reconnaissance plane
+reconnaissance vehicle
+recreational vehicle
+refrigerator car
+research rocket
+ricksha
+rig
+road roller
+robot bomb
+roll-on roll-off
+rolling stock
+rope tow
+ropeway
+rowing boat
+safety bicycle
+safety bike
+sailing boat
+sailing ship
+sailing vessel
+sailing warship
+sam
+sausage
+sausage balloon
+school ship
+scout car
+scull
+sea boat
+sea scooter
+secondhand car
+sedan
+sedan chair
+self-propelled vehicle
+semi
+serving cart
+sharpie
+sharpshooter
+shay
+ship's boat
+shipping
+shipwreck
+shooting brake
+showboat
+shrimper
+shunter
+shuttle helicopter
+side-wheeler
+sidewinder
+single prop
+single shell
+single-propeller plane
+single-rotor helicopter
+sister ship
+ski lift
+ski tow
+ski-plane
+skibob
+skidder
+sled
+sleeping car
+slip carriage
+slip coach
+slip tongue log skidder
+slip-tongue wheels
+sloop of war
+small boat
+small ship
+smoker
+smoking car
+smoking carriage
+smoking compartment
+sno-cat
+snowplough
+sound truck
+sounding rocket
+space probe
+sport car
+sport utility
+sport utility vehicle
+sports car
+squad car
+square-rigger
+stanhope
+stanley steamer
+station waggon
+station wagon
+stealth aircraft
+steam locomotive
+steamboat
+steamer
+steamroller
+step rocket
+stinger
+stockcar
+stroller
+sub
+subcompact
+subcompact car
+submersible warship
+subway train
+sulky
+supply ship
+surface lift
+surface ship
+surface-to-air missile
+surrey
+swamp buggy
+switch engine
+t-bar
+t-bar lift
+tandem
+tandem bicycle
+tandem trailer
+tank car
+tank destroyer
+tank engine
+tank locomotive
+tank ship
+tank truck
+tanker plane
+tanker truck
+taxicab
+tea cart
+tea trolley
+tea wagon
+technical
+telfer
+telpher
+test instrument vehicle
+test rocket
+three-decker
+tip truck
+tipper
+tipper lorry
+tipper truck
+toboggan
+torpedo-boat destroyer
+touring car
+tow car
+tow truck
+tracked vehicle
+trackless trolley
+traction engine
+tractor trailer
+trailer truck
+training ship
+tramcar
+tramp
+tramp steamer
+transport
+treasure ship
+trial balloon
+troika
+trolley
+trolley car
+trolley coach
+trolleybus
+troop carrier
+troop transport
+trucking rig
+tub-cart
+tug
+tumbrel
+tumbril
+turbo-propeller plane
+turbojet
+twin-aisle airplane
+twin-prop
+twin-propeller-plane
+twinjet
+two-seater
+u-boat
+used-car
+vehicle
+velocipede
+vessel
+waggon
+wagon-lit
+wain
+war vessel
+warplane
+warship
+water cart
+water scooter
+water tank truck
+water truck
+water waggon
+water wagon
+watering cart
+weapons carrier
+weather ship
+welcome wagon
+whaler
+whaling ship
+wheel
+wheeled forecarriage
+wheeled vehicle
+whirlybird
+wide-body
+widebody aircraft
+wreck
+wrecker


### PR DESCRIPTION
## Summary

- add 12,373 moderated, category-unique entries across 27 useful sublists
- put each ontology branch in the repository's most appropriate existing category:
  - `thing`: 8,956 general objects (devices, containers, implements, equipment, coverings, components, toys, weapons, and more)
  - `architecture`: 2,324 structures, building materials, facilities, furnishings, and openings
  - `fashion`: 468 footwear, personal-care, and textile terms
  - `vehicle`: 625 transport terms
- deduplicate every addition against its destination category, including punctuation/hyphen variants
- retain source, license, attribution, and source-archive SHA-256 in every new list's frontmatter

## Source and method

The vocabulary is adapted from the `noun.artifact` taxonomy in [Open English WordNet 2025](https://en-word.net/downloads), whose lexicographer class is the man-made-object branch. The common-noun release was used, rather than the separate proper-name edition.

Source archive SHA-256: `38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93`

Filtering removed the commercial-drug subtree, malformed/numeric labels, entries already present in each destination category, exact duplicates, and punctuation-only spelling duplicates. Terms were assigned to their nearest useful ontology branch, then audited against the repository's category boundaries.

A second moderation pass removed explicit sexual items/adult toys, racist or otherwise harmful legacy terms, drug paraphernalia, prostitution venues, reproductive-drug terms, and explicit torture/execution artifacts that are poor defaults for a general prompt picker.

Open English WordNet is published by the Open English WordNet Community under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) and derives from Princeton WordNet 3.1. Each derived list records that attribution and marks itself as adapted.

## Validation

- 12,373 additions / 12,373 unique across new lists
- zero exact or punctuation-normalized collisions with existing entries in each destination category
- all entries lowercase and non-empty
- directory and frontmatter category agree for all 27 lists
- every new list imports through the package API
- moderation keyword audit clean for the removal set
- isolated `npm run build` succeeds
- `npm run lint` succeeds
- `git diff --check` clean

Generated indexes are intentionally omitted per the repository content-PR contract; the post-merge build workflow regenerates them.
