### PR TITLE
Expand animal category with 6,173 sourced terms

### DIFF
--- a/lists/animal/all.yml
+++ b/lists/animal/all.yml
@@ -2,14 +2,25 @@
 title: All animals
 category: animal
 description: "Diverse mix of animals including mammals, birds, reptiles, insects, and pets"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 aardvark
 aardwolf
+abortus
 abyssinian
+abyssinian cat
 achrioptera manga
+acrodont
 addax
 adelie penguin
+adult
 aesculapian snake
+afghan
 african bullfrog
 african bush elephant
 african civet
@@ -24,7 +35,10 @@ african penguin
 african tree toad
 african wild dog
 agama lizard
+agnathan
+ailanthus silkworm
 ainu dog
+airedale
 airedoodle
 akita shepherd
 alabai
@@ -32,13 +46,16 @@ alaskan pollock
 alaskan shepherd
 albacore tuna
 albatross
+albino
 albino (amelanistic) corn snake
 aldabra giant tortoise
+alley cat
 alligator
 alligator gar
 allosaurus
 alpaca
 alpine goat
+alsatian
 alusky
 amargasaurus
 amazon parrot
@@ -57,12 +74,18 @@ american robin
 american toad
 american wirehair
 amethystine python (scrub python)
+amniota
+amniote
+amphioxus
 amur leopard
 anaconda
+anaspid
 anchovies
 angelfish
 angelshark
 anglerfish
+angora
+angora cat
 angora ferret
 angora goat
 anna’s hummingbird
@@ -75,9 +98,13 @@ antelope
 anteosaurus
 aoudad
 ape
+aphid lion
+aphis lion
+appenzeller
 appenzeller dog
 apple head chihuahua
 apple moth
+aquatic vertebrate
 arabian cobra
 arafura file snake
 arapaima
@@ -98,13 +125,17 @@ arizona coral snake
 armadillo
 armadillo lizard
 armored catfish
+army cutworm
 armyworm
 arsinoitherium
+arthropod
 aruba rattlesnake
+ascidian tadpole
 asian arowana
 asian cockroach
 asian elephant
 asian giant hornet
+asian horseshoe crab
 asian lady beetle
 asian longhorn beetle
 asian palm civet
@@ -116,6 +147,7 @@ atlantic salmon
 atlantic sturgeon
 atlas beetle
 atlas moth
+attack dog
 aurochs
 aussiedoodle
 aussiedor
@@ -131,10 +163,14 @@ australopithecus
 avocet
 axolotl
 aye aye
+baa-lamb
 babirusa
 baboon
+baby
+baby bird
 bactrian camel
 badger
+badger dog
 baiji
 baird’s rat snake
 bald eagle
@@ -152,6 +188,7 @@ banded water snake
 bandicoot
 banjo catfish
 barb
+barker
 barn owl
 barn swallow
 barnacle
@@ -164,6 +201,7 @@ basilisk lizard
 basilosaurus
 basking shark
 bassador
+basset
 bassetoodle
 bat
 bat-eared fox
@@ -179,26 +217,34 @@ bear
 bearded dragon
 bearded vulture
 beaski
+beast of burden
 beauty rat snake
 beaver
 bed bugs
 bee
 beefalo
+beet armyworm
 beetle
+belgian griffon
 belted kingfisher
 beluga sturgeon
 bengal tiger
 bergamasco
 bernedoodle
 bernese shepherd
+beroe
 betta fish (siamese fighting fish)
 bichir
 bichpoo
+biddy
+big game
 bighorn
 bighorn sheep
 bilby
 binturong
+biped
 bird
+bird dog
 bird of paradise
 bird snake
 birds of paradise
@@ -221,8 +267,14 @@ black-headed python
 blacknose shark
 blackpoll warbler
 blacktip reef shark
+bladder worm
 bladefin basslet
 blanket octopus
+blastocyst
+blastodermic vesicle
+blastosphere
+blastula
+blenheim spaniel
 blind snake
 blister beetle
 blobfish
@@ -236,6 +288,7 @@ blue grosbeak
 blue iguana
 blue jay
 blue lacy dog
+blue point siamese
 blue racer
 blue shark
 blue tit
@@ -243,15 +296,19 @@ blue whale
 blue-ringed octopus
 bluefin tuna
 bluegill
+bluetick
 boar
+boarhound
 boas
 bobcat
 bobolink
+bobtail
 boelen’s python
 boggle
 boglen terrier
 boiga
 bolivian anaconda
+bollworm
 bolognese dog
 bombay
 bongo
@@ -262,11 +319,16 @@ booby
 boomslang
 borador
 bordoodle
+borer
 borkie
 bornean orang-utan
 borneo elephant
+boston bull
+bot
 bottle nosed dolphin
 bottlenose dolphin
+bouviers des flandres
+bow-wow
 bowfin
 bowhead whale
 box tree moth
@@ -278,10 +340,13 @@ boxerdoodle
 boxfish
 boxsky
 boxweiler
+brabancon griffon
+brachiopod
 brachiosaurus
 brahminy blindsnake
 bredl’s python
 british timber
+brittany spaniel
 brontosaurus
 bronze whaler shark
 brook trout
@@ -294,6 +359,7 @@ brown snake
 brown water snake
 brown-banded cockroach
 brug
+bryozoan
 budgerigar
 buffalo
 buffalo fish
@@ -303,10 +369,12 @@ bull mastiff
 bull shark
 bull trout
 bullfrog
+bullock
 bullsnake
 bumblebee
 bunny
 burmese
+burmese cat
 burmese python
 burro
 burrowing frog
@@ -316,13 +384,19 @@ bush viper
 bushmaster snake
 butterfly
 butterfly fish
+by-catch
 cabbage moth
+cabbageworm
 cactus moth
 cactus mouse
 cactus wren
+caddisworm
 caecilian
 caiman
 caiman lizard
+cairn
+calf
+calico cat
 california condor
 california kingsnake
 camel
@@ -332,19 +406,26 @@ canada lynx
 canada warbler
 canadian horse
 canary
+canis familiaris
+cankerworm
 cantil
 cape lion
+captive
 capybara
 caracal
+cardigan
 cardinal
 caribbean reef shark
 caribou
+carnivore
 carolina parakeet
 carp
 carpenter ant
 carpet python
 carpet viper
+carriage dog
 cascabel
+caseworm
 cashmere goat
 cassowary
 cat
@@ -362,7 +443,11 @@ cave lion
 cecropia moth
 centipede
 central ranges taipan
+cephalaspid
+cephalochordate
 ceratosaurus
+cercaria
+cestum veneris
 chameleon
 chamois
 chartreux
@@ -371,6 +456,7 @@ checkered garter snake
 cheetah
 chestnut-sided warbler
 chi chi
+chick
 chickadee
 chicken
 chicken snake
@@ -388,20 +474,28 @@ chipmunk
 chipoo
 chipping sparrow
 chiweenie
+chordate
+chorizagrotis auxiliaris
 chorkie
+chow
 chow shepherd
 christmas beetle
 christmas island red crab
+chrysanthemum dog
 chusky
 cicada
 cichlid
 cinereous vulture
 cinnamon ferret
 civet
+class merostomata
 click beetle
 clothes moth
 clouded leopard
 clownfish
+clumber
+clydesdale terrier
+coach dog
 coachwhip snake
 coastal carpet python
 coastal taipan
@@ -412,6 +506,7 @@ cockalier
 cockapoo
 cockatiel
 cockatoo
+cocker
 cockroach
 codfish
 codling moth
@@ -431,21 +526,28 @@ common loon
 common raven
 common toad
 compsognathus
+conceptus
 conger eel
 congo snake
+conodont
 cookiecutter shark
+coondog
+coonhound
 cooper’s hawk
 copperhead
 coral
 coral snake
+corgi
 corgidor
 corgipoo
 corkie
 corman shepherd
+corn earworm
 corn rex cat (cornish rex)
 corn snake
 cory catfish
 costa’s hummingbird
+cotton bollworm
 cotton-top tamarin
 cottonmouth
 cougar
@@ -456,29 +558,40 @@ crab spider
 crab-eating macaque
 crabeater seal
 crane
+craniate
 crappie fish
+creepy-crawly
 crested gecko
 crested penguin
 cricket
+critter
 crocodile
 crocodile monitor
 cross fox
 cross river gorilla
 crow
 crucian carp
+ctenophore
+cub
 cuban boa
 cuban cockroach
 cuckoo
 cuscus
 cuttlefish
+cutworm
+cyclostome
 dachsador
+dachsie
 daeodon
 dalmadoodle
 dalmador
+dam
+dandie dinmont
 danios
 dapple dachshund
 dark-eyed junco
 darkling beetle
+darter
 darwin’s fox
 darwin’s frog
 de kay’s brown snake
@@ -488,6 +601,7 @@ deathwatch beetle
 deer
 deer head chihuahua
 deer tick
+deerhound
 desert kingsnake
 desert locust
 desert rain frog
@@ -506,12 +620,21 @@ dinosaur shrimp
 diplodocus
 dire wolf
 discus
+doberman
 dodo
 doe
 dog
 dog tick
+doggie
+doggy
+dogie
+dogy
 dolphin
+domestic animal
+domestic dog
+domesticated animal
 donkey
+doodlebug
 dorgi
 dorkie
 dormouse
@@ -521,6 +644,7 @@ downy woodpecker
 doxiepoo
 doxle
 draco volans lizard
+draft animal
 dragon eel
 dragonfish
 dragonfly
@@ -566,8 +690,11 @@ eastern turkey (wild turkey)
 eastern woodrat
 echidna
 eclectus parrot
+ectoproct
+ectotherm
 edible frog
 eel
+egyptian cat
 egyptian cobra (egyptian asp)
 egyptian goose
 egyptian mau
@@ -583,6 +710,8 @@ elephant beetle
 elephant seal
 elephant shrew
 elk
+elkhound
+embryo
 emerald tree boa
 emerald tree monitor
 emperor penguin
@@ -591,7 +720,12 @@ emu
 english bulldog
 english cream golden retriever
 english pointer
+english springer
+entire
+entlebucher
+entoproct
 epagneul pont audemer
+eptatretus
 equatorial spitting cobra
 ermine
 escolar
@@ -609,6 +743,7 @@ european polecat
 european robin
 european starling
 european wildcat
+eurypterid
 evening bat
 evening grosbeak
 ewe
@@ -616,6 +751,9 @@ executioner wasp
 eyelash viper
 fairy-wren
 falcon
+fall armyworm
+fall cankerworm
+fall webworm
 fallow deer
 false cobra
 false coral snake
@@ -624,16 +762,26 @@ false water cobra
 false widow spider
 fangtooth
 fawn
+feeder
 feist
+felis catus
+felis domesticus
+female
 fennec fox
 fer-de-lance snake
 ferret
 ferruginous hawk
+fertilized egg
+fetus
+fice
+fictional animal
 fiddler crab
 fierce snake
 figeater beetle
+filly
 fin whale
 finch
+finisher
 fire eel
 fire salamander
 fire-bellied toad
@@ -646,6 +794,8 @@ flat coat retriever
 flathead catfish
 flea
 fleckvieh cattle
+fledgeling
+fledgling
 florida gar
 florida panther
 florida woods cockroach
@@ -658,13 +808,17 @@ flying fish
 flying lemur
 flying snake
 flying squirrel
+foal
+foetus
 football fish
 forest cobra
+forest tent caterpillar
 fossa
 fox
 fox snakes
 fox squirrel
 fox terrier
+foxhound
 french lop
 frenchton
 frengle
@@ -683,12 +837,19 @@ gaboon viper
 galapagos penguin
 galapagos shark
 galapagos tortoise
+game
 gar
+garden centipede
 garden eel
+garden symphilid
+garden webworm
 gargoyle gecko
 garter snake
+gastrula
 gazelle
+gazelle hound
 gecko
+gelding
 gemsbok
 genet
 gentoo penguin
@@ -696,12 +857,15 @@ geoffroys tamarin
 gerberian shepsky
 gerbil
 german cockroach
+german police dog
+german shepherd dog
 german shepherd guide
 german sheppit
 german sheprador
 gharial
 ghost catfish
 ghost crab
+giant
 giant african land snail
 giant armadillo
 giant beaver
@@ -711,7 +875,9 @@ giant leopard moth
 giant panda bear
 giant salamander
 giant schnoodle
+giant silkworm
 giant weta
+gib
 gibbon
 gigantopithecus
 gila monster
@@ -721,6 +887,7 @@ glass lizard
 glechon
 glow worm
 gnat
+gnathostome
 gnu
 goat
 goberian
@@ -796,13 +963,18 @@ ground snake
 groundhog (woodchuck)
 grouper
 grouse
+grub
 guanaco
+guard dog
+guide dog
 guinea fowl
 guinea pig
 gulper eel
+gun dog
 guppy
 habu snake
 haddock
+hag
 hagfish
 hairy woodpecker
 halibut
@@ -818,6 +990,7 @@ harp seal
 harpy eagle
 harris hawk
 hartebeest
+hatchling
 havapoo
 havashire
 hawaiian crow
@@ -825,22 +998,35 @@ hawaiian goose
 hawaiian monk seal
 hawk
 hawk moth caterpillar
+head
+hearing dog
 hedgehog
+heifer
 hellbender
+hellgrammite
+hen
 hepatic tanager (red tanager)
+herbivore
 hercules beetle
 hercules moth
 hermit crab
 heron
 herring
+heterostracan
+hexapod
 highland cattle
 himalayan
 hippopotamus
 hoary bat
 hobo spider
 hog
+hogg
+hogget
 hognose snake
 holy cross frog
+homeotherm
+homoiotherm
+homotherm
 honduran white bat
 honey badger
 honey bee
@@ -861,17 +1047,23 @@ hornet
 horse
 horsefly
 horseshoe crab
+hound
+hound dog
+house cat
+house centipede
 house finch
 house sparrow
 house wren
+housedog
 housefly
 howler monkey
-human
 humboldt penguin
 humboldt squid
 hummingbird
 hummingbird hawk-moth
 humpback whale
+hungarian pointer
+hunting dog
 huntsman spider
 huskador
 huskita
@@ -882,12 +1074,14 @@ hyaenodon
 hyena
 ibex
 ibis
+ibizan podenco
 ichthyosaurus
 iguana
 iguanodon
 immortal jellyfish
 impala
 imperial moth
+inchworm
 indian cobra
 indian elephant
 indian giant squirrel
@@ -901,7 +1095,10 @@ indochinese tiger
 indri
 inland taipan
 insect
+insectivore
 insects
+instar
+invertebrate
 irish doodle
 ivory-billed woodpecker
 jacana
@@ -918,15 +1115,20 @@ jamaican boa
 japanese beetle
 japanese macaque
 japanese rat snake
+japanese spaniel
 japanese squirrel
 javan rhinoceros
 javanese
+jawless fish
+jawless vertebrate
 jellyfish
 jerboa
 jewel beetle
 john dory
+jointworm
 jonah crab
 joro spider
+jument
 jumping spider
 jungle carpet python
 junglefowl
@@ -938,6 +1140,7 @@ kangaroo rat
 katydid
 keel-billed toucan
 keelback
+kelpie
 kenyan sand boa
 kestrel
 keta salmon
@@ -957,9 +1160,12 @@ king vulture
 kingfisher
 kinkajou
 kirtland’s snake
+kit
 kit fox
 kitefin shark
 kitten
+kitty
+kitty-cat
 kiwi
 klipspringer
 koala
@@ -983,20 +1189,30 @@ ladyfish
 lake sturgeon
 lamancha goat
 lamb
+lambkin
+lamp shell
+lamper eel
 lamprey
+lancelet
 landseer newfoundland
+lapdog
+lappet caterpillar
 lappet-faced vulture
 larder beetle
+large poodle
+larva
 lavender albino ball python
 lawnmower blenny
 lazarus lizard
 leaf-tailed gecko
 leatherback sea turtle
+leatherjacket
 leech
 leedsichthys
 lemming
 lemon shark
 lemur
+leonberg
 leopard
 leopard cat
 leopard frog
@@ -1005,15 +1221,20 @@ leopard lizard
 leopard seal
 leopard shark
 leopard tortoise
+leppy
 leptocephalus
+lhasa
 lhasapoo
 liger
+limulus polyphemus
 linnet
 lion
+lion cub
 lion’s mane jellyfish
 lionfish
 little brown bat
 little penguin
+liver-spotted dalmatian
 livyatan
 lizard
 lizardfish
@@ -1027,6 +1248,7 @@ long-haired rottweiler
 long-tailed tit
 longfin mako shark
 longnose gar
+looper
 lorikeet
 lovebird
 lowchen
@@ -1050,13 +1272,21 @@ mahi mahi (dolphin fish)
 maiasaura
 maine coon
 mal shi
+malamute
 malayan civet
 malayan krait
 malayan tiger
 malchi
+male
+male horse
+malemute
+malinois
 mallard
 malteagle
+maltese cat
+maltese dog
 maltese shih tzu
+maltese terrier
 maltipoo
 mamba
 mamushi snake
@@ -1068,9 +1298,12 @@ maned wolf
 mangrove snake
 manta ray
 mantella frog
+manx cat
 marabou stork
 marble fox
 mare
+marine animal
+marine creature
 marine iguana
 marine toad
 markhor
@@ -1082,31 +1315,41 @@ masked angelfish
 masked palm civet
 massasauga
 mastador
+maverick
 may beetle
 mayfly
 meagle
+mealworm
 mealworm beetle
 mealybug
+measuring worm
 meerkat
 megalania
 megalodon
 megamouth shark
 megatherium
 mekong giant catfish
+merostomata
+metazoan
 mexican alligator lizard
 mexican black kingsnake
 mexican eagle (northern crested caracara)
 mexican free-tailed bat
+mexican hairless
 mexican mole lizard
 microraptor
 midget faded rattlesnake
+migrator
 miki
 milk snake
 milkfish
+millepede
+milliped
 millipede
 mini labradoodle
 mini lop
 miniature husky
+miniature poodle
 mink
 minke whale
 mississippi kite
@@ -1118,10 +1361,13 @@ mole
 mole cricket
 mole snake
 molly
+molter
 monarch butterfly
 mongoose
 monitor lizard
 monkey
+monkey dog
+monkey pinscher
 monkfish
 monocled cobra
 monster
@@ -1131,14 +1377,18 @@ moorhen
 moose
 moray eel
 morkie
+morula
 mosasaurus
 mosquito
+moss animal
 moth
+moulter
 mountain bluebird
 mountain gorilla
 mountain lion
 mourning dove
 mouse
+mouser
 mozambique spitting cobra
 mud snake
 mudpuppy
@@ -1151,8 +1401,13 @@ musk ox
 muskrat
 mussurana snake
 mustang
+mutant
+mutt
 muttaburrasaurus
 myna bird
+myriapod
+myxine glutinosa
+myxinikela siroka
 naked mole rat
 narwhal
 natterjack
@@ -1161,6 +1416,8 @@ nebelung
 needlefish
 neon tetra
 neptune grouper
+nestling
+newfoundland dog
 newfypoo
 newt
 nicobar pigeon
@@ -1188,12 +1445,14 @@ nudibranch
 numbat
 nurse shark
 nyala
+nymph
 oak toad
 oarfish
 oceanic whitetip shark
 ocelot
 octopus
 oenpelli python
+offspring
 okapi
 old house borer
 oleander hawk moth
@@ -1201,7 +1460,9 @@ olive baboon
 olive python
 olive sea snake
 olm
+omnivore
 onagadori chicken
+onychophoran
 opah
 opossum
 orange-crowned warbler
@@ -1209,10 +1470,13 @@ orangutan
 orb weaver
 oriental cockroach
 ornithomimus
+orphan
 ortolan bunting
 oryx
 oscar fish
 osprey
+osteostracan
+ostracoderm
 ostrich
 otter
 oviraptor
@@ -1221,6 +1485,8 @@ ox
 oyster
 oyster toadfish
 pacific sleeper shark
+pack animal
+packhorse
 paddlefish
 pademelon
 painted turtle
@@ -1231,6 +1497,7 @@ panther
 paradise flying snake
 parakeet
 parasaurolophus
+pariah dog
 parrot
 parrot snake
 parrotfish
@@ -1244,28 +1511,44 @@ peacock
 peacock butterfly
 peacock spider
 peagle
+peanut worm
 peccary
 peekapoo
+peeper
+peke
+pekinese
 pelagornis
 pelican
+pembroke
 penguin
 pennsylvania wood cockroach
+pentastomid
 peppered moth
 peppermint angelfish
 pere davids deer
 peregrine falcon
 peringuey’s adder
+peripatus
 persian
+persian cat
+persian lamb
 pesquet’s parrot (dracula parrot)
+pest
+pet
 petite goldendoodle
+petromyzon marinus
 pheasant
 philippine cobra
 phoenix chicken
+phoronid
 phorusrhacos
+pie-dog
 pied ball python
 pied tamarin
 pig
 pigeon
+piggy
+piglet
 pika
 pike
 pike fish
@@ -1275,41 +1558,57 @@ pine beetle
 pine marten
 pine siskin
 pine snake
+pink bollworm
 pink fairy armadillo
 pink-necked green pigeon
+pinscher
 pipe snake
 pipefish
 piranha
 pit bull
+pit bull terrier
 pit viper
 pitador
 pitsky
+placoderm
 plains hognose snake
 platinum arowana
 platybelodon
+platyctenean
 platypus
+pleurodont
+plicatoperipatus jamaicensis
 pocket beagle
 pocket pitbull
+poikilotherm
 poison dart frog
 polar bear
 polecat
+police dog
 polish tatra sheepdog
 polka dot stingray
+polliwog
 pollock fish
+pollywog
 polyphemus moth
+polyzoan
 pomapoo
 pomchi
 pomeagle
 pomsky
 pond skater
 pony
+pooch
 poochon
+poodle dog
 poogle
 pool frog
 porbeagle shark
 porcupine
 porpoise
 possum
+potato tuberworm
+potato worm
 potoo
 potoroo
 powderpost beetle
@@ -1318,6 +1617,9 @@ prairie dog
 prairie rattlesnake
 prawn
 praying mantis
+predator
+predatory animal
+prey
 proboscis monkey
 procoptodon
 pronghorn
@@ -1327,15 +1629,22 @@ pterodactyl
 puff adder
 pufferfish
 puffin
+pug-dog
 pugapoo
 puggle
 pugshire
 puma
+pup
 puppy
+pureblood
+purebred
 purple emperor
 purple emperor butterfly
 purple finch
 puss moth
+pussycat
+pycnogonid
+pye-dog
 pygmy hippopotamus
 pygmy marmoset
 pygmy marmoset (finger monkey)
@@ -1346,8 +1655,10 @@ pyjama shark
 pyrador
 pyredoodle
 python
+quadruped
 quagga
 quail
+quarry
 queen snake
 quetzal
 quokka
@@ -1363,8 +1674,10 @@ raggle
 rainbow boa
 rainbow shark
 ram
+range animal
 rat
 rat snakes
+ratter
 rattlesnake
 red diamondback rattlesnake
 red finch
@@ -1374,6 +1687,7 @@ red knee tarantula
 red panda
 red paper wasp
 red racer snake
+red setter
 red spitting cobra
 red squirrel
 red tail boa (common boa)
@@ -1390,6 +1704,7 @@ red-lipped batfish
 red-shouldered hawk
 red-winged blackbird
 redback spider
+redbone
 redhump eartheater
 redstart
 redtail catfish
@@ -1397,6 +1712,7 @@ reef shark
 reindeer
 repenomamus
 reticulated python
+retriever
 rex rabbit
 rhino beetle
 rhino viper
@@ -1404,6 +1720,10 @@ rhinoceros
 rhombic egg-eater snake
 ribbon eel
 ribbon snake
+ridgel
+ridgeling
+ridgil
+ridgling
 rim rock crowned snake
 ring-billed gull
 ringed kingfisher
@@ -1424,6 +1744,7 @@ root aphids
 rose-breasted grosbeak
 roseate spoonbill
 rosy boa
+rotifer
 rotterman
 rottsky
 rough earth snake
@@ -1439,6 +1760,7 @@ russel’s viper
 russian bear dog
 russian blue
 russian tortoise
+russian wolfhound
 saanen goat
 saber-toothed tiger
 sable
@@ -1454,6 +1776,7 @@ salamander
 salmon
 salmon shark
 sambar
+samoyede
 san francisco garter snake
 sand crab
 sand dollar
@@ -1467,6 +1790,8 @@ sardines
 sarkastodon
 satanic leaf-tailed gecko
 sauropoda
+sausage dog
+sausage hound
 savanna goat
 savannah sparrow
 savu python
@@ -1477,50 +1802,74 @@ scarab beetle
 scarlet kingsnake
 scarlet macaw
 scarlet tanager
+scavenger
+schnauzer
 schneagle
 schnoodle
 scimitar-horned oryx
 scorpion
 scorpion fish
 scotch collie
+scotch terrier
+scottie
 scrotum frog
 sculpin
+scutigera coleoptrata
+scutigerella immaculata
 sea anemone
+sea animal
+sea creature
 sea dragon
 sea eagle
+sea gooseberry
+sea lamprey
 sea lion
+sea mat
+sea moss
 sea otter
 sea roach
 sea slug
 sea snake
+sea spider
 sea squirt
 sea turtle
 sea urchin
 seagull
 seahorse
 seal
+sealyham
 sedge warbler
+seeing eye dog
 sei whale
+seizure-alert dog
 senegal parrot
+sennenhunde
 serval
+setter
 shark
 sharp-shinned hawk
 sharp-tailed snake
 sheep
 sheepadoodle
+sheepdog
 sheepshead fish
 shepadoodle
+shepherd dog
 shepkita
 shepweiler
+shetland
 shichi
 shih poo
+shoat
 shoebill stork
 shollie
 short-faced bear
 shortfin mako shark
+shote
 shrew
 shrimp
 siamese
+siamese cat
 siamese fighting fish
 siberian
 siberian ibex
@@ -1529,23 +1878,31 @@ siberian tiger
 siberpoo
 sidewinder
 silkie chicken
+silkworm
 silky shark
 silver dollar
 silver labrador
 sinosauropteryx
+sipunculid
+sire
 sixgill shark
 skate fish
 skink lizard
 skipjack tuna
 skua
 skunk
+sled dog
+sledge dog
 sleeper shark
+slime eels
 sloth
 slow worm
 slug
+small game
 smokybrown cockroach
 smooth green snake
 smooth snake
+smooth-haired fox terrier
 snail
 snake
 snapping turtle
@@ -1571,9 +1928,12 @@ southern hognose snake
 southern pacific rattlesnake
 spadefoot toad
 spanador
+spaniel
 spanish goat
+spanish pointer
 sparrow
 sparrowhawk
+spat
 speckled kingsnake
 spectacled bear
 sperm whale
@@ -1589,14 +1949,20 @@ spinosaurus
 spiny bush viper
 spiny dogfish
 spiny hill turtle
+spirit animal
 spitting cobra
+spitz
 spixs macaw
 sponge
+sporting dog
 spotted gar
 spotted lanternfly
 spotted python
+spring cankerworm
 springador
 springbok
+springer
+springer spaniel
 springerdoodle
 squash beetle
 squid
@@ -1604,27 +1970,39 @@ squirrel
 squirrel monkey
 squirrelfish
 sri lankan elephant
+staffordshire terrier
 stag beetle
 stallion
+standard poodle
 star-nosed mole
 starfish
 stargazer fish
+stayer
 steelhead salmon
+steeplechaser
 steer
 steller's sea cow
 stick insect
 stiletto snake
 stingray
 stoat
+stocker
 stone crab
 stork
 strawberry hermit crab
+strawworm
+stray
 striped hyena
 striped rocket frog
+stud
+studhorse
+stunt
 sturgeon
 styracosaurus
 suchomimus
 sucker fish
+sucking pig
+suckling
 sugar glider
 sulcata tortoise
 sumatran elephant
@@ -1632,14 +2010,22 @@ sumatran orang-utan
 sumatran rhinoceros
 sumatran tiger
 summer tanager
+sumpter
 sun bear
 sunbeam snake
 superworm
 surgeonfish
+survivor
 swai fish
 swan
+sydney silky
+symbion pandora
+symphilid
 syrian hamster
+tabby
+tabby cat
 taco terrier
+tadpole
 taipan
 takin
 tamaskan
@@ -1648,20 +2034,25 @@ tapanuli orang-utan
 tapir
 tarantula hawk
 tarbosaurus
+tardigrade
 tarpon
 tarsier
 tasmanian devil
 tasmanian tiger
 tawny owl
 teddy bear hamster
+teg
 telescope fish
 ten-lined june beetle
 tennessee walking horse
+tent caterpillar
 tentacled snake
+teras
 termite
 terrier
 terror bird
 tetra
+tetrapod
 texas blind snake
 texas coral snake
 texas garter snake
@@ -1680,6 +2071,8 @@ tick
 tiffany
 tiger
 tiger beetle
+tiger cat
+tiger cub
 tiger moth
 tiger rattlesnake
 tiger salamander
@@ -1691,13 +2084,26 @@ titan beetle
 titanoboa
 toad
 toadfish
+tobacco budworm
+tobacco hornworm
+tomato fruitworm
 tomato hornworm
+tomato worm
+tomcat
+tongue worm
 torkie
 tortoise
+tortoiseshell
+tortoiseshell-cat
 toucan
 towhee
 toxodon
+toy
+toy dog
+toy manchester
 toy poodle
+toy spaniel
+toy terrier
 tree frog
 tree kangaroo
 tree snake
@@ -1705,6 +2111,7 @@ tree swallow
 tree viper (bamboo viper)
 treecreeper
 triggerfish
+trilobite
 troodon
 tropicbird
 trout
@@ -1717,6 +2124,7 @@ turkey vulture
 turkish angora
 turtle
 turtles
+tussock caterpillar
 twig snake
 tylosaurus
 tyrannosaurus rex
@@ -1733,10 +2141,17 @@ vampire bat
 vampire crab
 vampire squid
 vaquita
+varment
+varmint
 velociraptor
+velvet worm
 venus flytrap
+venus's girdle
 vermilion flycatcher
+vermin
+vertebrate
 vervet monkey
+vetchworm
 vicuña
 vine snake
 vinegaroon
@@ -1748,6 +2163,8 @@ virgin islands dwarf gecko
 vulture
 wahoo fish
 waimanu
+walker foxhound
+walker hound
 walking catfish
 wallaby
 walleye fish
@@ -1756,14 +2173,17 @@ wandering albatross
 warbler
 warthog
 wasp
+watchdog
 water beetle
 water buffalo
 water dragon
+water spaniel
 water vole
 waterbuck
 wax moth
 weasel
 weaver bird
+webworm
 weimardoodle
 wels catfish
 welsh corgi
@@ -1780,6 +2200,7 @@ westiepoo
 whale
 whale shark
 wheaten terrier
+whelp
 whimbrel
 whinchat
 whiptail lizard
@@ -1797,15 +2218,23 @@ whiting
 whoodle
 whooping crane
 wild boar
+wild silkworm
 wildcat
 wildebeest
 willow warbler
 winter moth
+wire-haired fox terrier
+wirehair
+wirehaired terrier
+wireworm
 wolf
+wolf cub
 wolf eel
+wolf pup
 wolf snake
 wolf spider
 wolffish
+wolfhound
 wolverine
 woma python
 wombat
@@ -1813,24 +2242,32 @@ wood bison
 wood frog
 wood tick
 wood turtle
+woodborer
 woodchuck
 woodlouse
 woodlouse spider
 woodpecker
 woodrat
 woolly aphids
+woolly bear
+woolly bear caterpillar
+woolly bear moth
 woolly mammoth
 woolly monkey
 woolly rhinoceros
+work animal
+working dog
 worm
 worm snake
 wrasse
+wriggler
 writing spider
 wrought iron butterflyfish
 wryneck
 wyoming toad
 x-ray tetra
 xerus
+xiphosurus polyphemus
 yak
 yarara
 yellow anaconda
@@ -1849,6 +2286,10 @@ yokohama chicken
 yoranian
 yorkie bichon
 yorkie-poo
+young
+young bird
+young carnivore
+young mammal
 zebra
 zebra finch
 zebra mussels
@@ -1858,5 +2299,7 @@ zebra snake
 zebra spitting cobra
 zebu
 zonkey
+zoophyte
+zooplankton
 zorse
 zuchon

--- a/lists/animal/amphibian.yml
+++ b/lists/animal/amphibian.yml
@@ -2,56 +2,120 @@
 title: Amphibians
 category: animal
 description: "Various amphibian species including frogs, toads, newts, and sirens"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+acris crepitans
+acris gryllus
 african bullfrog
 african clawed frog
 african dwarf frog
 african reed frog
+agua
+agua toad
 alpine newt
 alpine salamander
+alytes cisternasi
+alytes obstetricans
 amazon milk frog
+ambystoma maculatum
+ambystoma mexicanum
+ambystoma talpoideum
+ambystoma tigrinum
+ambystomid
+ambystomid salamander
 american bullfrog
+american green toad
 american green tree frog
 american toad
+amphibian
 amphiuma
+anaxyrus americanus
+anaxyrus canorus
+anaxyrus debilis
+anaxyrus speciosus
+aneides lugubris
+anuran
 arboreal salamander
+ascaphus trui
 axolotl
+barking frog
 barking tree frog
+batrachian
+bell toad
 black rain frog
 black toad
+blind eel
+blindworm
 blue poison dart frog
 blue-spotted salamander
+bombina bombina
 boreas toad
 budgett's frog
+bufo
+bufo americanus
+bufo boreas
+bufo bufo
+bufo calamita
+bufo canorus
+bufo debilis
+bufo marinus
+bufo microscaphus
+bufo speciosus
+bufo viridis
+bufotes viridis
 bullfrog
 caecilian
 california newt
 california tiger salamander
 cane toad
 canyon tree frog
+cascades frog
+caudate
+chameleon tree frog
 chinese giant salamander
+chorus frog
 chubby frog
+climbing salamander
 common frog
 common mudpuppy
+common newt
 common toad
+congo eel
 cope's gray tree frog
 coqui
 corroboree frog
+crapaud
 cricket frog
+cryptobranchus alleganiensis
 cuban tree frog
 dart frog
 darwin's frog
 desert rain frog
+dicamptodon
+dicamptodon ensatus
+dicamptodontid
+dryophytes arenicolor
 dumpy tree frog
 dusky salamander
+eastern cricket frog
 eastern hellbender
+eastern narrow-mouthed toad
 eastern newt
 eastern red-backed salamander
 eastern spadefoot toad
 edible frog
+eft
 emperor newt
+eurasian green toad
+european fire salamander
 european fire-bellied toad
 european green toad
+european toad
 european tree frog
 fire salamander
 fire-bellied newt
@@ -59,6 +123,8 @@ fire-bellied toad
 fowler's toad
 frog
 gastric-brooding frog
+gastrophryne carolinensis
+gastrophryne olivacea
 ghost frog
 giant salamander
 glass frog
@@ -67,6 +133,7 @@ golden poison frog
 golden toad
 goliath frog
 gopher frog
+grass frog
 gray tree frog
 great crested newt
 great plains toad
@@ -79,25 +146,49 @@ green tree frog
 hairy frog
 hellbender
 horned frog
+hydromantes brunus
+hydromantes shastae
+hyla arenicolor
+hyla crucifer
+hyla regilla
+hylactophryne augusti
+hynerpeton bassetti
 iberian ribbed newt
+ichthyostega
 indian bullfrog
 japanese fire-bellied newt
 japanese giant salamander
 jefferson salamander
 kaiser's spotted newt
+labyrinthodont
 lake titicaca water frog
 lemur leaf frog
 leopard frog
+leptodactylid
+leptodactylid frog
+leptodactylus pentadactylus
 lesser siren
+limestone salamander
+liopelma hamiltoni
+lithobates catesbeianus
+lithobates clamitans
+lithobates palustris
+lithobates pipiens
+lithobates sylvaticus
+lithobates tarahumarae
 long-tailed salamander
+lowland burrowing treefrog
 lumpy newt
+lungless salamander
 malayan horned frog
 mantella
 marbled newt
 marbled salamander
 marsh frog
+megalobatrachus maximus
 midwife toad
 mink frog
+mole salamander
 monkey frog
 mossy frog
 mountain chicken frog
@@ -106,18 +197,26 @@ mud salamander
 mudpuppy
 mudpuppy (salamander)
 natterjack toad
+necturus maculosus
 newt
+northern casque-headed frog
+northern cricket frog
 northern leopard frog
 northern red-legged frog
 northern slimy salamander
+notophthalmus viridescens
 oak toad
+obstetrical toad
 olm
+olympic salamander
 oregon spotted frog
 oriental fire-bellied toad
 ornate horned frog
 pacific chorus frog
 pacific giant salamander
+pacific newt
 pacific tree frog
+pacific tree toad
 pacman frog
 paddle-tail newt
 painted reed frog
@@ -126,53 +225,109 @@ panamanian golden frog
 paradox frog
 pickerel frog
 pig frog
+pipa americana
+pipa pipa
+plains spadefoot
+plethodon cinereus
+plethodon vehiculum
+plethodont
 poison dart frog
 pool frog
+proteus anguinus
+pternohyla fodiens
 purple frog
 rain frog
+rana cascadae
+rana catesbeiana
+rana clamitans
+rana goliath
+rana palustris
+rana pipiens
+rana sylvatica
+rana tarahumarae
+rana temporaria
+ranid
+red eft
 red salamander
 red-backed salamander
 red-eyed tree frog
 red-legged frog
 red-spotted newt
+rhyacotriton olympicus
+ribbed toad
 ringed caecilian
 river frog
+robber frog
 rough-skinned newt
 salamander
+salamandra atra
+salamandra maculosa
+salamandra salamandra
+salientian
+scaphiopus bombifrons
+scaphiopus hammondii
+scaphiopus multiplicatus
+shasta salamander
+sheep frog
 shovel-nosed salamander
 siren
 siren (amphibian)
+slender salamander
 slimy salamander
 smooth newt
 solomon island leaf frog
+south american bullfrog
+south american poison toad
 southern leopard frog
+southern spadefoot
 southern toad
+southwestern toad
+spadefoot
 spadefoot toad
 spanish ribbed newt
 spotted salamander
+spring frog
 spring peeper
 spring salamander
 strawberry poison dart frog
 surinam toad
 tailed frog
+tailed toad
 tarahumara frog
+taricha granulosa
+taricha torosa
+texas toad
 tiger salamander
 toad
+toad frog
 tomato frog
+tongueless frog
 tree frog
+tree toad
+triton
+triturus vulgaris
+true frog
+true toad
 two-lined salamander
+urodele
 vietnamese mossy frog
 wallace's flying frog
 warty newt
 water dog
 water frog
 waxy monkey frog
+web-toed salamander
 western chorus frog
 western leopard frog
+western narrow-mouthed toad
+western red-backed salamander
+western spadefoot
 western toad
 white's tree frog
 wood frog
 woodhouse's toad
+worm salamander
+xenopus laevis
 yellow-bellied toad
 yellow-spotted salamander
 yosemite toad

--- a/lists/animal/arachnid.yml
+++ b/lists/animal/arachnid.yml
@@ -1,0 +1,75 @@
+---
+title: Arachnids
+category: animal
+description: "Spiders, scorpions, mites, ticks, and related arachnids"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acarid
+acarine
+acarus
+arachnid
+arachnoid
+aranea diademata
+araneus cavaticus
+argasid
+argiope aurantia
+barn spider
+black and gold garden spider
+black widow
+black-legged tick
+book scorpion
+chelifer cancroides
+chigger
+comb-footed spider
+daddy longlegs
+dermacentor variabilis
+european wolf spider
+false scorpion
+garden spider
+genus acarus
+hard tick
+harvest mite
+harvestman
+hunting spider
+itch mite
+ixodes dammini
+ixodes dentatus
+ixodes neotomae
+ixodes pacificus
+ixodes persulcatus
+ixodes ricinus
+ixodes scapularis
+ixodes spinipalpis
+ixodid
+jigger
+latrodectus mactans
+lycosa tarentula
+mastigoproctus giganteus
+mite
+orb-weaving spider
+panonychus ulmi
+phalangium opilio
+pseudoscorpion
+red spider
+red spider mite
+redbug
+rust mite
+sarcoptid
+sheep-tick
+soft tick
+spider mite
+tarantula
+tetranychid
+theridiid
+trap-door spider
+trombiculid
+trombidiid
+vinegarroon
+web-spinning mite
+western black-legged tick
+whip-scorpion

--- a/lists/animal/bird.yml
+++ b/lists/animal/bird.yml
@@ -2,58 +2,172 @@
 title: All birds
 category: animal
 description: "Wide variety of bird species including songbirds, raptors, parrots, and penguins"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 abert's towhee
 acadian flycatcher
+acanthisitta chloris
+accentor
+accipiter cooperii
+accipiter gentilis
+accipiter nisus
+accipitriformes
 acorn woodpecker
+acridotheres tristis
+acrocephalus schoenobaenus
+actitis hypoleucos
+actitis macularia
+adelie
 adelie penguin
+adjutant
+adjutant bird
+adjutant stork
+aegypiidae
+aegypius monachus
+aepyornis
+african gray
+african grey
 african grey parrot
+afropavo
+afropavo congensis
+agelaius phoeniceus
+agriocharis ocellata
+aix galericulata
+aix sponsa
+ajaia ajaja
+alauda arvensis
 albert's lyrebird
+alca torda
+alcedo atthis
 alder flycatcher
+alectoris graeca
+alectoris ruffa
+alectura lathami
 aleutian tern
 allen's hummingbird
 altamira oriole
+amadavat
+amazon
 american avocet
 american bittern
 american black duck
 american coot
+american creeper
 american crow
 american dipper
+american eagle
+american egret
+american gallinule
 american golden-plover
 american goldfinch
 american kestrel
+american magpie
+american merganser
+american oriole
 american oystercatcher
 american pipit
 american redstart
 american robin
 american tree sparrow
+american water ouzel
 american white pelican
+american widgeon
 american wigeon
 american woodcock
+anas acuta
+anas americana
+anas clypeata
+anas crecca
+anas discors
+anas penelope
+anas platyrhynchos
+anas querquedula
+anas rubripes
 ancient murrelet
 andean condor
+anhima cornuta
 anhinga
+anhinga anhinga
+ani
 anna's hummingbird
+anomalopteryx
+anomalopteryx oweni
+anser anser
+anser cygnoides
+anseriform bird
+ant shrike
+ant thrush
+antbird
+anthus pratensis
 antillean nighthawk
 antillean palm swift
+aphriza virgata
 aplomado falcon
+apodiform bird
+aptenodytes forsteri
+aptenodytes patagonica
+apteryx
+apus apus
+aquatic bird
+aquila chrysaetos
+aquila rapax
+aramus guarauna
+aramus pictus
+archaeopteryx lithographica
+archaeornis
+archeopteryx
+archilochus colubris
 arctic loon
+arctic skua
 arctic tern
 arctic warbler
+ardea herodia
+ardea herodius
+ardea occidentalis
+arenaria interpres
+arenaria melanocephala
+argus
+argus pheasant
+arkansas kingbird
 ash-throated flycatcher
 ashy storm-petrel
+asian black grouse
 asian brown flycatcher
+asio otus
+athene noctua
 atlantic puffin
+audubon warbler
+audubon's caracara
 audubon's oriole
 audubon's shearwater
+audubon's warbler
+auk
+auklet
+auriparus flaviceps
 australasian grebe
 australasian swamphen
+australian magpie
 australian owlet-nightjar
 australian shelduck
+australian stilt
+australian turtledove
+avadavat
+aythya affinis
+aythya americana
+aythya ferina
+aythya marila
+aythya valisineria
 aztec thrush
 azure gallinule
+babbler
 bachman's sparrow
 bachman's warbler
+baeolophus bicolor
 bahama mockingbird
 bahama swallow
 bahama woodstar
@@ -61,13 +175,21 @@ baikal teal
 baillon's crake
 baird's sandpiper
 baird's sparrow
+balaeniceps rex
 bald eagle
+baldpate
+baltimore bird
 baltimore oriole
 bananaquit
 band-rumped storm-petrel
+band-tail pigeon
 band-tailed gull
 band-tailed pigeon
+banded stilt
+bandtail
+bank martin
 bank swallow
+bantam
 bar-shouldered dove
 bar-tailed godwit
 barn owl
@@ -75,17 +197,32 @@ barn swallow
 barnacle goose
 barred owl
 barrow's goldeneye
+bartramia longicauda
+bartramian sandpiper
 bay-breasted warbler
 bean goose
+bee eater
+bell magpie
 bell's vireo
 bellbird
 belted kingfisher
 bendire's thrasher
 berylline hummingbird
+bewick's swan
 bewick's wren
 bicknell's thrush
+bird of jove
+bird of juno
+bird of minerva
+bird of night
+bird of passage
+bird of prey
+bittern
 black catbird
+black duck
+black grouse
 black guillemot
+black kite
 black noddy
 black oystercatcher
 black phoebe
@@ -93,6 +230,7 @@ black rail
 black rosy-finch
 black scoter
 black skimmer
+black stork
 black storm-petrel
 black swan
 black swift
@@ -100,6 +238,7 @@ black tern
 black turnstone
 black vulture
 black-and-white warbler
+black-backed gull
 black-backed wagtail
 black-backed woodpecker
 black-bellied plover
@@ -116,10 +255,13 @@ black-chinned sparrow
 black-crowned night heron
 black-faced grassquit
 black-footed albatross
+black-fronted bush shrike
 black-headed grosbeak
 black-headed gull
 black-legged kittiwake
+black-necked grebe
 black-necked stilt
+black-necked stork
 black-tailed gnatcatcher
 black-tailed godwit
 black-tailed gull
@@ -132,13 +274,21 @@ black-vented oriole
 black-vented shearwater
 black-whiskered vireo
 black-winged stilt
+blackbird
+blackburn
 blackburnian warbler
+blackcap
+blackcock
+blackpoll
 blackpoll warbler
 blue bunting
+blue darter
+blue goose
 blue grosbeak
 blue grouse
 blue jay
 blue mockingbird
+blue peafowl
 blue-billed duck
 blue-footed booby
 blue-gray gnatcatcher
@@ -146,17 +296,40 @@ blue-headed vireo
 blue-throated hummingbird
 blue-winged teal
 blue-winged warbler
+bluebill
+bluebird
 bluethroat
+bluewing
+boat-billed heron
 boat-tailed grackle
+boatbill
+boatswain bird
 bobolink
+bobwhite
+bobwhite quail
 bohemian waxwing
+bombycilla cedrorum
+bombycilla cedrorun
+bombycilla garrulus
 bonaparte's gull
+bonasa umbellus
+bonxie
 boreal chickadee
 boreal owl
+botaurus lentiginosus
+botaurus stellaris
 botteri's sparrow
+bowerbird
 brambling
 brandt's cormorant
 brant
+brant goose
+branta bernicla
+branta canadensis
+branta leucopsis
+brazilian trumpeter
+brent
+brent goose
 brewer's blackbird
 brewer's sparrow
 bridled tern
@@ -166,8 +339,12 @@ broad-billed hummingbird
 broad-billed sandpiper
 broad-tailed hummingbird
 broad-winged hawk
+broadbill
 brolga
 bronzed cowbird
+brood hen
+broody
+broody hen
 brown booby
 brown creeper
 brown cuckoo-dove
@@ -177,6 +354,7 @@ brown noddy
 brown pelican
 brown shrike
 brown thrasher
+brown thrush
 brown-capped rosy-finch
 brown-chested martin
 brown-crested flycatcher
@@ -185,19 +363,53 @@ brown-headed nuthatch
 brush bronzewing
 brush cuckoo
 brush turkey
+bubo virginianus
+bubulcus ibis
+bucephala albeola
+bucephala clangula
+bucephala islandica
+bucephela albeola
+bucephela clangula
+budgereegah
 budgerigar
+budgerygah
+budgie
 buff-banded rail
 buff-bellied hummingbird
 buff-breasted flycatcher
 buff-breasted sandpiper
 buff-collared nightjar
 bufflehead
+bulbul
+bullbat
 buller's shearwater
+bullfinch
 bullock's oriole
 bumblebee hummingbird
+bunting
+burhinus oedicnemus
 burrowing owl
+bush shrike
 bushtit
+bustard
+bustard quail
+butcherbird
+buteo buteo
+buteo jamaicensis
+buteo lagopus
+buteo lineatus
+buteonine
+butterball
+button quail
+buzzard
+cacatua galerita
+cacique
+cackler
 cactus wren
+cairina moschata
+calidris canutus
+calidris ferruginea
+calidris melanotos
 california condor
 california gnatcatcher
 california gull
@@ -205,59 +417,167 @@ california quail
 california thrasher
 california towhee
 calliope hummingbird
+camp robber
+campephilus principalis
+canachites canadensis
 canada goose
+canada jay
 canada warbler
+canadian goose
+canary bird
 canvasback
+canvasback duck
 canyon towhee
 canyon wren
 cape barren goose
 cape may warbler
+capercaillie
+capercailzie
+capon
+caprimulgid
+caprimulgiform bird
+caprimulgus carolinensis
+caprimulgus europaeus
+caprimulgus vociferus
+caracara
+carancha
+cardinal grosbeak
+cardinalis cardinalis
+carduelis cannabina
+carduelis carduelis
+carduelis cucullata
+carduelis flammea
+carduelis hornemanni
+carduelis spinus
+cariama cristata
 caribbean elaenia
+carinate
+carinate bird
 carolina chickadee
 carolina parakeet
 carolina wren
+carpodacus mexicanus
+carpodacus purpureus
+carrier pigeon
+carrion crow
+casmerodius albus
 caspian tern
 cassin's auklet
 cassin's finch
 cassin's kingbird
 cassin's sparrow
 cassin's vireo
+catbird
+catharacta skua
+cathartes aura
+cathartid
+catoptrophorus semipalmatus
 cattle egret
 cave swallow
+cazique
 cedar waxwing
+cedarbird
+centrocercus urophasianus
+centropus phasianinus
+centropus sinensis
+cephalopterus ornatus
+cepphus columba
+cepphus grylle
+certhia americana
+certhia familiaris
 cerulean warbler
+ceryle alcyon
+chachalaca
+chaffinch
+chaja
+chamaea fasciata
 channel-billed cuckoo
+charadrius melodus
+charadrius morinellus
+charadrius vociferus
+chat
+chateura pelagica
+chatterer
+chauna torquata
+cheewink
+chen caerulescens
 chestnut-backed chickadee
 chestnut-breasted cuckoo
 chestnut-collared longspur
 chestnut-rail
 chestnut-sided warbler
+chewink
+chicken hawk
 chihuahuan raven
+chimney swallow
 chimney swift
 chinese egret
+chinese goose
 chinstrap penguin
 chipping sparrow
+chlamydera nuchalis
+chlorophoneus nigrifrons
+chlorura chlorura
+choriotis australis
+chough
+chrysolophus pictus
 chuck-will's-widow
 chukar
+chunga
+chunga burmeisteri
+ciconia ciconia
+ciconia nigra
+cinclus aquaticus
+cinclus mexicanus
 cinnamon hummingbird
 cinnamon teal
+circus aeruginosus
+circus cyaneus
+circus pygargus
+cistothorus palustris
+cistothorus platensis
 citrine wagtail
+cladorhyncus leucocephalum
+clangula hyemalis
 clapper rail
 clark's grebe
 clark's nutcracker
 clay-colored robin
 clay-colored sparrow
 cliff swallow
+coastal diving bird
+cob
+coccothraustes coccothraustes
+coccyzus erythropthalmus
+cochin
+cochin china
+cochlearius cochlearius
+cockateel
 cockatiel
+cockatoo parrot
+cockerel
+colaptes auratus
+colaptes auratus cafer
+colaptes caper collaris
+colaptes chrysoides
 colima warbler
+colinus virginianus
 collared forest-falcon
 collared plover
+collocalia inexpectata
+columba fasciata
+columba livia
+columba palumbus
+columbiform bird
 common black-hawk
+common brant goose
 common bronzewing
+common canary
 common chaffinch
 common crane
 common cuckoo
 common eider
+common european jay
 common goldeneye
 common grackle
 common greenshank
@@ -268,6 +588,7 @@ common merganser
 common moorhen
 common murre
 common nighthawk
+common nutcracker
 common ostrich
 common pauraque
 common pochard
@@ -277,46 +598,141 @@ common redpoll
 common ringed plover
 common rosefinch
 common sandpiper
+common scoter
 common snipe
+common spoonbill
+common starling
 common swift
 common tern
 common yellowthroat
+condor
+congo peafowl
 connecticut warbler
+contopus sordidulus
+contopus virens
+conuropsis carolinensis
 cook's petrel
 cooper's hawk
+coot
+coracias garrulus
+coraciiform bird
+coragyps atratus
 cordilleran flycatcher
+cormorant
 corn crake
+cornish
+cornish fowl
+corvine bird
+corvus brachyrhyncos
+corvus corax
+corvus frugilegus
+corvus monedula
 cory's shearwater
+coscoroba
 costa's hummingbird
+cotinga
 cotton pygmy goose
+coturnix communis
+coturnix coturnix
+coucal
 couch's kingbird
+courlan
+courser
+cowbird
+crake
 crane hawk
 craveri's murrelet
+cream-colored courser
+creeper
 crescent-chested warbler
 crested auklet
 crested caracara
+crested cariama
 crested myna
 crested pigeon
+crested screamer
+crested swift
+crex crex
 crimson rosella
 crimson-collared grosbeak
 crissal thrasher
+crocethia alba
+crocodile bird
+crossbill
+crow blackbird
+crow pheasant
 cuban martin
+cuculiform bird
+cuculus canorus
+curassow
+curlew
 curlew sandpiper
+currawong
+curruca communis
+cursorius cursor
 curve-billed thrasher
+cushat
+cyanistes caeruleus
+cyanocitta cristata
+cygnet
+cygnus atratus
+cygnus buccinator
+cygnus columbianus
+cygnus columbianus bewickii
+cygnus columbianus columbianus
+cygnus cygnus
+cygnus olor
+dabbler
+dabbling duck
+dabchick
+dacelo gigas
 dark-eyed junco
+daw
+delichon urbica
+dendroica auduboni
+dendroica coronata
+dendroica fusca
+dendroica petechia
+dendroica striata
+dendroica striate
+dendroica tigrina
 diamond dove
 dickcissel
+dickeybird
+dickybird
+dinornis giganteus
+diomedea exulans
+diomedea nigripes
+dipper
+diver
+diving duck
+diving petrel
+dolichonyx oryzivorus
+domestic fowl
+domestic pigeon
+dominick
+dominique
+dorking
+dotrel
+dotterel
 double-crested cormorant
 double-striped thick-knee
 double-wattled cassowary
+dove
 dovekie
+dowitcher
 downy woodpecker
+drake
+dromaius novaehollandiae
+duckling
+dumetella carolinensis
 dunlin
 dusky flycatcher
 dusky moorhen
 dusky thrush
 dusky warbler
 dusky-capped flycatcher
+eaglet
 eared grebe
 eared trogon
 eastern bluebird
@@ -327,14 +743,41 @@ eastern rosella
 eastern screech-owl
 eastern towhee
 eastern wood-pewee
+ectopistes migratorius
+egret
+egretta albus
+egretta caerulea
+egretta garzetta
+egretta thula
+eider
+eider duck
+elanoides forficatus
+elanus leucurus
 elegant tern
 elegant trogon
+elephant bird
 elf owl
+emberiza aureola
+emberiza citrinella
+emberiza hortulana
+emberiza schoeniclus
 emperor goose
 emperor penguin
 emu
+emu novaehollandiae
 emu-wren
+english sparrow
+ephippiorhynchus senegalensis
+erithacus rubecola
+erithacus rubecula
+erithacus svecicus
+ern
+erne
+erolia alpina
+erolia minutilla
 eskimo curlew
+eudromias morinellus
+euphagus carolinus
 eurasian blackbird
 eurasian bullfinch
 eurasian collared-dove
@@ -344,19 +787,50 @@ eurasian dotterel
 eurasian hobby
 eurasian jackdaw
 eurasian kestrel
+eurasian kingfisher
 eurasian oystercatcher
 eurasian siskin
 eurasian tree sparrow
 eurasian wigeon
 eurasian woodcock
 eurasian wryneck
+european bittern
+european black grouse
+european blackbird
+european creeper
+european cuckoo
+european curlew
+european gallinule
+european goatsucker
 european golden-plover
+european hoopoe
+european magpie
+european nightjar
+european nuthatch
+european roller
+european sandpiper
+european sea eagle
+european shrike
 european starling
 european storm-petrel
+european swift
 european turtle-dove
+european water ouzel
 evening grosbeak
+eyas
 eyebrowed thrush
+fairy bluebird
+fairy swallow
 falcated duck
+falco columbarius
+falco peregrinus
+falco rusticolus
+falco sparverius
+falco subbuteo
+falco tinnunculus
+falcon-gentil
+falcon-gentle
+family aegypiidae
 fan-tailed cuckoo
 fan-tailed warbler
 fantail
@@ -365,42 +839,113 @@ ferruginous hawk
 ferruginous pygmy-owl
 field sparrow
 fieldfare
+fig-bird
+firebird
 fish crow
+fish duck
+fish eagle
+fish hawk
+fishing eagle
 five-striped sparrow
 flame-colored tanager
 flammulated owl
 flesh-footed shearwater
+flicker
+flightless bird
+flinthead
 flock bronzewing
+florida gallinule
 florida scrub-jay
+flycatcher
+flycatching warbler
+flying bird
 fork-tailed flycatcher
 fork-tailed storm-petrel
 fork-tailed swift
 forster's tern
+fowl
 fox sparrow
 franklin's gull
+fratercula arctica
+fratercula cirrhata
+fratercula corniculata
 freckled duck
+fringilla coelebs
+fringilla montifringilla
+frogmouth
+fulica americana
+fulica atra
+fulmar
+fulmar petrel
+fulmarus glacialis
 fulvous whistling-duck
 gadwall
 galah
+gallina
+gallinacean
+gallinaceous bird
+gallinago gallinago
+gallinago gallinago delicata
+gallinago media
+gallinula chloropus
+gallinula chloropus cachinnans
+gallinule
+gallus gallus
 gambel's quail
+game bird
+game fowl
+gamecock
+gander
 gang-galah
+gannet
 garganey
+garrulus glandarius
+garullus garullus
+gaviiform seabird
 gentoo penguin
+geococcyx californianus
+geothlypis trichas
+gerfalcon
+giant fulmar
+giant moa
+giant petrel
 gila woodpecker
 gilded flicker
+glareole
 glaucous gull
 glaucous-winged gull
+glossopsitta versicolor
 glossy ibis
+gnatcatcher
+goatsucker
+gobbler
+godwit
+gold-crowned kinglet
 golden bowerbird
 golden eagle
 golden pheasant
+golden plover
+golden warbler
 golden-cheeked warbler
+golden-crested kinglet
 golden-crowned kinglet
 golden-crowned sparrow
 golden-crowned warbler
 golden-fronted woodpecker
 golden-winged warbler
+goldeneye
+goldfinch
+gooney
+gooney bird
+goonie
+goony
+goosander
+gosling
 grace's warbler
+grackle
+gracula religiosa
+grass finch
+grass parakeet
 grasshopper sparrow
 gray bunting
 gray catbird
@@ -409,6 +954,7 @@ gray hawk
 gray jay
 gray kingbird
 gray partridge
+gray sea eagle
 gray silky-flycatcher
 gray vireo
 gray wagtail
@@ -419,21 +965,30 @@ gray-crowned yellowthroat
 gray-headed chickadee
 gray-spotted flycatcher
 gray-tailed tattler
+grayback
+grayhen
+graylag
+graylag goose
 great auk
 great black-backed gull
 great blue heron
+great bowerbird
+great bustard
 great cormorant
 great crested flycatcher
 great crested grebe
 great egret
 great frigatebird
 great gray owl
+great grey owl
 great hornbill
 great horned owl
 great kiskadee
 great knot
 great skua
+great snipe
 great spotted woodpecker
+great white heron
 great white pelican
 great-tailed grackle
 greater flamingo
@@ -444,97 +999,235 @@ greater roadrunner
 greater scaup
 greater shearwater
 greater white-fronted goose
+greater whitethroat
 greater yellowlegs
+greek partridge
 green heron
 green jay
 green kingfisher
 green peacock
+green peafowl
+green plover
 green pygmy goose
 green sandpiper
 green violet-ear
+green woodpecker
 green-breasted mango
 green-tailed towhee
 green-winged teal
 greenish elaenia
+greenshank
+greenwing
+grey catbird
 grey heron
+grey jay
+grey kingbird
+grey partridge
+grey sea eagle
 grey warbler
+greyback
+greyhen
+greylag
+greylag goose
+griffon
 groove-billed ani
+grosbeak
+grossbeak
+ground roller
+grus americana
+guacharo
+guan
+guillemot
+guinea
+guinea hen
+gull
 gull-billed tern
+gymnogyps californianus
+gymnorhina tibicen
+gypaetus barbatus
+gyps fulvus
 gyrfalcon
 hadada ibis
 hairy woodpecker
+half snipe
+haliaeetus leucocephalus
+haliaeetus leucorhyphus
+haliaeetus pelagicus
+haliatus albicilla
 hammond's flycatcher
+hangbird
 hardhead
 harlequin duck
+harpia harpyja
+harpy
 harpy eagle
+harrier eagle
 harris's hawk
 harris's sparrow
+hawaiian honeycreeper
 hawfinch
+hawk owl
+heath hen
+heathfowl
+hedge sparrow
 heermann's gull
 helmeted guineafowl
+hemipode
+hen harrier
+hen hawk
 henslow's sparrow
 hepatic tanager
 herald petrel
 hermit thrush
 hermit warbler
 herring gull
+hesperiphona vespertina
+heteroscelus incanus
+hill myna
 himalayan snowcock
+himantopus himantopus
+himantopus himantopus leucocephalus
+himantopus mexicanus
+himantopus novae-zelandiae
+himantopus stilt
+hirundo nigricans
+hirundo pyrrhonota
+hirundo rustica
+hoactzin
 hoary redpoll
 hoary-headed grebe
+hoatzin
+hobby
+homer
+homing pigeon
+honey eater
+honey guide
+honeycreeper
+honeysucker
+honker
 hooded merganser
 hooded oriole
+hooded sheldrake
 hooded warbler
 hook-billed kite
 hoopoe
+hoopoo
+hoot owl
+hooter
 hornbill
 horned grebe
 horned lark
+horned owl
 horned puffin
+horned screamer
+horse of the wood
 house finch
+house martin
 house sparrow
 house swift
 house wren
 hudsonian godwit
+hungarian partridge
 hutton's vireo
 hyacinth macaw
+hydrobates pelagicus
+hylocichla fuscescens
+hylocichla guttata
+hylocichla mustelina
+hylophylax naevioides
+ibero-mesornis
+ibis ibis
 iceland gull
+icteria virens
+icterus galbula
+icterus galbula bullockii
+icterus galbula galbula
+icterus spurius
 inca dove
+indian grackle
 indian peacock
 indian roller
+indigo bird
 indigo bunting
+indigo finch
+iridoprocne bicolor
 island scrub-jay
 ivory gull
 ivory-billed woodpecker
+ivorybill
+ixobrychus exilis
 jabiru
+jabiru mycteria
+jacamar
 jack snipe
+jaeger
+java finch
+java sparrow
+jay
+jaybird
+jenny wren
+junco
+junco hyemalis
+jungle hen
 jungle nightjar
 juniper titmouse
 kaka
 kakapo
+kakatoe galerita
+kakatoe leadbeateri
+kaki
+kamchatkan sea eagle
 kea
 keel-billed toucan
 kentucky warbler
 key west quail-dove
+kildeer
 killdeer
+killdeer plover
 king eider
 king penguin
 king rail
+kingbird
+kinglet
 kirtland's warbler
+kite
+kittiwake
 kittlitz's murrelet
+knot
 kokako
 la sagra's flycatcher
 labrador duck
 ladder-backed woodpecker
 lady amherst's pheasant
+lagopus scoticus
+lake duck
+lammergeier
+lammergeyer
 lanceolated warbler
+land rail
+lanius borealis
+lanius excubitor
+lanius lucovicianus
+lanius ludovicianus
+lanius ludovicianus excubitorides
+lanius ludovicianus migrans
 lapland longspur
+lapwing
 large-billed tern
+larid
+lark
 lark bunting
 lark sparrow
+larus argentatus
+larus canus
+larus marinus
+larus ridibundus
 laughing dove
 laughing gull
 laughing kookaburra
+laughing owl
 lawrence's goldfinch
+layer
 laysan albatross
 lazuli bunting
 le conte's sparrow
@@ -547,6 +1240,10 @@ least grebe
 least sandpiper
 least storm-petrel
 least tern
+leipoa
+leipoa ocellata
+leptoptilus crumeniferus
+leptoptilus dubius
 lesser black-backed gull
 lesser flamingo
 lesser frigatebird
@@ -554,87 +1251,208 @@ lesser goldfinch
 lesser nighthawk
 lesser prairie-chicken
 lesser scaup
+lesser scaup duck
 lesser white-fronted goose
+lesser whitethroat
 lesser yellowlegs
 lewin's rail
 lewis's woodpecker
 lilac-breasted roller
+limicoline bird
+limnocryptes minima
+limnodromus griseus
+limnodromus scolopaceus
+limosa haemastica
 limpkin
 lincoln's sparrow
+lintwhite
+little auk
 little blue heron
 little bronze cuckoo
 little bunting
 little curlew
 little egret
+little grebe
 little gull
+little owl
 little ringed plover
 little shearwater
 little spotted kiwi
 little stint
+lobipes lobatus
+lofortyx californicus
 loggerhead kingbird
 loggerhead shrike
 long-billed curlew
 long-billed dowitcher
+long-billed marsh wren
 long-billed murrelet
 long-billed thrasher
 long-eared owl
 long-tailed cuckoo
 long-tailed jaeger
 long-toed stint
+longlegs
+loon
+lophodytes cucullatus
+lory
 louisiana waterthrush
+lowan
+loxia curvirostra
 lucifer hummingbird
 lucy's warbler
+lunda cirrhata
+luscinia luscinia
+luscinia megarhynchos
+lyrurus mlokosiewiczi
+lyrurus tetrix
 macgillivray's warbler
+macrocephalon maleo
+macronectes giganteus
 magnificent frigatebird
 magnificent hummingbird
 magnolia warbler
 malachite kingfisher
+maleo
 mallard
+mallee hen
 malleefowl
+mamo
+man-of-war bird
+manakin
 mandarin duck
 mangrove cuckoo
 manx shearwater
+maori hen
+marabou
 marabou stork
+marabout
 marbled frogmouth
 marbled godwit
 marbled murrelet
+mareca americana
+mareca penelope
+marsh harrier
+marsh hawk
+marsh hen
 marsh sandpiper
 marsh wren
+martin
+maryland yellowthroat
 masked booby
 masked duck
 masked tityra
+mavis
 mccown's longspur
 mckay's bunting
+meadow pipit
+meadowlark
+megapode
+melanerpes erythrocephalus
+melanitta nigra
+melanotis caerulescens
+meleagris gallopavo
+melopsittacus undulatus
+melospiza georgiana
+melospiza melodia
+merganser
+mergus albellus
+mergus merganser
+mergus merganser americanus
+mergus serrator
+merl
+merle
 merlin
+mew
 mew gull
 mexican chickadee
 mexican jay
 middendorff's grasshopper-warbler
+migrant shrike
+migratory quail
+milvus migrans
+mimus polyglottos
+mina
+minah
+missel thrush
 mississippi kite
+mistle thrush
+mistletoe thrush
+moa
+mocker
+mocking thrush
+mockingbird
+mollymawk
+momot
+monal
+monaul
 mongolian plover
 monk parakeet
+montagu's harrier
 montezuma quail
+moorbird
+moorcock
+moorfowl
+moorgame
 morepork
+mosquito hawk
+mother carey's chicken
+mother carey's hen
+mother hen
+motmot
 mottled duck
 mottled owl
 mottled petrel
+mound bird
+mound builder
 mountain bluebird
 mountain chickadee
+mountain partridge
 mountain plover
 mountain quail
 mourning dove
 mourning warbler
+mud hen
 mugimaki flycatcher
 murphy's petrel
+murre
+muscicapa grisola
+muscicapa striata
+muscivora forficata
 muscovy duck
 musk duck
 mute swan
+mycteria americana
+myna
+mynah
+mynah bird
+myrtle bird
+myrtle warbler
+nandu
 narcissus flycatcher
 nashville warbler
 nelson's sharp-tailed sparrow
+neophron percnopterus
 neotropic cormorant
+nester
+nestor notabilis
+new world blackbird
+new world chat
+new world flycatcher
+new world goldfinch
+new world jay
+new world oriole
+new world sparrow
+new world vulture
+new world warbler
 new zealand robin
+new zealand wren
+night bird
+night raven
+nighthawk
+nightjar
 noisy scrub-bird
+nonpasserine bird
 north island takahe
 northern beardless-tyrannulet
 northern bobwhite
@@ -648,99 +1466,315 @@ northern hawk owl
 northern jacana
 northern lapwing
 northern mockingbird
+northern oriole
 northern parula
+northern phalarope
 northern pintail
 northern pygmy-owl
 northern rough-winged swallow
 northern saw-whet owl
 northern shoveler
 northern shrike
+northern storm petrel
 northern waterthrush
 northern wheatear
 northwestern crow
+notornis
+notornis mantelli
+nucifraga caryocatactes
+nucifraga columbiana
+numenius arquata
+numenius borealis
+numida meleagris
+nutcracker
+nuthatch
 nuttall's woodpecker
 nutting's flycatcher
+nyctanassa violacea
+nycticorax nycticorax
+nymphicus hollandicus
 oak titmouse
+oceanic bird
+oceanites oceanicus
+ocellated turkey
+oilbird
+old world chat
+old world coot
+old world flycatcher
+old world jay
+old world oriole
+old world quail
+old world robin
+old world scops owl
+old world vulture
+old world warbler
+old world white pelican
 oldsquaw
+oldwife
 olive sparrow
 olive warbler
 olive-backed pipit
 olive-sided flycatcher
+openbill
+opisthocomus hoazin
 orange-bellied fruit-dove
 orange-crowned warbler
 orange-footed scrubfowl
 orchard oriole
+order accipitriformes
+oreortyx picta palmeri
 oriental cuckoo
 oriental greenfinch
 oriental pratincole
 oriental scops-owl
 oriental turtle-dove
+oriole
+oriolus oriolus
+orpington
+orthotomus sutorius
+ortilis vetula macalli
+ortolan
+ortygan
+oscine
+oscine bird
 osprey
+otis tarda
+otus asio
+otus scops
+otus sunia
+ousel
+ouzel
 ovenbird
+owlet
+oxyura jamaicensis
+oystercatcher
 pacific emerald dove
 pacific golden-plover
 pacific koel
 pacific loon
 pacific swift
 pacific-slope flycatcher
+padda oryzivora
+pagophila eburnea
 paint-billed crake
 painted bunting
 painted redstart
+painted sandgrouse
 pallas's bunting
+pallas's sandgrouse
 pallid cuckoo
 palm cockatoo
 palm warbler
+pandion haliaetus
 papuan frogmouth
 parakeet auklet
+paraquet
 parasitic jaeger
+paroquet
+parrakeet
+parroket
+parroquet
 partridge pigeon
+parula americana
+parula warbler
+parus atricapillus
+parus bicolor
+parus caeruleus
+parus carolinensis
 passenger pigeon
+passer domesticus
+passer montanus
+passeriform bird
+passerina cyanea
+passerine
+pastor roseus
+pastor sturnus
+pavo cristatus
+pavo muticus
 peaceful dove
+peachick
 peafowl
+peahen
 pechora pipit
+pecker
+peckerwood
 pectoral sandpiper
+pedioecetes phasianellus
+pedionomus torquatus
+peewee
+peewit
+pelagic bird
 pelagic cormorant
+pelecaniform seabird
+pelecanus erythrorhynchos
+pelecanus onocrotalus
+pen
+perdix perdix
+peregrine
 peregrine falcon
+perisoreus canadensis
+perisoreus canadensis capitalis
+pernis apivorus
+petchary
+petrel
+petrochelidon nigricans
+pewee
+pewit
+pewit gull
+pezophaps solitaria
 phainopepla
+phalacrocorax carbo
+phalaenoptilus nuttallii
+phalarope
+phalaropus fulicarius
+phalaropus tricolor
+pharaoh's chicken
+pharomacrus mocino
+phasianid
+phasianus colchicus
 pheasant coucal
+pheasant cuckoo
 philadelphia vireo
+philohela minor
+philomachus pugnax
+phoebe
+phoebe bird
+phylloscopus sibilatrix
+pica pica
+pica pica hudsonia
+piciform bird
+piculet
+picus viridis
 pied-billed grebe
 pigeon guillemot
+pigeon hawk
 pileated woodpecker
+pin-tailed duck
+pin-tailed grouse
+pin-tailed sandgrouse
 pin-tailed snipe
 pine bunting
+pine finch
 pine grosbeak
 pine siskin
 pine warbler
+pinguinus impennis
+pinicola enucleator
+pink cockatoo
 pink-eared duck
 pink-footed goose
 pink-footed shearwater
+pintail
 pinyon jay
+pipilo erythrophthalmus
+piping crow
+piping crow-shrike
+piping guan
 piping plover
+pipit
+piranga flava hepatica
+piranga ludoviciana
+piranga olivacea
+piranga rubra
+pitta
 plain chachalaca
+plain turkey
+plain wanderer
 plain-capped starthroat
+platalea leucorodia
+plautus alle
+plectrophenax nivalis
+ploceus philippinus
+plover
 plumbeous vireo
 plumed whistling duck
+pluvianus aegyptius
+plymouth rock
+pochard
+podiceps cristatus
+podiceps grisegena
+podiceps nigricollis
+podiceps ruficollis
+podicipitiform seabird
+podilymbus podiceps
+poecile atricapillus
+poecile carolinensis
+poephila castanotis
+policeman bird
+poll
+poll parrot
+polyborus cheriway audubonii
+polyborus plancus
+polynesian tattler
 pomarine jaeger
+pooecetes gramineus
+poorwill
+popinjay
+porphyrio porphyrio
+porphyrula martinica
+porzana porzana
+poultry
+pouter
+pouter pigeon
 prairie falcon
+prairie fowl
+prairie grouse
 prairie warbler
+pratincole
+procellaria aequinoctialis
+procellariiform seabird
+progne subis
 prothonotary warbler
+protoavis
+prunella modularis
+psittacula krameri
+psittacus erithacus
+psophia crepitans
+ptarmigan
+pterocles alchata
+pterocles indicus
+pterocnemia pennata
+ptilonorhynchus violaceus
+ptiloris paradisea
+puffbird
+puffinus puffinus
 pukeko
+pullet
 purple finch
 purple gallinule
+purple grackle
 purple martin
 purple sandpiper
 purple-crowned fairywren
 pygmy nuthatch
+pygoscelis adeliae
+pyrocephalus rubinus mexicanus
+pyrrhula pyrrhula
 pyrrhuloxia
+pyrrhuloxia sinuata
+quack-quack
 quetzal
+quetzal bird
+quiscalus quiscula
 radjah shelduck
+rail
 rainbow lorikeet
+raphus cucullatus
+raptor
+raptorial bird
+ratite
+ratite bird
+raven
+razor-billed auk
 razorbill
 red crossbill
+red grouse
+red jungle fowl
 red knot
 red phalarope
+red siskin
 red-backed fairywren
+red-backed sandpiper
 red-bellied woodpecker
 red-billed pigeon
 red-billed tropicbird
@@ -748,6 +1782,7 @@ red-breasted flycatcher
 red-breasted merganser
 red-breasted nuthatch
 red-breasted sapsucker
+red-breasted snipe
 red-cockaded woodpecker
 red-crowned parrot
 red-eyed vireo
@@ -758,11 +1793,13 @@ red-footed booby
 red-headed woodpecker
 red-legged crake
 red-legged kittiwake
+red-legged partridge
 red-naped sapsucker
 red-necked crake
 red-necked grebe
 red-necked phalarope
 red-necked stint
+red-shafted flicker
 red-shouldered hawk
 red-tailed hawk
 red-tailed tropicbird
@@ -770,24 +1807,60 @@ red-throated loon
 red-throated pipit
 red-whiskered bulbul
 red-winged blackbird
+redbird
+redbreast
 reddish egret
 redhead
+redpoll
+redshank
+redtail
 redwing
 reed bunting
+reedbird
+reeve
 regent bowerbird
+regulus calendula
+regulus regulus
+regulus satrapa
 resplendent quetzal
+resplendent trogon
+rhea
+rhea americana
 rhinoceros auklet
 rhinoceros hornbill
+rhode island red
+ricebird
+richmondena cardinalis
+riflebird
+rifleman bird
+ring blackbird
+ring ouzel
+ring thrush
 ring-billed gull
 ring-necked duck
+ring-necked parakeet
 ring-necked pheasant
+ringdove
 ringed kingfisher
+ringtail
+riparia riparia
+roadrunner
 roadside hawk
+robin redbreast
+rock cornish
 rock dove
+rock hopper
+rock partridge
+rock pigeon
 rock ptarmigan
 rock sandpiper
 rock wren
+rocky mountain jay
+roller
+rook
 rose-breasted grosbeak
+rose-colored pastor
+rose-colored starling
 rose-crowned fruit-dove
 rose-ringed parakeet
 rose-throated becard
@@ -796,8 +1869,10 @@ roseate tern
 ross's goose
 ross's gull
 rough-legged hawk
+roughleg
 royal tern
 ruby-crowned kinglet
+ruby-crowned wren
 ruby-throated hummingbird
 ruddy duck
 ruddy ground-dove
@@ -811,55 +1886,116 @@ rufous-backed robin
 rufous-capped warbler
 rufous-crowned sparrow
 rufous-winged sparrow
+rupicola peruviana
+rupicola rupicola
 rustic bunting
 rusty blackbird
+rusty grackle
 sabine's gull
+sacred ibis
 saddle-billed stork
 saddleback
+saddlebill
 sage grouse
+sage hen
 sage sparrow
 sage thrasher
+sagittarius serpentarius
+salpinctes obsoletus
 saltmarsh sharp-tailed sparrow
+sand martin
 sanderling
+sandgrouse
 sandhill crane
+sandpiper
 sandwich tern
+sapsucker
+sarcorhamphus papa
 sarus crane
+satin bird
 satin bowerbird
 savannah sparrow
+sawbill
+saxicola rubetra
+saxicola torquata
 say's phoebe
+sayornis phoebe
 scaled quail
 scaly-breasted lorikeet
 scaly-naped pigeon
 scarlet ibis
 scarlet macaw
 scarlet tanager
+scaup
+scaup duck
+sceloglaux albifacies
 scissor-tailed flycatcher
+scissortail
+scolopax rusticola
+scooter
+scops owl
+scoter
 scott's oriole
+screamer
 screech owl
+scrub fowl
+scrubbird
+sea duck
+sea mew
+sea swallow
+seabird
+seafowl
 seaside sparrow
 secretary bird
+sedge bird
 sedge wren
+seiurus aurocapillus
 semipalmated plover
 semipalmated sandpiper
+seriema
+serin
+serinus canaria
+setophaga ruticilla
+setting hen
 sharp-shinned hawk
 sharp-tailed grouse
 sharp-tailed sandpiper
+shearwater
+sheldrake
+shelduck
+shell parakeet
 shining bronze cuckoo
 shining cuckoo
 shiny cowbird
+shoebill
 shoebill stork
+shoebird
+shorebird
 short-billed dowitcher
+short-billed marsh wren
 short-eared owl
 short-tailed albatross
 short-tailed hawk
 short-tailed shearwater
+short-toed eagle
+shoveler
+shoveller
+shrike
 shy albatross
 siberian accentor
 siberian blue robin
 siberian flycatcher
 siberian rubythroat
 silvereye
+sinornis
+siskin
+sitta canadensis
+sitta carolinensis
+sitta europaea
+sitter
+skimmer
 sky lark
+slate-colored junco
 slate-throated redstart
 slaty-backed gull
 slender-billed curlew
@@ -867,14 +2003,26 @@ smew
 smith's longspur
 smooth-billed ani
 snail kite
+snakebird
+snipe
 snow bunting
 snow goose
+snowbird
+snowflake
 snowy egret
+snowy heron
 snowy owl
 snowy plover
+solan
+solan goose
+solant goose
+solitaire
 solitary sandpiper
+solitary vireo
 somali ostrich
 song sparrow
+songbird
+songster
 sooty shearwater
 sooty tern
 sora
@@ -882,36 +2030,85 @@ south polar skua
 southern cassowary
 southern emu-wren
 southern martin
+spatula clypeata
+spatula discors
+spatula querquedula
 spectacled eider
+sphenisciform seabird
+spheniscus demersus
+sphyrapicus varius
+sphyrapicus varius ruber
 spinifex pigeon
+spinus pinus
+spinus tristis
+spizella arborea
+spizella passerina
+spizella pusilla
 splendid fairywren
+spoonbill
 spoonbill sandpiper
 spot-billed duck
 spot-breasted oriole
 spotless crake
+spotted antbird
+spotted crake
 spotted dove
+spotted flycatcher
 spotted owl
 spotted rail
 spotted redshank
 spotted sandpiper
 spotted towhee
 sprague's pipit
+sprigtail
+spring chicken
 spruce grouse
+squab
 squatter pigeon
+stake driver
+starling
+steatornis caripensis
+steganopus tricolor
 stejneger's petrel
+stellar's sea eagle
 steller's eider
 steller's jay
 steller's sea-eagle
+stercorarius parasiticus
+sterna hirundo
+stictopelia cuneata
+stilt
+stilt plover
 stilt sandpiper
+stiltbird
+stinkbird
+stint
 stitchbird
+stone curlew
 stonechat
+storm petrel
+stormy petrel
 streak-backed oriole
 streaked shearwater
+streptopelia risoria
+streptopelia turtur
 striated grasswren
 strickland's woodpecker
 stripe-headed tanager
+striped button quail
+strix aluco
+strix nebulosa
+strix occidentalis
+strix varia
+struthio camelus
+sturnella magna
+sturnella neglecta
+sturnus vulgaris
+sula bassana
 sulphur-bellied flycatcher
 sulphur-crested cockatoo
+summer duck
+summer redbird
 summer tanager
 sun conure
 superb fairywren
@@ -920,47 +2117,137 @@ superb lyrebird
 superb starling
 surf scoter
 surfbird
+surnia ulula
 swainson's hawk
 swainson's thrush
 swainson's warbler
+swallow
+swallow shrike
+swallow-tailed hawk
 swallow-tailed kite
 swamp sparrow
+swamphen
+swiftlet
+sylvia atricapilla
+sylvia communis
+sylvia curruca
+syrrhaptes paradoxus
+tailorbird
+takahe
 tamaulipas crow
+tanager
 tasmanian native-hen
+tattler
+tawny eagle
 tawny frogmouth
 tawny-shouldered blackbird
+teal
 temminck's stint
 tennessee warbler
+tercel
+tercelet
 terek sandpiper
+tern
+tetrao urogallus
+texas chachalaca
 thayer's gull
 thick-billed kingbird
 thick-billed murre
 thick-billed parrot
 thick-billed vireo
+thick-knee
+thickhead
+thornbill
 three-toed woodpecker
+threskiornis aethiopica
+throstle
+thrush nightingale
+thryothorus ludovicianus
+tichodroma muriaria
+tichodrome
+tiercel
+tinamou
+titlark
+titmouse
 toco toucan
+tody
+tom
+tom turkey
+tomtit
 tooth-billed bowerbird
 topknot pigeon
 torresian imperial pigeon
+toucanet
+touraco
 townsend's solitaire
 townsend's warbler
+toxostoma rufum
+tragopan
+tree martin
 tree pipit
+tree sparrow
 tree swallow
+tree swift
+trichoglossus moluccanus
 tricolored blackbird
 tricolored heron
+tringa flavipes
+tringa melanoleuca
+tringa nebularia
+tringa totanus
+troglodytes aedon
+troglodytes troglodytes
+trogon
 tropical kingbird
 tropical parula
+true flycatcher
+true sparrow
+true warbler
+trumpeter
 trumpeter swan
 tufted duck
 tufted flycatcher
 tufted puffin
 tufted titmouse
 tui
+tumbler
+tumbler pigeon
 tundra swan
+turaco
+turacou
+turakoo
+turdus greyi
+turdus iliacus
+turdus merula
+turdus migratorius
+turdus philomelos
+turdus pilaris
+turdus torquatus
+turdus viscivorus
+turkey buzzard
 turkey vulture
+turnix sylvatica
+turnstone
+turtledove
+twitterer
+tympanuchus cupido
+tympanuchus cupido cupido
+tympanuchus pallidicinctus
+tyrannid
+tyrannus domenicensis domenicensis
+tyrannus tyrannus
+tyrannus vociferans
+tyrant bird
+tyrant flycatcher
+tyto alba
 uniform swiftlet
+upland plover
 upland sandpiper
+upupa epops
+uria aalge
+uria lomvia
 varied bunting
+varied lorikeet
 varied thrush
 variegated fairywren
 variegated flycatcher
@@ -968,16 +2255,35 @@ vaux's swift
 veery
 verdin
 vermilion flycatcher
+vermillion flycatcher
 vesper sparrow
 violet-crowned hummingbird
 violet-green swallow
+vireo
+vireo olivaceous
+vireo solitarius
+vireo solitarius solitarius
 virginia rail
 virginia's warbler
 vogelkop bowerbird
+vultur gryphus
+wader
+wading bird
+wagtail
+wall creeper
 wandering albatross
 wandering tattler
 wandering whistling duck
 warbling vireo
+water bird
+water hen
+water ouzel
+water thrush
+water turkey
+waterfowl
+waxwing
+weaver
+weaver finch
 wedge-rumped storm-petrel
 wedge-tailed shearwater
 weka
@@ -992,13 +2298,21 @@ western screech-owl
 western scrub-jay
 western tanager
 western wood-pewee
+wheatear
+whidah
 whimbrel
 whip-poor-will
+whisker jack
 whiskered auklet
 whiskered screech-owl
 whiskered tern
+whistler
+whistling swan
 white ibis
+white pelican
+white stork
 white wagtail
+white-bellied swallow
 white-breasted nuthatch
 white-browed crake
 white-cheeked pintail
@@ -1012,14 +2326,17 @@ white-eyed vireo
 white-faced ibis
 white-faced storm-petrel
 white-headed pigeon
+white-headed stilt
 white-headed woodpecker
 white-quilled pygmy goose
 white-rumped sandpiper
+white-rumped shrike
 white-rumped swiftlet
 white-tailed eagle
 white-tailed hawk
 white-tailed kite
 white-tailed ptarmigan
+white-tailed sea eagle
 white-tailed tropicbird
 white-throated needletail
 white-throated robin
@@ -1032,32 +2349,60 @@ white-winged fairywren
 white-winged parakeet
 white-winged scoter
 white-winged tern
+whitethroat
+whole snipe
+whooper
 whooper swan
 whooping crane
+whydah
+widgeon
+widow bird
+wigeon
+wild duck
 wild turkey
 willet
 williamson's sapsucker
 willow flycatcher
 willow ptarmigan
+wilson's blackcap
 wilson's phalarope
 wilson's plover
+wilson's snipe
 wilson's storm-petrel
+wilson's thrush
 wilson's warbler
+wilsonia pusilla
 winter wren
 wompoo fruit-dove
 wonga pigeon
+wood drake
 wood duck
+wood hoopoe
+wood ibis
+wood pewee
+wood pigeon
 wood sandpiper
 wood stork
+wood swallow
 wood thrush
 wood warbler
+wood widgeon
+woodcock
+woodcock snipe
+woodcreeper
 woodhen
+woodhewer
 worm-eating warbler
 worthen's sparrow
+wren
+wren warbler
 wrentit
 xantus's hummingbird
 xantus's murrelet
+xenicus gilviventris
+xenorhyncus asiaticus
 yellow bittern
+yellow bunting
 yellow grosbeak
 yellow rail
 yellow wagtail
@@ -1078,8 +2423,16 @@ yellow-headed blackbird
 yellow-legged gull
 yellow-nosed albatross
 yellow-rumped warbler
+yellow-shafted flicker
 yellow-throated vireo
 yellow-throated warbler
+yellowbird
+yellowhammer
+yellowlegs
+yellowthroat
 yucatan vireo
 zenaida dove
+zenaidura macroura
 zone-tailed hawk
+zonotrichia albicollis
+zonotrichia leucophrys

--- a/lists/animal/crustacean.yml
+++ b/lists/animal/crustacean.yml
@@ -1,0 +1,116 @@
+---
+title: Crustaceans
+category: animal
+description: "Crabs, lobsters, shrimp, barnacles, and related crustaceans"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acorn barnacle
+alaska crab
+alaska king crab
+alaskan king crab
+american crayfish
+american lady crab
+american lobster
+amphipod
+artemia salina
+balanus balanoides
+beach flea
+blue crab
+brachyuran
+branchiopod
+branchiopod crustacean
+branchiopodan
+brine shrimp
+brit
+britt
+calico crab
+callinectes sapidus
+cancer borealis
+cancer irroratus
+cancer magister
+cape lobster
+cirriped
+cirripede
+copepod
+copepod crustacean
+crawdad
+crawdaddy
+crawfish
+crayfish
+crustacean
+cyclops
+daphnia
+decapod crustacean
+ecrevisse
+english lady crab
+euphausia pacifica
+european lobster
+european spider crab
+fairy shrimp
+fish louse
+giant crab
+goose barnacle
+gooseneck barnacle
+hard-shell crab
+homarus americanus
+homarus capensis
+homarus gammarus
+homarus vulgaris
+isopod
+lady crab
+langouste
+lepas fascicularis
+long-clawed prawn
+macrocheira kaempferi
+maine lobster
+maja squinado
+malacostracan crustacean
+mantis crab
+mantis prawn
+menippe mercenaria
+mussel shrimp
+nephrops norvegicus
+northern lobster
+norway lobster
+old world crayfish
+opossum shrimp
+ostracod
+ovalipes ocellatus
+oyster crab
+palaemon australis
+paralithodes camtschatica
+pea crab
+pill bug
+pinnotheres ostreum
+pistol shrimp
+portunus puber
+river prawn
+rock barnacle
+rock lobster
+sand flea
+sand hopper
+sea crawfish
+sea louse
+sea slater
+seed shrimp
+skeleton shrimp
+slater
+snapping shrimp
+soft-shell crab
+soft-shelled crab
+sow bug
+spiny lobster
+squilla
+stomatopod
+stomatopod crustacean
+swimming crab
+tadpole shrimp
+tropical prawn
+true lobster
+water flea
+whale louse

--- a/lists/animal/fish.yml
+++ b/lists/animal/fish.yml
@@ -1,0 +1,1087 @@
+---
+title: Fish
+category: animal
+description: "Bony fish, sharks, rays, and other fish"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+a. testudineus
+abramis brama
+abudefduf saxatilis
+acanthocybium solandri
+acanthopterygian
+acanthurus chirurgus
+achoerodus gouldii
+acipenser huso
+acipenser transmontanus
+aetobatus narinari
+agonus cataphractus
+alaska cod
+albacore
+albula vulpes
+alectis ciliaris
+alewife
+allice
+allice shad
+alligatorfish
+allis
+allis shad
+allmouth
+alopius vulpinus
+alosa alosa
+alosa chrysocloris
+alosa pseudoharengus
+alosa sapidissima
+amberfish
+amberjack
+ambloplites rupestris
+ameiurus melas
+american flagfish
+american plaice
+american smooth dogfish
+amia calva
+amphiprion percula
+anabas testudineus
+anchovy
+anemone fish
+angler
+anguilla sucklandii
+anisotremus surinamensis
+anisotremus virginicus
+anomalops
+apogon maculatus
+archosargus probatocephalus
+archosargus rhomboidalis
+argentine
+armed bullhead
+armored searobin
+aspidophoroides monopterygius
+astropogon stellatus
+atherinopsis californiensis
+atlantic bonito
+atlantic cod
+atlantic croaker
+atlantic halibut
+atlantic herring
+atlantic manta
+atlantic moonfish
+atlantic sailfish
+atlantic sea bream
+atlantic spiny dogfish
+atlantic tripletail
+aulostomus maculatus
+bairdiella chrysoura
+balistes vetula
+balloonfish
+banded rudderfish
+barbu
+barndoor skate
+barracouta
+barred pickerel
+barrelfish
+bass
+beaked salmon
+beaugregory
+bellows fish
+belted sandfish
+bergall
+bermuda chub
+bessy cerca
+big-eyed scad
+bigeye
+bigeye scad
+billfish
+biplane flying fish
+black bass
+black bream
+black buffalo
+black crappie
+black margate
+black rudderfish
+black sea bass
+blackback flounder
+blackmouth bass
+blacktip shark
+blanquillo
+blennioid
+blennioid fish
+blennius pholis
+blenny
+blowfish
+blue cat
+blue channel cat
+blue channel catfish
+blue jack
+blue pickerel
+blue pike
+blue pikeperch
+blue pointed
+blue runner
+blue walleye
+blueback salmon
+bluefin
+bluefish
+bluehead
+bluethroat pikeblenny
+boarfish
+bolti
+bonefish
+bonito
+bonito shark
+bonnet shark
+bonnethead
+bony fish
+bottom fish
+bottom lurker
+bottom-dweller
+bottom-feeder
+bracketed blenny
+brama raii
+bream
+brevoortia tyrannis
+brill
+brisling
+brosme brosme
+brotula
+brown bullhead
+brown trout
+bullhead
+bullhead catfish
+burbot
+burrfish
+butterfish
+butterfly ray
+calamus penna
+california pompano
+capelan
+capelin
+caplin
+capros aper
+carangid
+carangid fish
+caranx bartholomaei
+caranx crysos
+caranx hippos
+carassius auratus
+carassius carassius
+carassius vulgaris
+carcharhinus leucas
+carcharhinus limbatus
+carcharhinus longimanus
+carcharhinus obscurus
+carcharhinus plumbeus
+carcharias taurus
+carcharinus longimanus
+carcharodon carcharias
+cardinal tetra
+cardinalfish
+caribe
+carpet shark
+cartilaginous fish
+cat shark
+catalufa
+catostomid
+cavalla
+centrarchid
+centropristis philadelphica
+centropristis striata
+ceratodus
+cero
+cetorhinus maximus
+chaenopsis ocellata
+chaetodipterus faber
+chaetodon
+chain pickerel
+chain pike
+channel bass
+channel cat
+channel catfish
+char
+characid
+characin
+characin fish
+charr
+chenfish
+chile bonito
+chilean bonito
+chimaera monstrosa
+chondrichthian
+chrysophrys auratus
+chrysophrys australis
+chub
+chub mackerel
+chum
+chum salmon
+cichlid fish
+cigarfish
+cisco
+citharichthys cornutus
+climbing perch
+clingfish
+clinid
+clinid fish
+clown anemone fish
+clupea harangus
+clupea harengus
+clupea harengus harengus
+clupea harengus pallasii
+clupea sprattus
+clupeid
+clupeid fish
+cobia
+cod
+codling
+coho
+coho salmon
+cohoe
+combtooth blenny
+common american shad
+common eel
+common mackerel
+common shiner
+conchfish
+conger
+convict fish
+copper rockfish
+corbina
+coregonus artedi
+coregonus clupeaformis
+cornetfish
+coryphaena equisetis
+coryphaena hippurus
+cosmocampus profundus
+cottonwick
+cow shark
+cow-nosed ray
+cowfish
+cownose ray
+crampfish
+crappie
+creole-fish
+crevalle jack
+croaker
+crossopterygian
+crucifix fish
+cryptacanthodes maculatus
+cub shark
+cunner
+cusk
+cusk-eel
+cutlassfish
+cyclopterus lumpus
+cynoscion nebulosus
+cynoscion regalis
+cyprinid
+cyprinid fish
+cypriniform fish
+cyprinodont
+cyprinus carpio
+dace
+damselfish
+dasyatis centroura
+dealfish
+decapterus macarellus
+decapterus punctatus
+deepwater pipefish
+deepwater squirrelfish
+demoiselle
+devilfish
+diodon holocanthus
+diodon hystrix
+doctorfish
+dogfish
+dollarfish
+dolphinfish
+domestic carp
+dory
+dragonet
+driftfish
+drum
+dwarf pipefish
+echeneis naucrates
+eelblenny
+eelpout
+elagatis bipinnulata
+elasmobranch
+electric ray
+electrophorus electricus
+elops saurus
+elver
+emerald shiner
+english sole
+engraulis encrasicholus
+epinephelus adscensionis
+epinephelus fulvus
+equetus lanceolatus
+equetus pulcher
+esox americanus
+esox lucius
+esox masquinongy
+esox niger
+etropus rimosus
+eucinostomus gula
+european bream
+european catfish
+european flatfish
+european perch
+european sea bream
+european smelt
+european sole
+euthynnus pelamis
+filefish
+fingerling
+fish doctor
+flagfish
+flame fish
+flashlight fish
+flatfish
+flathead
+florida pompano
+florida smoothhound
+flying gurnard
+flying robin
+food fish
+four-wing flying fish
+fox shark
+freshwater bass
+freshwater bream
+frost fish
+fundulus heteroclitus
+fundulus majalis
+gadoid
+gadoid fish
+gadus macrocephalus
+gadus merlangus
+gadus morhua
+galeocerdo cuvieri
+galeorhinus zyopterus
+gambusia affinis
+game fish
+ganoid
+ganoid fish
+garfish
+garpike
+gasterosteus aculeatus
+gasterosteus pungitius
+gempylid
+gempylus serpens
+genyonemus lineatus
+gerres cinereus
+ghostfish
+giant pigfish
+ginglymostoma cirratum
+globefish
+goatfish
+gobiesox strumosus
+gobio gobio
+goby
+goggle-eye
+golden shiner
+gonorhynchus gonorhynchus
+goujon
+gray flounder
+gray mullet
+gray skate
+gray snapper
+great barracuda
+great blue shark
+greeneye
+greenling
+grey flounder
+grey mullet
+grey skate
+grey snapper
+grindle
+groundfish
+grubby
+grunt
+gudgeon
+guitarfish
+gunnel
+gurnard
+gymnelus viridis
+haemulon album
+haemulon aurolineatum
+haemulon macrostomum
+haemulon malanurum
+haemulon parra
+hairtail
+hake
+halfbeak
+halicoeres bivittatus
+halicoeres radiatus
+hammerhead
+handsaw fish
+harvestfish
+hausen
+headfish
+helleri
+hemipteronatus novacula
+hemitripterus americanus
+hexagrammos decagrammus
+hexanchus griseus
+hippoglossoides platessoides
+hippoglossus hippoglossus
+hippoglossus stenolepsis
+hipsurus caryi
+hog molly
+hog snapper
+hog sucker
+hogchoker
+hogfish
+holibut
+holocanthus tricolor
+holocentrus ascensionis
+holocentrus bullisi
+holocentrus coruscus
+holocephalan
+holocephalian
+horned pout
+horned whiff
+hornpout
+horsefish
+horsehead
+hypentelium nigricans
+hyperglyphe perciformis
+ictalurus punctatus
+ictiobus niger
+istiophorus albicans
+isurus glaucus
+isurus oxyrhinchus
+isurus oxyrhincus
+isurus paucus
+jack crevalle
+jack mackerel
+jack salmon
+jackknife-fish
+jacksmelt
+jawfish
+jewfish
+jordanella floridae
+katsuwonus pelamis
+kelp greenling
+kentucky black bass
+killifish
+king mackerel
+king of the herring
+king salmon
+king whiting
+kingfish
+kyphosus sectatrix
+lachnolaimus maximus
+lactophrys quadricornis
+lagodon rhomboides
+lake herring
+lake salmon
+lake trout
+lake whitefish
+lamna nasus
+lampris guttatus
+lampris regius
+lancetfish
+landlocked salmon
+largemouth
+largemouth bass
+largemouth black bass
+largemouthed bass
+largemouthed black bass
+latimeria chalumnae
+launce
+leather carp
+leatherfish
+leatherjack
+lebistes reticulatus
+lefteye flounder
+lefteyed flounder
+lemon sole
+lepidocybium flavobrunneum
+lepisosteus osseus
+lepomis gibbosus
+lepomis macrochirus
+lepomis punctatus
+leuciscus cephalus
+leuciscus leuciscus
+limanda ferruginea
+ling
+liparis liparis
+little skate
+live-bearer
+liza
+lobe-finned fish
+lobefin
+lobotes pacificus
+lobotes surinamensis
+long-fin tunny
+longfin mako
+lookdown fish
+lophius americanus
+lopholatilus chamaeleonticeps
+lota lota
+lotte
+louvar
+lumpenus lumpretaeformis
+lumpsucker
+lutjanus analis
+lutjanus apodus
+lutjanus blackfordi
+lutjanus griseus
+luvarus imperialis
+mackerel
+mackerel scad
+mackerel shad
+mackerel shark
+macrozoarces americanus
+mademoiselle
+mahimahi
+maiger
+maigre
+makaira albida
+makaira marlina
+makaira mazara
+makaira mitsukurii
+makaira nigricans
+mako
+malacopterygian
+malopterurus electricus
+man-eater
+man-eating shark
+mangrove snapper
+manta
+manta birostris
+margate
+marlin
+mayfish
+mediterranean anchovy
+melanogrammus aeglefinus
+menhaden
+menominee whitefish
+menticirrhus americanus
+menticirrhus littoralis
+menticirrhus saxatilis
+menticirrhus undulatus
+merlangus merlangus
+merluccius bilinearis
+micropogonias undulatus
+micropterus dolomieu
+micropterus pseudoplites
+micropterus salmoides
+microstomus kitt
+miller's-thumb
+minnow
+mirror carp
+mobula hypostoma
+mola
+mola lanceolata
+mollie
+molly miller
+molva molva
+monoplane flying fish
+moray
+morone americana
+morone interrupta
+mosquitofish
+mouthbreeder
+mudcat
+mudskipper
+mudspringer
+mugil cephalus
+mugil curema
+mugil liza
+mullet
+mulloidichthys martinicus
+mulloway
+mullus auratus
+mullus surmuletus
+mummichog
+muskellunge
+mustelus canis
+mustelus mustelus
+mustelus norrisi
+mutton snapper
+muttonfish
+mycteroperca bonaci
+myxocephalus aenaeus
+naucrates ductor
+negaprion brevirostris
+new world opah
+northern pike
+northern porgy
+northern scup
+northern sea robin
+northern snakehead
+northern whiting
+notemigonus crysoleucas
+notropis atherinoides
+notropis cornutus
+numbfish
+ocean perch
+ocean pout
+ocean sunfish
+oceanic bonito
+ocyurus chrysurus
+odontaspis taurus
+oilfish
+oldwench
+oncorhynchus keta
+oncorhynchus kisutch
+oncorhynchus nerka
+oncorhynchus tshawytscha
+ophiodon elongatus
+opsanus tau
+order ostariophysi
+orectolobus barbatus
+orthopristis chrysopterus
+osmerus eperlanus
+osmerus mordax
+ostariophysi
+oxylebius pictus
+oyster fish
+pacific bonito
+pacific cod
+pacific halibut
+pacific herring
+pacific sardine
+pacific spiny dogfish
+pacific sturgeon
+pacific tripletail
+pagellus centrodontus
+pagrus pagrus
+painted greenling
+palometa
+palometa simillima
+paprilus alepidotus
+paracheirodon axelrodi
+paralichthys dentatus
+paralichthys lethostigmus
+paranthias furcifer
+parophrys vetulus
+parophrys vitulus
+parr
+pearlfish
+pearly razorfish
+perca flavescens
+perca fluviatilis
+perch
+percina tanasi
+percoid
+percoid fish
+percoidean
+peristedion miniatum
+permit
+pholis gunnellus
+photoblepharon palpebratus
+phoxinus phoxinus
+pickerel
+pigfish
+pike-perch
+pikeblenny
+pilchard
+pilotfish
+pinfish
+pintado
+pirana
+plaice
+platichthys flesus
+platy
+platypoecilus maculatus
+plectognath
+plectognath fish
+pleuronectes platessa
+plumed scorpionfish
+poacher
+poeciliid
+poeciliid fish
+pogge
+pollachius pollachius
+pollack
+pollock
+polly fish
+polydactylus virginicus
+polyodon spathula
+polyprion americanus
+pomacentrus leucostictus
+pomatomus saltatrix
+pomfret
+pomolobus pseudoharengus
+pomoxis annularis
+pomoxis nigromaculatus
+pompano
+pompon
+porbeagle
+porcupinefish
+porgy
+porkfish
+poronotus triacanthus
+pout
+priacanthus arenatus
+prickleback
+prionace glauca
+prionotus carolinus
+pristis pectinatus
+prosopium cylindraceum
+prosopium williamsonii
+psephurus gladis
+psetta maxima
+psettichthys melanostichus
+pseudopleuronectes americanus
+puddingwife
+puffer
+pumpkinseed
+pylodictus olivaris
+queen triggerfish
+queenfish
+quiaquia
+quinnat salmon
+rabbitfish
+rachycentron canadum
+rainbow fish
+rainbow perch
+rainbow runner
+rainbow seaperch
+rainbow smelt
+rainbow trout
+raja batis
+raja erinacea
+raja laevis
+raja radiata
+rasher
+rattail
+rattail fish
+ray
+razor fish
+red drum
+red goatfish
+red mullet
+red porgy
+red rockfish
+red salmon
+red snapper
+redfin pickerel
+redfish
+redhorse
+redhorse sucker
+reef squirrelfish
+reef whitetip shark
+regalecus glesne
+remilegia australis
+remora
+requiem shark
+rhincodon typus
+rhinoptera bonasus
+righteye flounder
+righteyed flounder
+river shad
+rivulus
+roach
+robalo
+roccus saxatilis
+rock bass
+rock beauty
+rock gunnel
+rock hind
+rock sea bass
+rock sunfish
+rocky mountain whitefish
+rosefish
+rough fish
+roughtail stingray
+round scad
+round whitefish
+rudd
+rudderfish
+runner
+rutilus rutilus
+ruvettus pretiosus
+sacramento sturgeon
+sailfish
+sailor's-choice
+salmo gairdneri
+salmo salar
+salmo trutta
+salmon trout
+salmonid
+salvelinus alpinus
+salvelinus fontinalis
+salvelinus namaycush
+sand dab
+sand eel
+sand lance
+sand launce
+sand shark
+sand sole
+sand stargazer
+sand tiger
+sandbar shark
+sandfish
+sarda chiliensis
+sarda sarda
+sardina pilchardus
+sardine
+sardinops caerulea
+sargassum fish
+saurel
+saury
+scad
+scardinius erythrophthalmus
+scartella cristata
+schoolmaster
+schrod
+sciaena antarctica
+sciaena aquila
+sciaenid
+sciaenid fish
+sciaenops ocellatus
+scomber colias
+scomber japonicus
+scomber scombrus
+scomberesox saurus
+scomberomorus cavalla
+scomberomorus maculatus
+scomberomorus regalis
+scomberomorus sierra
+scombroid
+scombroid fish
+scophthalmus aquosus
+scophthalmus rhombus
+scorpaena grandicornis
+scorpaenid
+scorpaenid fish
+scorpaenoid
+scorpaenoid fish
+scrod
+scup
+sea bass
+sea bream
+sea catfish
+sea chub
+sea poacher
+sea poker
+sea raven
+sea robin
+sea scorpion
+sea trout
+sebastes caurinus
+sebastes marinus
+sebastes miniatus
+sebastes ruberrimus
+selachian
+selar crumenophthalmus
+selene setapinnis
+selene vomer
+sergeant fish
+sergeant major
+seriola dorsalis
+seriola grandis
+seriola zonata
+seriphus politus
+serranid
+serranid fish
+serranus subligarius
+shad
+shanny
+sharksucker
+sharptail mola
+sheatfish
+sheepshead
+sheepshead porgy
+shiner
+shortfin mako
+shovelhead
+shovelnose catfish
+shrimpfish
+sierra
+sild
+silurid
+silurid fish
+siluriform fish
+silurus glanis
+silver hake
+silver jenny
+silver perch
+silver salmon
+silver whiting
+silverfish
+silverside
+silversides
+six-gilled shark
+skate
+skillet fish
+sleeper
+sleeper goby
+smalleye hammerhead
+smallmouth
+smallmouth bass
+smallmouth black bass
+smallmouthed bass
+smallmouthed black bass
+smalltooth sawfish
+smelt
+smooth dogfish
+smooth hammerhead
+smoothhound
+smoothhound shark
+snail darter
+snailfish
+snake mackerel
+snakeblenny
+snakefish
+snipefish
+snoek
+snook
+soapfish
+sockeye
+soft-finned fish
+soldierfish
+sole
+solea lascaris
+solea solea
+soupfin
+soupfin shark
+southern flounder
+southern porgy
+southern scup
+spadefish
+spanish grunt
+spanish mackerel
+sparid
+sparid fish
+sparling
+spawner
+spearfish
+speckled trout
+sphyraena barracuda
+sphyrna tiburo
+sphyrna tudes
+sphyrna zygaena
+spiny puffer
+spiny-finned fish
+spoonbill catfish
+sport fish
+spotted black bass
+spotted ray
+spotted sea trout
+spotted squeateague
+spotted sunfish
+spotted weakfish
+sprat
+squalus acanthias
+squalus suckleyi
+squaretail
+squatina squatina
+stargazer
+stenotomus aculeatus
+stenotomus chrysops
+stickleback
+stizostedion vitreum
+stone bass
+striped bass
+striped drum
+striped killifish
+striped marlin
+striped mullet
+striper
+strizostedion vitreum glaucum
+stromateid
+stromateid fish
+stumpknocker
+sucker
+sucking fish
+summer flounder
+surffish
+surfperch
+surmullet
+sweeper
+swordtail
+synagrops bellus
+synanceja verrucosa
+syngnathus hildebrandi
+tarpon atlanticus
+tautog
+tautoga onitis
+tautogolabrus adspersus
+teleost
+teleost fish
+teleostan
+ten-spined stickleback
+tench
+tenpounder
+thalassoma bifasciatum
+thorny skate
+thrasher
+threadfin
+threadfish
+three-spined stickleback
+thresher
+thunnus alalunga
+thunnus albacares
+thunnus thynnus
+tilapia nilotica
+tilefish
+timucu
+tinca tinca
+tinker
+tomtate
+tonguefish
+topminnow
+torpedo
+torsk
+toxotes jaculatrix
+trachinotus carolinus
+trachinotus falcatus
+trachipterus arcticus
+trachurus symmetricus
+trachurus trachurus
+triaenodon obesus
+triaenodon obseus
+trigla lucerna
+trinectes maculatus
+tripletail
+trumpetfish
+trunkfish
+tub gurnard
+tunny
+turbot
+two-wing flying fish
+umbrina roncador
+vermillion rockfish
+viviparous eelpout
+wahoo
+walleye
+walleyed pike
+weakfish
+whale sucker
+whiff
+white crappie
+white croaker
+white marlin
+white mullet
+white perch
+white sturgeon
+white-tipped shark
+whitebait
+whitefish
+whitetip shark
+windowpane
+winter flounder
+worm fish
+wreckfish
+wrymouth
+xiphias gladius
+xyphophorus helleri
+yellow bass
+yellow goatfish
+yellow gurnard
+yellow jack
+yellowfin
+yellowfin croaker
+yellowfin mojarra
+yellowtail
+yellowtail flounder
+yellowtail snapper
+young fish
+zeus faber
+zoarces viviparus

--- a/lists/animal/insect.yml
+++ b/lists/animal/insect.yml
@@ -2,133 +2,896 @@
 title: Insects
 category: animal
 description: "Various insect species, predominantly focusing on ants, bees, and wasps"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 acacia-ants
+acanthoscelides obtectus
+acherontia atropos
+acheta assimilis
+acheta domestica
 acorn-plum gall
+acridid
+actias luna
+adalia bipunctata
+adelges abietis
+adelges piceae
+adelgid
+admiral
+aedes aegypti
+aedes albopictus
 aerial yellowjacket
+africanized bee
 africanized honey bee
+alderfly
+alkali bee
 allegheny mound ant
+almond moth
 almond stone wasp
+alsophila pometaria
+amazon ant
+american blight
+anabrus simplex
+anagasta kuehniella
+anasa tristis
+andrena
+andrenid
+anglewing
+angoumois grain moth
+angoumois moth
+anomala orientalis
+anopheline
+anoplophora glabripennis
 ant
+ant cow
+ant lion
+antheraea mylitta
+antheraea pernyi
+antheraea polyphemus
+anthonomus grandis
+anthrenus scrophulariae
+antler moth
+antlion fly
+apatura iris
+aphid
+aphis fabae
+aphis pomi
+aphrophora saratogensis
+apis mellifera
+apis mellifera adansonii
+apis mellifera scutellata
+apple aphid
+apple maggot
 arboreal ant
+arctiid
+arctiid moth
 argentine ant
+argyrotaenia citrana
+arilus cristatus
+armored scale
+army ant
+asian longhorned beetle
 asian paper wasp
+asian tiger mosquito
+asiatic beetle
+asiatic cockroach
+aspidiotus perniciosus
+atticus atlas
+automeris io
+backswimmer
 baldfaced hornet
+balsam woolly aphid
+banded purple
+bark beetle
+bark-louse
+bean aphid
+bean beetle
+bean weevil
+bedbug
 bee
+bee beetle
+bee fly
+bee killer
+bee moth
+bemisia tabaci
+big bedbug
 bigheaded ant
+birch leaf miner
+bird louse
+biting louse
+biting midge
 black and yellow mud dauber
+black bee
 black carpenter ant
+black carpet beetle
 black imported fire ant
+black weevil
+blackbeetle
+blackfly
+blatta orientalis
+blattella germanica
+blissus leucopterus
+blowfly
+blue
 blue horntail woodwasp
 blue orchard bee
+bluebottle
+boat bug
+body louse
+boll weevil
+bombardier beetle
+bombycid
+bombycid moth
+bombyx mori
+booklouse
+botfly
 braconid wasp
+bristletail
+brown lacewing
+brown soft scale
+brown-tail moth
+browntail
+bruchus pisorum
+brush-footed butterfly
+buffalo carpet beetle
+buffalo gnat
+bug
+bulldog ant
 bumble bee
+cabbage butterfly
+cacao moth
+caddice fly
+caddis fly
+cadra cautella
+cadra figulilella
+callimorpha jacobeae
+calliphora vicina
+calosoma
+calosoma scrutator
+camberwell beauty
+capsid
+carabid beetle
+carniolan bee
 carpenter ant
+carpenter bee
 carpenter wasp
+carpet beetle
+carpet bug
+carpet moth
+carpocapsa pomonella
+casemaking clothes moth
+cat flea
+catocala nupta
+cecropia
+cerapteryx graminis
+ceratitis capitata
+cetonia aurata
+chalcid
+chalcid fly
 chalcid wasp
+chalcis fly
+chicken louse
+chigoe
+chigoe flea
+chinch
+chinch bug
+chrysalis
+chrysomelid
+chrysopid
 cicada killer
+cicala
+cimex lectularius
+cinnabar
+cinnabar moth
+citrophilous mealybug
+citrophilus mealybug
 citrus blackfly parasitoid
+citrus mealybug
+citrus whitefly
+cleg
+clegg
+clerid
+clerid beetle
+coccid insect
+coccus hesperidum
+cochineal
+cochineal insect
+cockchafer
+codlin moth
+collembolan
+colorado beetle
+colorado potato beetle
+comma butterfly
+common booklouse
+common european earwig
+common louse
+common mosquito
 common paper wasp
+common pond-skater
+common wasp
+comstock mealybug
+comstock's mealybug
+cone-nosed bug
+conenose
+conenose bug
+cootie
+copper
+coreid
+coreid bug
+corn borer
+corn borer moth
+corydalus cornutus
+cotton stainer
+cotton strain
+crab louse
+crane fly
 crazy ant
+croton bug
+cryptotermes brevis
+ctenocephalides canis
+ctenocephalides felis
 cuckoo wasp
+cuckoo-bumblebee
+culex fatigans
+culex pipiens
+culex quinquefasciatus
 cynipid gall wasp
+cynipid wasp
+cynthia moth
+dactylopius coccus
+damselfly
+danaid
+danaid butterfly
+danaus plexippus
+darkling ground beetle
+darning needle
+dayfly
+death's-head moth
+deathwatch
+defoliator
+dendroctonus rufipennis
+dermatobia hominis
+devil's darning needle
+dialeurodes citri
+diapheromera
+diapheromera femorata
+dictyopterous insect
+digger wasp
+dipteran
+dipteron
+dipterous insect
+dobson
+dobsonfly
+dog flea
+dog-day cicada
+domestic silkworm moth
+domesticated silkworm moth
+dorbeetle
+driver ant
+drone
+drosophila
+drosophila melanogaster
+dry-wood termite
+dutch-elm beetle
+eacles imperialis
 eastern carpenter bee
 eastern yellowjacket
+echidnophaga gallinacea
+eggar
+egger
+elater
+elaterid
+elaterid beetle
 elm sawfly
+emmet
+emperor
+emperor butterfly
+emperor moth
 encyrtid wasp
+ephemeral
+ephemerid
+ephemeron
+ephemeropteran
+ephestia elutella
+epilachna varivestis
+eriosoma lanigerum
 erythrina gall wasp
 eulophid wasp
+euproctis chrysorrhoea
+euproctis phaeorrhoea
+european corn borer moth
 european hornet
+european house cricket
 european imported fire ant
 false honey ant
+family mutillidae
+fenusa pusilla
+field cricket
+fig moth
+figeater
 fire ant
+fire beetle
+firebrat
+firebug
+fish fly
+flea beetle
+flesh fly
+flour weevil
 forest bachac
 forest yellowjacket
+forficula auricularia
+formica fusca
+formica rufa
+formica sanguinea
+four-footed butterfly
+four-lined leaf bug
+four-lined plant bug
+frankliniella fusca
+fritillary
+froghopper
+fungus gnat
+gadfly
+gall gnat
+gall midge
+gall wasp
+galleria mellonella
+gallfly
+gasterophilus intestinalis
+gelechia gossypiella
+gelechiid
+gelechiid moth
+geometrid
+geometrid moth
+german bee
 german yellowjacket
+gerris lacustris
 ghost ant
+giant cockroach
+giant hornet
 giant ichneumon wasp
 giant resin bee
+giant silkworm moth
+giant water bug
 giant wood wasp
+gipsy moth
+glossina
+gold-tail moth
 golden northern bumble bee
 golden paper wasp
+golden-eyed fly
 gouty oak gall
+gracilariid
+gracilariid moth
+grain moth
+grape louse
+grape phylloxera
 grass carrying wasp
 great black wasp
 great golden digger wasp
+green apple aphid
+green june beetle
+green lacewing
+green peach aphid
+greenbottle
+greenbottle fly
+greenfly
+greenhouse whitefly
+ground beetle
 hackberry nipple gall parasitoid
+haematobia irritans
+hairstreak
+hairstreak butterfly
+hanging fly
+harvest fly
+hawkmoth
+head louse
+heliothis moth
+heliothis zia
+hemerobiid
+hemerobiid fly
+hemipteran
+hemipteron
+hemipterous insect
+hessian fly
+heteropterous insect
+hippobosca equina
+hippoboscid
+hippodamia convergens
+holometabola
+homona coffearia
+homopteran
+homopterous insect
 honey bee
+hopper
+horn fly
 horned oak gall
+horse botfly
 horse guard wasp
+horse tick
+human botfly
+humblebee
+hummingbird moth
 hunting wasp
+hyalophora cecropia
+hymenopter
+hymenopteran
+hymenopteron
+hymenopterous insect
+hyphantria cunea
+ichneumon fly
 ichneumonid wasp
+imago
+inachis io
+io moth
+italian bee
+jassid
+jerusalem cricket
+jumping bristletail
+jumping plant louse
+june beetle
+june bug
 keyhole wasp
+killer bee
+kissing bug
 knopper gall
+lace bug
+lacewing
+lacewing fly
+ladybeetle
+ladybird beetle
+lamellicorn beetle
+lantern fly
+lappet
+lappet moth
 large garden bumble bee
 large oak-apple gall
+lasiocampid
+lasiocampid moth
+leaf beetle
+leaf bug
+leaf insect
+leaf miner
+leaf roller
+leaf-cutter
+leaf-cutter bee
+leaf-foot bug
+leaf-footed bug
 leafcutting bee
+leafhopper
+legionary ant
+lepidopteran
+lepidopteron
+lepidopterous insect
+lepisma saccharina
+leptinotarsa decemlineata
+lightning bug
+limenitis archippus
+limenitis arthemis
+limenitis astyanax
+limenitis camilla
+liposcelis divinatorius
+little black ant
 little fire ant
 little yellow ant
+locusta migratoria
 long-horned bee
+long-horned beetle
+long-horned grasshopper
 long-legged ant
+longicorn
+longicorn beetle
+louse
+louse fly
+loxostege similalis
+luna moth
+lycaena hypophlaeas
+lycaenid
+lycaenid butterfly
+lygaeid
+lygaeid bug
+lygus bug
+lygus lineolaris
+lymantria dispar
+lymantriid
 macao paper wasp
+machilid
+macrodactylus subspinosus
+magicicada septendecim
+malacosoma americana
+malacosoma disstria
+malaria mosquito
+malarial mosquito
 mallow bee
+manduca quinquemaculata
+manduca sexta
+mantid
+mantis
+mantis religiosa
+mantis religioso
+mantispid
 marble gall
+mason bee
+mason wasp
+mastotermes darwiniensis
+mastotermes electrodominicus
+mastotermes electromexicus
+may bug
+mayetiola destructor
+meadow spittlebug
+mecopteran
+medfly
+mediterranean flour moth
+mediterranean fruit fly
+meloid
+melolontha melolontha
+melolonthid beetle
+melophagus ovinus
+menopon gallinae
+menopon palladum
+metabola
+mexican bean beetle
+midge
+migratory grasshopper
+migratory locust
+milkweed butterfly
+miller
+mining bee
+mirid
+mirid bug
+monomorium minimum
+monomorium pharaonis
+mormon cricket
 mossyrose gall wasp
+moth miller
+mourning cloak butterfly
 mud-dauber
 multiflora rose seed chalcid
+musca domestica
+mutillidae
+neuropteran
+neuropteron
+neuropterous insect
+no-see-um
+noctuid
+noctuid moth
+nomia melanderi
+notonecta undulata
+nymphalid
+nymphalid butterfly
+nymphalis antiopa
 oak apple gall wasp
 oak rough bulletgall wasp
 oak saucer gall
 oak shoot sawfly
+odonate
 odorous house ant
+oecanthus fultoni
+oestrus ovis
+oil beetle
+onion louse
+onion thrips
+orange tortrix
 orange-tailed bumble bee
 orangetailed potter wasp
 oriental chestnut gall wasp
+orthopteran
+orthopteron
+orthopterous insect
+owlet moth
+painted beauty
+pale chrysanthemum aphid
+paleacrita vernata
 paper wasp
 pavement ant
+pea weevil
+pediculus capitis
+pediculus corporis
+pediculus humanus
+periodical cicada
+periplaneta americana
+periplaneta australasiae
+pernyi moth
+pharaoh ant
+pharaoh's ant
+phasmid
+phasmid insect
+philaenus spumarius
+phlebotomus papatasii
+phthirius pubis
+phthorimaea operculella
+phylloxera vitifoleae
+pierid
+pierid butterfly
+pieris brassicae
+pieris protodice
+pieris rapae
 pigeon tremex
+pine leaf aphid
+pine sawyer
+pine spittlebug
+pineus pinifoliae
 pip gall wasp
+pismire
+planococcus citri
+plant bug
+plant hopper
+plant louse
+plecopteran
+plectophera
+poecilocapsus lineatus
+poinsettia strain
+polistes annularis
+pollinator
+polyergus rufescens
+polygonia comma
+pomace fly
+popillia japonica
+potato beetle
+potato bug
+potato moth
+potato tuber moth
+potter bee
+potter wasp
+powder-post termite
 prairie yellowjacket
+praying mantid
+prociphilus tessellatus
+proturan
+pseudaletia unipuncta
+pseudococcus comstocki
+pseudococcus fragilis
+psocid
+psocopterous insect
+psychodid
+psylla
+psyllid
 pteromalid wasp
+pthirus pubis
+pubic louse
+pulex irritans
+punkey
+punkie
+punky
+pupa
+pyralid
+pyralid moth
 pyramid ant
+pyrausta nubilalis
+pyrophorus noctiluca
+queen bee
+railroad worm
+raisin moth
 raspberry horntail
 red ant
 red carpenter ant
 red harvester ant
 red imported fire ant
+red underwing
 red wasp
 red wood ant
 red-tailed wasp
 reddish carpenter ant
+reduviid
+reticulitermes flanipes
+reticulitermes flavipes
+reticulitermes lucifugus
+rhagoletis pomonella
+rhinoceros beetle
+rice weevil
+ringlet butterfly
+robber fly
+rodolia cardinalis
+rose beetle
+rose bug
+rose chafer
 rough harvester ant
+samia cynthia
+samia walkeri
+san jose scale
+sand cricket
+sand fly
+sanguinary ant
+saratoga spittlebug
+sarcophaga carnaria
+saturnia pavonia
+saturniid
+saturniid moth
+sawfly
 sawfly parasitic wasp
+sawyer
+sawyer beetle
+scale insect
 scale parasitoid
+scarab
+scarabaean
+scarabaeid
+scarabaeid beetle
+scarabaeus
+scarabaeus sacer
+sciara
+sciarid
+scolytus multistriatus
+scorpion fly
+searcher
+searcher beetle
+seed beetle
+seed weevil
+seventeen-year locust
+sewing needle
+shadfly
+shaft louse
+sheep botfly
+sheep gadfly
+sheep ked
+short-horned grasshopper
+sialis lutaria
+silkworm moth
 silky ant
+silverspot
 sirex woodwasp
 siricid woodwasp
+sitophylus oryzae
+sitotroga cerealella
+skeeter hawk
+skipjack
 smaller yellow ant
+snake doctor
+snake feeder
+snakefly
+snapping beetle
+snout beetle
+snowy tree cricket
+social insect
+soft scale
+soldier
 southeastern blueberry bee
+southern cabbage butterfly
 southern fire ant
 southern yellowjacket
+spanish fly
 sphecid wasp
+sphecius speciosus
+sphecoid
+sphecoid wasp
+sphingid
+sphinx moth
+spittle insect
+spittlebug
+splitworm
+spodoptera exigua
+spodoptera frugiperda
+spongefly
+spongillafly
+springtail
+spruce bark beetle
+spruce gall aphid
+squash bug
+stenopelmatus fuscus
+sticktight
+sticktight flea
+stink fly
+stonefly
 stony gall
+strymon melinus
+sucking louse
+sulfur butterfly
+sulphur butterfly
+superbug
 sweat bee
+sweet-potato whitefly
+tachina fly
+tapestry moth
+tarnished plant bug
+tea tortrix
+telsontail
+tenebrionid
+tent-caterpillar moth
+tettigoniid
 texas leafcutting ant
+thermobia domestica
+thrip
+thripid
+thrips
+thrips tobaci
+thysanopter
+thysanopteron
+thysanopterous insect
+thysanuran insect
+thysanuron
+tinea pellionella
+tineid
+tineid moth
+tineoid
+tineoid moth
+tineola bisselliella
 tiphiid wasp
+tobacco moth
+tobacco thrips
+tortoiseshell butterfly
+tortricid
+tortricid moth
+tortrix
 torymid wasp
 tramp ant
+tree cricket
+treehopper
+trialeurodes vaporariorum
+trichophaga tapetzella
+trichopteran
+trichopteron
+trichopterous insect
+trogium pulsatorium
+true bug
+tsetse
+tumblebug
+tunga penetrans
+tussah
+tusseh
+tusser
+tussock moth
+tussore
+tussur
+two-spotted ladybug
+two-winged insects
+tzetze
+tzetze fly
+underwing
 valentine ant
+vanessa atalanta
+vanessa virginiensis
+vedalia
 velvet ant
+vespa crabro
+vespid
 vespid wasp
+vespula maculata
+vespula maculifrons
+vespula vulgaris
+vinegar fly
+walking leaf
+walking stick
+warble fly
+water boatman
+water bug
+water scorpion
+water skater
+water strider
+wax insect
+web spinner
+webbing clothes moth
+webbing moth
+webworm moth
+weevil
 weevil parasitoid
 western harvester ant
 western paper wasp
 western thatching ant
 western yellowjacket
+wheel bug
+whirligig beetle
+white ant
+white-faced hornet
 white-horned horntail
+whitefly
 willow shoot sawfly
+wood ant
 woodwasp
 wool sower gall maker
+woolly adelgid
+woolly alder aphid
+woolly aphid
+woolly apple aphid
+woolly plant louse
+worker
+worker bee
+xestobium rufovillosum
 yellow and black potter wasp
 yellow crazy ant
+yellow hornet
+yellow jacket
+yellow-fever mosquito
 yellow-horned horntail

--- a/lists/animal/mammal.yml
+++ b/lists/animal/mammal.yml
@@ -2,184 +2,1705 @@
 title: Mammals
 category: animal
 description: "Diverse mammal species including rodents, primates, marsupials, and small carnivores"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 aardvark
+aberdeen angus
+abrocome
+acinonyx jubatus
+addax nasomaculatus
+adenota vardoni
+aegyptopithecus
+aepyceros melampus
+african elephant
+african golden wolf
+african green monkey
+african hunting dog
+africander
+agouti
+ailuropoda melanoleuca
+ailurus fulgens
+alaska fur seal
+alaskan brown bear
+alces alces
+algeripithecus minutus
+alopex lagopus
+american antelope
+american badger
+american bison
+american black bear
+american buffalo
+american elk
+american flying squirrel
+american harvest mouse
+american marten
+american mastodon
+american mastodont
 american mink
+american red squirrel
+american sable
+american saddle horse
+american shrew mole
+american water shrew
+ammotragus lervia
+angora rabbit
+angus
+angwantibo
+anoa
+anoa depressicornis
+anoa mindorensis
+ant bear
 anteater
 antelope
+antelope chipmunk
+antelope squirrel
+anthropoid
+anthropoid ape
+antidorcas euchore
+antidorcas marsupialis
+antilocapra americana
+antilope cervicapra
+antrozous pallidus
 aotus monkey
+aotus trivirgatus
+apar
 ape
+aperea
+aplodontia rufa
+apodemus sylvaticus
+aquatic mammal
+arab
+arabian camel
+archidiskidon imperator
 arctic fox
+arctic ground squirrel
 arctic hare
+arcticonus thibetanus
+arctictis bintourong
+arctictis binturong
+arctocebus calabarensis
+arctocephalus townsendi
+arctonyx collaris
+argal
 armadillo
+artiodactyl
+artiodactyl mammal
+arui
+arvicola amphibius
+asian wild ox
+asiatic buffalo
+asiatic flying squirrel
+asiatic shrew mole
+ateles geoffroyi
+atlantic bottlenose dolphin
+atlantic walrus
+audad
+australian sea lion
+australopithecine
+australopithecus afarensis
+australopithecus africanus
+australopithecus boisei
+australopithecus robustus
 avahi
+avahi laniger
 aye aye
+ayrshire
+babiroussa
+babirussa
 baboon
+babyrousa babyrussa
 badger
+badger skunk
+baiomys taylori
+balaena mysticetus
+balaenoptera acutorostrata
+balaenoptera borealis
+balaenoptera musculus
+balaenoptera physalus
 bamboo lemur
+banded anteater
+bandicoot rat
+bangtail
+banteng
+banting
+baranduki
+barbary ape
+barbary sheep
+barking deer
+baronduki
+barren ground caribou
+barunduki
+bassariscus astutus
+bassarisk
 bat
+bay
+beaked whale
 bear
+bear cub
+bearcat
 beaver
+beaver rat
+beech marten
+beef
+beef cattle
+belgian hare
+bellwether
+beluga
+bettong
+bezoar goat
+bibos frontalis
+bibos gaurus
+big brown bat
+big cat
+big-eared bat
+billy goat
 bison
+bison bison
+bison bonasus
 black and white ruffed lemur
+black angus
+black cat
+black fox
+black rat
+black sheep
+black squirrel
+black whale
 black-backed jackal
+black-tailed deer
+blackbuck
+blacktail
+blacktail deer
+blacktail jackrabbit
+blacktail prairie dog
+bladdernose
+blarina brevicauda
+blower
+blue bull
+blue fox
 bobcat
 bongo
+bonnet macaque
+bonnet monkey
 bontebok
+boocercus eurycerus
+bos banteng
+bos grunniens
+bos indicus
+bos primigenius
+bos taurus
+boselaphus tragocamelus
+bottle-nosed whale
+bottlenose
+bottlenose whale
+bovid
+bovine
+bowhead
+bradypus tridactylus
+brahma
+brahman
+brahmin
+brewer's mole
+broadtail
+brocket
+bronc
+broncho
+bronco
+broodmare
+brown bat
+brown lemming
 brown mouse lemur
 brown rat
+brown swiss
+bruin
+brush kangaroo
+brush wolf
+brush-tail porcupine
+brush-tailed phalanger
+brush-tailed porcupine
+bubalus bubalis
+bubalus mindorensis
+buck
+bucking bronco
+buckskin
+budorcas taxicolor
 buffalo
+bunny rabbit
+burchell's zebra
+burmeisteria retusa
+burro deer
+burunduki
 bushbaby
+bushbuck
+bushytail woodrat
+cabassous
+cabassous unicinctus
+cachalot
+cacomistle
+cacomixle
+caffer cat
+callorhinus ursinus
 camel
+camelopard
+camelus bactrianus
+camelus dromedarius
+canada porcupine
+canecutter
+canid
+canine
+canis adustus
+canis anthus
+canis aureus
+canis dingo
+canis latrans
+canis lupus
+canis lupus arctos
+canis mesomelas
+canis niger
+canis rufus
+cape buffalo
+cape hunting dog
+capibara
+capped macaque
+capra aegagrus
+capra falconeri
+capra hircus
+capra ibex
+capreolus capreolus
+caprine animal
 capuchin
 capybara
+carabao
 caracal
+caracul
+carcajou
 caribou
+carnivorous bat
+carthorse
+castor canadensis
+castor fiber
 cat
+cat bear
+cat squirrel
+catamountain
+catarrhine
+cattalo
+cattle
+cavalry horse
+cave bat
+cave myotis
+cavia cobaya
+cavia porcellus
+cavy
+cayuse
+cebuella pygmaea
+cebus capucinus
+central chimpanzee
+ceratotherium simum
+cercopithecus aethiops
+cercopithecus aethiops pygerythrus
+cercopithecus aethiops sabaeus
+cercopithecus talapoin
+cervid
+cervus elaphus
+cervus elaphus canadensis
+cervus nippon
+cervus sika
+cervus unicolor
+cetacean
+cetacean mammal
+chacma
+chacma baboon
+chacoan peccary
+chaetodipus hispidus
+charger
+charronia flavigula
 cheetah
+chestnut
+chetah
+cheviot
+chevrotain
+chickeree
+chigetai
+chimp
 chimpanzee
+chinchilla laniger
+chinchilla rat
+chinchillon
 chipmunk
+chiropteran
+chlamyphore
+chlamyphorus truncatus
+choeronycteris mexicana
+choloepus didactylus
+choloepus hoffmanni
+cimarron
+cinnamon bear
+citellus citellus
+citellus lateralis
+citellus leucurus
+citellus parryi
+citellus richardsoni
+citellus variegatus
+civet cat
+coach horse
+coati-mondi
+coati-mundi
+coelodonta antiquitatis
+collared pika
+colobus
+colobus guereza
 colobus monkey
+colugo
+columbian mammoth
+common blackfish
+common eland
+common lynx
+common opossum
+common raccoon
+common racoon
+common rorqual
+common seal
+common shrew
+common wallaby
+common zebra
+condylura cristata
+conepatus leuconotus
+coney
+cony
 coquerel's sifaka
+cotswold
+cotton mouse
+cotton rat
+cottontail
+cottontail rabbit
 cougar
+cow pony
+cows
+coydog
 coyote
+coypu
+crab-eating dog
+crab-eating fox
+crab-eating opossum
+crab-eating raccoon
+crab-eating seal
+cricetus cricetus
+cro-magnon
+crocuta crocuta
+croo monkey
+crowbait
+crown monkey
+cryptoprocta
+cryptoprocta ferox
+cryptotis parva
+cuniculus paca
+cuon alpinus
+cyclopes didactylus
+cynocephalus variegatus
+cynomys gunnisoni
+cynomys ludovicianus
+cynopterus sphinx
+cystophora cristata
+dairy cattle
+dairy cow
+dall sheep
+dall's sheep
+dama dama
+damaliscus lunatus
+damaraland mole rat
+dark horse
+das
+dassie
+dasyprocta aguti
+dasypus novemcinctus
+dasyure
+dasyurid
+dasyurid marsupial
+dasyurus quoll
+dasyurus viverrinus
+daubentonia madagascariensis
+dawn horse
 deer
+deer mouse
+delphinapterus leucas
+delphinus delphis
+desert rat
+desmodus rotundus
+devon
 diademed sifaka
+diceros bicornis
+diceros simus
+dicrostonyx hudsonius
+didelphis marsupialis
+didelphis virginiana
+digitigrade
+digitigrade mammal
 dingo
+dinoceras
+dinocerate
+diphylla ecaudata
+dipodomys ordi
+dipodomys phillipsii
+dobbin
 dog
+dolichotis patagonum
 domestic cat
+domestic goat
+domestic llama
+domestic sheep
+douglas squirrel
+douroucouli
+draft horse
+draught horse
+dray horse
+drill
+dryopithecine
+dryopithecus rudapithecus hungaricus
+duckbill
+duckbilled platypus
 dugong
+dugong dugon
 duiker
+dun
+duplicidentata
+durham
+dusicyon cancrivorus
+dusky-footed wood rat
+dwarf buffalo
 dwarf lemur
+dwarf pocket rat
+dziggetai
+eared seal
+earless seal
+eastern chimpanzee
 eastern chipmunk
+eastern cottontail
+eastern dasyure
+eastern fox squirrel
+eastern grey squirrel
+eastern pipistrel
 eastern spotted skunk
 echidna
+edentate
+egg-laying mammal
+egyptian jackal
+eira barbara
 eland
+elaphure
+elaphurus davidianus
 elephant
+elephas maximus
 elk
+enhydra lutris
+entellus
+eohippus
+eptesicus fuscus
+eptesicus serotinus
+equid
+equine
+equus africanus
+equus asinus
+equus burchelli
+equus caballus
+equus caballus gomelini
+equus caballus przevalskii
+equus caballus przewalskii
+equus grevyi
+equus hemionus
+equus hemionus hemionus
+equus kiang
+equus quagga
+equus zebra zebra
+erethizon dorsatum
+erignathus barbatus
+erinaceus europaeus
+erinaceus europeaeus
 ermine
+erythrocebus patas
+eschrichtius gibbosus
+eschrichtius robustus
 ethiopian wolf
+euarctos americanus
+euderma maculata
+eumetopias jubatus
+euphractus sexcinctus
+eurasian badger
+eurasian hamster
+eurasian otter
+european brown bat
+european hare
+european lemming
+european rabbit
+european water shrew
+european wood mouse
+eutamius asiaticus
+eutamius sibiricus
+eutherian
+eutherian mammal
+even-toed ungulate
+exmoor
+eyra
+fairy armadillo
+false saber-toothed tiger
+false vampire
+false vampire bat
+fanaloka
+farm animal
+farm horse
+felid
+feline
+felis bengalensis
+felis chaus
+felis concolor
+felis manul
+felis ocreata
+felis onca
+felis pardalis
+felis serval
+felis silvestris
+felis tigrina
+felis wiedi
+felis yagouaroundi
+female horse
+female mammal
 feral dog
+ferret badger
+field mouse
+finback
+finback whale
 fisher
+fissiped
+fissiped mammal
+fissipedia
+fitch
+flickertail
+florida water rat
+flying cat
+flying fox
+flying marmot
+flying mouse
+flying opossum
+flying phalanger
+forest goat
 fork marked lemur
+fossa cat
+fossa fossa
+fossorial mammal
+foulmart
+foumart
 fox
+free-tailed bat
+freetail
+frosted bat
+galago
+galictis vittatus
+gaur
+gayal
+gazella subgutturosa
+gazella thomsoni
+gee-gee
 gemsbok
+gemsbuck
+genetta genetta
+genus cryptoprocta
+genus javanthropus
+genus paranthropus
+genus pithecanthropus
+genus sinanthropus
+genus zinjanthropus
+geomys bursarius
+geomys pinetis
+gerbille
+gerenuk
+giant anteater
+giant eland
+giant kangaroo
+giant panda
 gibbon
+giraffa camelopardalis
 giraffe
+glaucomys sabrinus
+glaucomys volans
+glis glis
+globicephala melaena
+glutton
+gnawer
+gnawing mammal
+gnu goat
+goat antelope
+golden hamster
 golden jackal
 golden lion tamarin
+golden mole
+golden potto
+gomphothere
+goral
 gorilla
+gorilla gorilla
+gorilla gorilla beringei
+gorilla gorilla gorilla
+gorilla gorilla grauri
+grade
+grampus
+grampus griseus
+gray
 gray fox
+gray lemming
 gray squirrel
+gray whale
+great anteater
+great ape
+great grey kangaroo
 greater dwarf lemur
+greater kudu
+greater pichiciego
+green monkey
+greenland caribou
+greenland whale
+grevy's zebra
+grey
+grey fox
+grey jackal
+grey lemming
 grey mouse lemur
+grey whale
+grey wolf
+grison
+grison vittatus
+grivet
+grizzly
+ground sloth
+ground squirrel
 groundhog
+grunter
 grysbok
+guadalupe fur seal
+guano bat
+guenon
+guenon monkey
+guereza
+guernsey
+guib
 guinea pig
+gulo gulo
+gulo luscus
+hack
+hackee
+hair seal
+hair-tailed mole
+hairy-legged vampire bat
+hampshire
+hampshire down
 hamster
+hanuman
+harbor porpoise
 hare
+hare wallaby
+harness horse
+harnessed antelope
+harpy bat
+hart
 hartebeest
+harvest mouse
+hazel mouse
+he-goat
+hemigalus hardwickii
+hereford
+herpestes ichneumon
+herpestes nyula
+herring hog
+high stepper
+hind
+hinny
+hippo
 hippopotamus
+hippopotamus amphibius
+hippotragus niger
+hispid pocket mouse
+hoary marmot
+hog badger
+hog-nosed badger
 hog-nosed skunk
+hognose bat
+holstein
+holstein-friesian
+hominid
+hominoid
+homo erectus
+homo habilis
+homo soloensis
+honey bear
 hooded skunk
+hoofed mammal
+hooman
+horseshoe bat
 house mouse
+howler
 howler monkey
+hudson bay collared lemming
+humankind
+humans
+humpback
+hussar monkey
+hyaena
+hyaena brunnea
+hyaena hyaena
+hydrochoerus hydrochaeris
+hydrodamalis gigas
+hyemoschus aquaticus
 hyena
+hyena dog
+hylobates lar
+hylobates syndactylus
+hyperoodon ampullatus
+hypsiprymnodon moschatus
+hyrax
+ice bear
+ichneumon
+ictonyx frenata
+ictonyx striata
 impala
+imperial elephant
+imperial mammoth
+indian buffalo
+indian mongoose
+indian pony
+indian tapir
 indri
+indri brevicaudatus
+indri indri
+indris
 island fox
+jack
 jackal
+jaculus jaculus
+jade
 jaguar
+jaguarondi
 jaguarundi
+japanese deer
+javanthropus
+javelina
+jennet
+jenny
+jerboa kangaroo
+jerboa rat
+jersey
+jird
+jumping mouse
+kaffir cat
+kanchil
+kangaroo bear
+kangaroo hare
+kangaroo jerboa
+karakul
+kashmir goat
+kiang
+kid
+killer
+kine
+king of beasts
 kit fox
 koala
+koala bear
+kob
+kobus kob
+kobus leche
+kodiak
+kodiak bear
+kogia breviceps
+kogia simus
+koodoo
+koudou
 kudu
+lagomorph
+lagostomus maximus
+lama guanicoe
+lama pacos
+lama peruana
 langur
+lapin
+large civet
+lasiurus borealis
+laughing hyena
+leaf-nosed bat
+leafnose bat
+least shrew
 least weasel
+lechwe
+lemmus lemmus
+lemmus trimucronatus
 lemur
+lemur catta
+leoncita
+leontocebus oedipus
+leontocebus rosalia
 leopard
+leopardess
+leopardus pardalis
+leporid
+leporid mammal
+leporide
+lepus americanus
+lepus arcticus
+lepus californicus
+lepus europaeus
+lepus townsendi
+lerot
+lesser anteater
+lesser ape
 lesser dwarf lemur
+lesser kudu
+lesser panda
+lesser rorqual
+leveret
+lincoln
+liomys irroratus
 lion
+lion marmoset
+lion monkey
+lioness
+lionet
+lipizzan
+lippizan
+lippizaner
+litocranius walleri
+little brown myotis
+little chief hare
+little spotted skunk
+liver chestnut
+livestock
+loir
+long-eared bat
+long-tailed porcupine
 long-tailed weasel
+longhorn
+longtail weasel
+longwool
+loris gracilis
+loxodonta africana
+lutra canadensis
+lutra lutra
+lycaon pictus
 lynx
+lynx canadensis
+lynx caracal
+lynx lynx
+lynx pardina
+lynx rufus
+macaca irus
+macaca mulatta
+macaca radiata
+macaca sylvana
 macaque
+macropus agilis
+macropus giganteus
+macrotis lagotis
+macrotus
+macrotus californicus
+madagascar cat
+malayan tapir
+mammal
+mammalian
+mammoth
+mammut americanum
+mammuthus columbi
+mammuthus primigenius
 manatee
 mandrill
+mandrillus leucophaeus
+mandrillus sphinx
+maned sheep
 maned wolf
+mangabey
+mantled ground squirrel
+mapinguari
+mara
+marco polo sheep
+marco polo's sheep
+margay cat
+markhoor
 marmoset
+marmota caligata
+marmota flaviventris
+marmota monax
+marsh hare
+marsupial
+marsupial mole
+marsupial mouse
+marsupial rat
 marten
+marten cat
+martes americana
+martes foina
+martes martes
+martes pennanti
+martes zibellina
+masked shrew
+mastiff bat
+mastodon
+mastodont
+meadow jumping mouse
+meadow mouse
 meadow vole
+mediterranean water shrew
+megabat
+megaderma lyra
+megaptera novaeangliae
+megathere
+megatherian
+megatherian mammal
+megatheriid
+meles meles
+mellivora capensis
+melursus ursinus
+mephitis macroura
+mephitis mephitis
+merino
+merino sheep
+meriones longifrons
+meriones unguiculatus
+mesocricetus auratus
+mesohippus
+metatherian
+mexican freetail bat
+mexican pocket mouse
+microbat
+micromys minutus
+microtus ochrogaster
+microtus pennsylvaticus
+microtus richardsoni
+mierkat
+milch cow
+milcher
+milk cow
+milker
+milking shorthorn
+miner's cat
 mink
+mithan
+moke
+mole rat
 mongoose lemur
 monkey
+monodon monoceros
+monotreme
+moo-cow
 moose
+moschus moschiferus
+moufflon
+mouflon
+mount
 mountain beaver
+mountain chinchilla
+mountain goat
 mountain lion
+mountain nyala
+mountain paca
+mountain sheep
+mountain viscacha
+mountain zebra
 mouse
+mouse deer
+mouse hare
+mouse-eared bat
+mudder
+muishond
+mule deer
+murine
+mus musculus
+muscardinus avellanarius
+musk deer
+musk hog
+musk kangaroo
+musk sheep
 muskrat
+musquash
+mustela erminea
+mustela frenata
+mustela nigripes
+mustela nivalis
+mustela putorius
+mustela rixosa
+mustela vison
+mustelid
+musteline
+musteline mammal
+mylodon
+mylodontid
+myocastor coypus
+myotis leucifugus
+myotis velifer
+myrmecobius fasciatus
+myrmecophaga jubata
+naemorhedus goral
+nag
+nail-tailed kangaroo
+nail-tailed wallaby
+nanny
+nanny-goat
+napu
+narwal
+narwhale
+nasalis larvatus
+nasua narica
+native bear
+native cat
+neandertal
+neofiber alleni
+neomys anomalus
+neomys fodiens
+neotoma cinerea
+neotoma floridana
+neotoma fuscipes
+neurotrichus gibbsii
+new world anteater
+new world beaver
+new world least weasel
+new world monkey
+new world mouse
+new world porcupine
+new world tapir
 night monkey
+nine-banded armadillo
+nonstarter
 north american river otter
+northern bog lemming
+northern flying squirrel
+northern mammoth
+northern pocket gopher
+notoryctus typhlops
+nude mouse
 nutria
 nyala
+nyctereutes procyonides
+nyctereutes procyonoides
+nycticebus pygmaeus
+nycticebus tardigradua
+nyctinomops femorosaccus
+nylghai
+nylghau
 ocelot
+ochotona collaris
+ochotona princeps
+odd-toed ungulate
+odobenus divergens
+odobenus rosmarus
+odocoileus hemionus
+odocoileus hemionus columbianus
+odocoileus virginianus
 okapi
+okapia johnstoni
+old world beaver
+old world buffalo
+old world least weasel
+old world monkey
+old world porcupine
+old world rabbit
+onager
+ondatra zibethica
 opossum
+opossum rat
+orang
+orange bat
+orange horseshoe bat
 orangutan
+orangutang
+orcinus orca
+ord kangaroo rat
+oreamnos americanus
+ornithorhynchus anatinus
+orycteropus afer
+oryctolagus cuniculus
+oryx gazella
+oryzomys palustris
+otaria byronia
+otocolobus manul
 otter
+otter shrew
+ounce
+ovibos moschatus
+ovis ammon
+ovis aries
+ovis canadensis
+ovis montana dalli
+ovis musimon
+ovis poli
+ovis vignei
+oxen
+paca
+pacemaker
+pacer
+pacesetter
+pachyderm
+pacific bottlenose dolphin
+pacific walrus
+packrat
+paddymelon
+pagophilus groenlandicus
+painter
+palfrey
+pallid bat
+palm cat
+palm civet
+palomino
+pan paniscus
+pan troglodytes
+pan troglodytes schweinfurthii
+pan troglodytes troglodytes
+pan troglodytes verus
 panda
+panda bear
 pangolin
+panther cat
+panthera leo
+panthera onca
+panthera pardus
+panthera tigris
+panthera uncia
+papio ursinus
+parahyaena brunnea
+paranthropus
+parascalops breweri
+parka squirrel
+pasang
+patas
+peba
+peccari angulatus
+pekan
+peludo
+pen-tailed tree shrew
+pentail
+perissodactyl
+perissodactyl mammal
+perodicticus potto
+perognathus flavescens
+perognathus flavus
+perognathus hispidus
+peromyscus eremicus
+peromyscus gossypinus
+peromyscus leucopus
+peromyscus maniculatus
 perrier's sifaka
+petaurista petaurista
+phalanger
+phascolarctos cinereus
+phenacomys
+phoca vitulina
+phocoena phocoena
+phocoena sinus
+phyllostomus hastatus
+physeter catodon
+pichiciago
+pichiciego
+pied lemming
+piked whale
+pinche
+pine mouse
+pine vole
+pinnatiped
+pinniped
+pinniped mammal
+pinto
+pipistrel
+pipistrelle
+pipistrellus hesperus
+pipistrellus pipistrellus
+pipistrellus subflavus
+pithecanthropus
+pithecanthropus erectus
+pitymys pinetorum
+placental
+placental mammal
+plains pocket gopher
+plains pocket mouse
+plantation walking horse
+plantigrade
+plantigrade mammal
 platypus
+platyrrhine
+platyrrhinian
+plecotus townsendi
+plough horse
+plow horse
+plug
+pocket gopher
+pocket mouse
+pocket rat
+pocketed bat
+pocketed free-tailed bat
+pocketed freetail bat
+poecilogale albinucha
+polar hare
+pole horse
+poler
+pollard
+polo pony
+pongid
+pongo pygmaeus
 porcupine
+porker
+post horse
+poster
+potamogale
+potamogale velox
+potos caudivolvulus
+potos flavus
 potto
+pouched mammal
+pouched mole
+pouched mouse
+pouched rat
+poyou
+prairie fox
+prairie marmot
 prairie vole
+prairie wolf
+prancer
+presbytes entellus
+pricket
+primate
+priodontes giganteus
+prionailurus bengalensis
+proboscidean
+proboscidian
+procavia capensis
+proconsul
+procyon cancrivorus
+procyon lotor
+procyonid
+prongbuck
+pronghorn antelope
+prosimian
+proteles cristata
+protohippus
+prototherian
+przevalski's horse
+pseudoryx nghetinhensis
+pteropus capestratus
+pteropus hypomelanus
+puku
 puma
+pygmy chimpanzee
+pygmy mouse
+queen mole rat
 rabbit
+rabbit bandicoot
+rabbit ears
+rabbit-eared bandicoot
 raccoon
 raccoon dog
+raccoon fox
+racehorse
+racoon
+rambouillet
+rangifer arcticus
+rangifer caribou
+rangifer tarandus
+raphicerus campestris
 rat
+rat chinchilla
+rat kangaroo
+ratel
+rattus norvegicus
+rattus rattus
+razorback
+razorback hog
+razorbacked hog
+red bat
 red fox
 red fronted lemur
 red ruffed lemur
 red squirrel
 red wolf
+red-backed lemming
+red-backed mouse
+redback vole
 reindeer
+remount
+reynard
+rhesus
+rhesus monkey
 rhinoceros
+rhinoceros antiquitatis
+rhinoceros unicornis
+rhinonicteris aurantius
+rice rat
+richardson ground squirrel
+richardson vole
+riding horse
+right whale
 ring tailed lemur
+ring-tailed cat
+river horse
+roan
+rock kangaroo
+rock rabbit
+rock squirrel
+rock wallaby
+rockchuck
+rocky mountain bighorn
+rocky mountain goat
+rocky mountain sheep
+rodent
+roebuck
+rogue elephant
+roof rat
+rooter skunk
+rorqual
+round-tailed muskrat
+royal
+royal stag
+rudapithecus
 rufous mouse lemur
+ruminant
+rupicapra rupicapra
+sabertooth
 sable
+sable antelope
+saddle horse
+saiga tatarica
+saimiri sciureus
+saki
 saki monkey
+sambur
+sand badger
+sand rat
+santa gertrudis
+sarcophilus harrisii
+sassaby
+scaly anteater
+sciurus carolinensis
+sciurus griseus
+sciurus hudsonicus
+sciurus niger
+sciurus vulgaris
+sea cow
+sea elephant
 sea lion
+sea wolf
 seal
+selenarctos thibetanus
+semnopithecus entellus
+serotine
+serow
 serval
+sewellel
+sewer rat
+she-goat
+shire
+short-tailed shrew
+shorthorn
+shorttail weasel
+shrew mole
+shrewmouse
+siamang
 side-striped jackal
 sifaka
+sigmodon hispidus
+sika
+silky anteater
+silky pocket mouse
+silky tamarin
+silver fox
+silverback
+silvertip
+simian
+sinanthropus
+sirenian
+sirenian mammal
+sivapithecus
 skunk
+skunk bear
 slender loris
+slender-tailed meerkat
 sloth
+sloth bear
+slow loris
+small civet
+small livestock
+smiledon californicus
+snake muishond
+snowshoe rabbit
+sorex araneus
+sorex cinereus
+sorex palustris
+sorrel
+souslik
+south american sea lion
+southeastern pocket gopher
+southern bog lemming
+southern flying squirrel
+sow
+spearnose bat
+spermophile
 spider monkey
+spilogale putorius
+spindle horn
+spiny anteater
+spotted bat
+spotted hyena
+spotted lynx
 spotted skunk
+spouter
 springbok
+springbuck
+springing cow
+spruce squirrel
+square flipper seal
+squareflipper
+squealer
 squirrel
 squirrel monkey
+stable companion
+stablemate
+stag
+stalking-horse
+starnose mole
+steed
+steenbok
+steinbok
+steller sea lion
+steller's sea lion
+stepper
+stirk
 stoat
+stock
+stone marten
+strand wolf
+striped muishond
 striped skunk
+striped squirrel
+stud mare
+sulfur bottom
+suricata suricatta
+suricata tetradactyla
+suricate
+sus scrofa
+suslik
+swamp hare
+swamp rabbit
 swift fox
+swine
+sylvilagus aquaticus
+sylvilagus floridanus
+sylvilagus palustris
+symphalangus syndactylus
+synaptomys borealis
+synaptomys cooperi
+synercus caffer
+syrian bear
+tadarida brasiliensis
+tadarida femorosacca
+taguan
+tailless tenrec
+taira
+talapoin
+tamandu
+tamandua
+tamandua tetradactyla
+tamanoir
+tamarao
+tamarau
 tamarin
+tamarisk gerbil
+tamias striatus
+tamiasciurus douglasi
+tamiasciurus hudsonicus
+tapirus indicus
+tapirus terrestris
+tarpan
+tarsius glis
+tarsius syrichta
+tasmanian wolf
+tatou
+tatouay
+tatu
+taurotragus derbianus
+taurotragus oryx
+taxidea taxus
+tayassu angulatus
+tayassu pecari
+tayassu tajacu
+tayra
+tendrac
+tenrec
+tenrec ecaudatus
+texas armadillo
+texas longhorn
+thalarctos maritimus
 thirteen-lined ground squirrel
+thomomys bottae
+thomomys talpoides
+thomson's gazelle
+three year old
+three-banded armadillo
+three-toed sloth
+three-year-old horse
+thylacine
+thylacinus cynocephalus
 tiger
+tiglon
+tigress
+timber wolf
+titi
 titi monkey
+tolypeutes tricinctus
+toothed whale
+topi
+trade rat
+tragelaphus angasi
+tragelaphus buxtoni
+tragelaphus eurycerus
+tragelaphus imberbis
+tragelaphus scriptus
+tragelaphus strepsiceros
+tragulus javanicus
+tragulus kanchil
+tree shrew
+tree sloth
+tree squirrel
+tree wallaby
+trichechus manatus
+trichosurus vulpecula
+trichys lipura
+trotter
+trotting horse
+true cat
+true marmoset
+true seal
+true vampire bat
+tsine
+tube-nosed bat
+tube-nosed fruit bat
+tup
+tursiops gilli
+tursiops truncatus
+tusker
+two year old
+two-toed anteater
+two-toed sloth
+two-year-old horse
+typical jerboa
 uakari
+uintathere
+unai
+unau
+unguiculata
+unguiculate
+unguiculate mammal
+ungulata
+ungulate
+urial
+urocyon cinereoargenteus
+uropsilus soricipes
+ursine dasyure
+ursus americanus
+ursus arctos
+ursus arctos horribilis
+ursus arctos middendorffi
+ursus arctos syriacus
+ursus horribilis
+ursus maritimus
+ursus middendorffi
+ursus thibetanus
+ursus ursinus
+urus
+valley pocket gopher
+varying hare
+vervet
+vesper mouse
+vespertilian bat
+vespertilio murinus
+vespertilionid
+vicugna vicugna
+vicuna
+virginia deer
+viscacha
+viverra zibetha
+viverricula indica
+viverricula malaccensis
+viverrine
+viverrine mammal
+vixen
 vole
+vulpes fulva
+vulpes macrotis
+vulpes velox
+vulpes vulpes
+walking horse
 wallaby
 walrus
+wapiti
+warhorse
+warragal
+warrigal
+water chevrotain
+water deer
+water ox
+water rat
+water shrew
 waterbuck
 weasel
 weasel lemur
+welsh
+welsh black
+western big-eared bat
+western chimpanzee
+western gray squirrel
+western grey squirrel
+western pipistrel
 western spotted skunk
+wether
+whalebone whale
+wharf rat
+wheel horse
+wheeler
+whistling marmot
+white elephant
+white fox
+white sheep
+white tail
+white whale
+white wolf
+white-footed mouse
+white-lipped peccary
+white-tailed deer
+white-tailed jackrabbit
+whiteface
+whitetail antelope squirrel
+whitetail jackrabbit
+whitetail prairie dog
+wild cavy
+wild dog
+wild goat
+wild horse
+wild ox
+wild sheep
 wildebeest
+wisent
 wolf
 wombat
+wood mouse
+wood rabbit
 woodchuck
+woodland caribou
+woolly indris
 woolly monkey
+workhorse
+world
+yearling
+yellow-throated marten
+yellowbelly marmot
+zalophus californianus
+zalophus californicus
+zalophus lobatus
+zapus hudsonius
 zebra
+zinjanthropus
+zoril

--- a/lists/animal/marine-invertebrate.yml
+++ b/lists/animal/marine-invertebrate.yml
@@ -1,0 +1,72 @@
+---
+title: Marine invertebrates
+category: animal
+description: "Cnidarians, echinoderms, sponges, tunicates, and other marine invertebrates"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+actinia
+actinian
+actiniarian
+actinozoan
+aegina
+anemone
+anthozoan
+apolemia
+appendicularia
+ascidian
+astrophyton muricatum
+basket fish
+basket star
+brain coral
+chrysaora quinquecirrha
+cnidarian
+coelenterate
+comatulid
+crinoid
+doliolum
+echinoderm
+echinus esculentus
+edible sea urchin
+glass sponge
+gorgonian coral
+heart urchin
+holothuria edulis
+holothurian
+hydra
+hydroid
+hydrozoan
+larvacean
+madrepore
+madriporian coral
+man-of-war
+medusa
+medusan
+medusoid
+mushroom coral
+nanomia
+parazoan
+planula
+polyp
+poriferan
+portuguese man-of-war
+praya
+red coral
+salpa
+scyphozoan
+sea feather
+sea lily
+sea star
+serpent star
+sertularian
+stag's-horn coral
+staghorn coral
+stony coral
+trepang
+urochord
+urochordate
+venus's flower basket

--- a/lists/animal/mollusk.yml
+++ b/lists/animal/mollusk.yml
@@ -1,0 +1,157 @@
+---
+title: Mollusks
+category: animal
+description: "Snails, slugs, clams, squid, octopuses, and related mollusks"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abalone
+ancylus fluviatilis
+anomia ephippium
+aplacophoran
+aplysia punctata
+architeuthis
+argonaut
+argonauta argo
+ark shell
+bankia setaceae
+bay scallop
+bivalve
+bleeding tooth
+blood clam
+bluepoint
+brown snail
+bubble shell
+capiz
+cardium edule
+cephalopod
+cephalopod mollusk
+chambered nautilus
+cherrystone
+cherrystone clam
+chiton
+coat-of-mail shell
+cockle
+common limpet
+conch
+cornu aspersum
+cowrie
+cowry
+cuttle
+cypraea moneta
+cypraea tigris
+decapod
+dibranch
+dibranchiate
+dibranchiate mollusk
+diodora apertura
+dreissena polymorpha
+ear-shell
+edible cockle
+edible mussel
+edible snail
+escallop
+fissurella apertura
+freshwater clam
+freshwater limpet
+freshwater mussel
+garden snail
+gastropod
+geoduck
+giant conch
+giant northwest shipworm
+giant scallop
+haliotis tuberculata
+hard clam
+hard-shell clam
+helix aspersa
+helix hortensis
+helix pomatia
+hermissenda crassicornis
+jackknife clam
+japanese oyster
+keyhole limpet
+knife-handle
+lamellibranch
+limpet
+littleneck
+littleneck clam
+lobatus gigas
+loligo
+long-neck clam
+marine mussel
+mercenaria mercenaria
+mollusc
+mollusk
+money cowrie
+moon shell
+mussel
+mya arenaria
+mytilid
+mytilus edulis
+nerita
+nerita peloronta
+neritid
+neritid gastropod
+neritina
+octopod
+ommastrephes
+ormer
+ostrea gigas
+paper nautilus
+patella vulgata
+pearl oyster
+pearly nautilus
+pearly-shelled mussel
+pecten irradians
+pecten magellanicus
+pelecypod
+periwinkle
+physa
+piddock
+pinctada margaritifera
+placuna placenta
+polyplacophore
+quahaug
+quahog
+razor clam
+river limpet
+round clam
+saddle oyster
+scallop
+scaphopod
+scollop
+scorpion shell
+sea cradle
+sea scallop
+sea-ear
+seasnail
+seed oyster
+shellfish
+shipworm
+soft-shell clam
+solenogaster
+spirula
+spirula peronii
+steamer
+steamer clam
+strombus gigas
+teredinid
+teredo
+thin-shelled mussel
+tiger cowrie
+tooth shell
+tridacna gigas
+tusk shell
+univalve
+venus mercenaria
+virginia oyster
+whelk
+window oyster
+windowpane oyster
+winkle
+zebra mussel

--- a/lists/animal/reptile.yml
+++ b/lists/animal/reptile.yml
@@ -2,253 +2,690 @@
 title: Reptiles
 category: animal
 description: "Various reptile species including snakes, lizards, tortoises, and crocodilians"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+acanthophis antarcticus
 ackie monitor
 adder
+african chameleon
+african coral snake
+african crocodile
 african fat-tailed gecko
+african monitor
 african rock python
 african spurred tortoise
+agama
+agamid
+agamid lizard
+agkistrodon contortrix
+agkistrodon piscivorus
 aldabra giant tortoise
+alligator lizard
+alligator mississipiensis
+alligator sinensis
+alligator snapper
 alligator snapping turtle
+allosaur
+amblyrhynchus cristatus
 american alligator
+american chameleon
 american crocodile
+amethystine python
 anaconda
+anapsid
+anapsid reptile
+anatotitan
+anguid lizard
+anguis fragilis
+ankylosaur
 anole
+anolis carolinensis
+apatosaur
+apatosaurus excelsus
+archosaur
+archosaurian
+archosaurian reptile
 argentina black and white tegu
+argentinosaur
 argus monitor
+arizona elegans
 armadillo girdled lizard
+armored dinosaur
+asian coral snake
+asian crocodile
+asp viper
+aspidelaps lubricus
+atlantic ridley
+australian blacksnake
+australian coral snake
 ball python
+banded adder
+banded gecko
+banded rattlesnake
+banded sand snake
+barosaur
+barosaurus
 basilisk
+bastard ridley
+bastard turtle
+beaded lizard
 bearded dragon
+bird-footed dinosaur
+bitis arietans
+bitis gabonica
 black mamba
+black racer
 black rat snake
 black spinytail iguana
+black-headed snake
+black-necked cobra
+blacksnake
 blind snake
 blood python
 blue iguana
+blue-belly
 blue-tongued skink
+boa
 boa constrictor
 boelen's python
 bog turtle
+bone-headed dinosaur
 boomslang
+bothrops atrops
+box tortoise
 box turtle
 brahminy blind snake
 broad-snouted caiman
+brontosaur
 brown anole
 brown basilisk
 bullsnake
+bungarus fasciatus
 burmese python
 bush viper
 caiman lizard
+caiman sclerops
 california king snake
+california whipsnake
+callisaurus draconoides
+canebrake rattler
+canebrake rattlesnake
+caretta caretta
+carnosaur
 carpet python
+carpet snake
+carphophis amoenus
 casque-headed iguana
+cayman
+cerastes
+cerastes cornutus
+ceratopsian
+ceratosaur
+chamaeleo chamaeleon
+chamaeleo oweni
+chamaeleon
 chameleon
+charina bottae
+checkered adder
+checkered whiptail
+chelonia mydas
+chelonian
+chelonian reptile
+chelydra serpentina
+chihuahuan spotted whiptail
+chilomeniscus cinctus
 chinese alligator
 chinese water dragon
+chlamydosaurus kingi
+chronoperates paradoxus
+chrysemys picta
 chuckwalla
+cnemidophorus exsanguis
+cnemidophorus sexlineatus
+cnemidophorus tesselatus
+cnemidophorus tigris
+cnemidophorus velox
+coachwhip
 cobra
 collared lizard
+coluber constrictor
+coluber constrictor flaviventris
+coluber hippocrepis
+colubrid
+colubrid snake
+common garter snake
+common iguana
+common kingsnake
 common snapping turtle
+common viper
+common water snake
+constrictor
+constrictor constrictor
+cooter
 copperhead
 coral snake
 corn snake
+corythosaur
+corythosaurus
 cottonmouth
+cottonmouth moccasin
 crested gecko
 crocodile
 crocodile monitor
 crocodile skink
+crocodilian
+crocodilian reptile
+crocodylus niloticus
+crocodylus porosus
+crotalus adamanteus
+crotalus atrox
+crotalus cerastes
+crotalus horridus atricaudatus
+crotalus horridus horridus
+crotalus lepidus
+crotalus mitchellii
+crotalus scutulatus
+crotalus tigris
+crotalus viridis
 cuban crocodile
 cuban rock iguana
+cynodont
 day gecko
 death adder
+deinocheirus
+dendroaspis angusticeps
+dendroaspis polylepis
+denisonia superba
+dermochelys coriacea
 desert iguana
 desert tortoise
+diamondback
 diamondback rattlesnake
 diamondback terrapin
+diapsid
+diapsid reptile
+diapsida
+dicynodont
+dimetrodon
+dinosaur
+dipsosaurus dorsalis
+dragon
 dragon lizard
+dromaeosaur
+drymarchon corais
+drymarchon corais couperi
+duck-billed dinosaur
 dwarf caiman
 dwarf crocodile
+earless lizard
 eastern box turtle
 eastern brown snake
+eastern ground snake
 eastern indigo snake
+edaphosaurus
+edmontonia
+edmontosaurus
 egyptian cobra
 egyptian tortoise
+elaphe guttata
+elaphe obsoleta
+elapid
+elapid snake
+eoraptor
+eretmochelys imbricata
+eumeces callicephalus
+eumeces skiltonianus
+eunectes murinus
+european tortoise
 eyelash viper
+false gavial
 false gharial
 false water cobra
 fat-tailed gecko
+fence lizard
 fer-de-lance
 fire skink
 flat-tailed horned lizard
 florida king snake
 flying dragon
 flying gecko
+flying lizard
+flying reptile
 flying snake
 freshwater crocodile
 frilled lizard
+fringe-toed lizard
+fringed gecko
 gaboon viper
 galapagos land iguana
 galapagos tortoise
 gargoyle gecko
 garter snake
+gator
+gavial
+gavialis gangeticus
 gecko
+genus argentinosaurus
 gharial
 giant day gecko
+giant lizard
+giant tortoise
 gila monster
 glass lizard
+glass snake
+glossy snake
 gold tegu
 gopher snake
 gopher tortoise
+gopher turtle
+gopherus agassizii
+gopherus polyphemus
 green anaconda
 green anole
 green basilisk
 green iguana
+green lizard
 green mamba
 green sea turtle
 green tree python
+green turtle
+gridiron-tailed lizard
+ground rattler
+ground-shaker
+hadrosaur
+haldea striatula
+hamadryad
+hawkbill
+hawksbill
 hawksbill sea turtle
+hawksbill turtle
+heloderma horridum
+heloderma suspectum
+hemachatus haemachatus
 hermann's tortoise
+herrerasaur
 hognose snake
+hoop snake
+horned asp
+horned chameleon
+horned dinosaur
 horned lizard
+horned rattlesnake
+horned toad
+horny frog
+horseshoe whipsnake
+house snake
 hydrosaurus
+hypsiglena torquata
+ichthyosaur
+ictodosaur
 iguana
+iguana iguana
+iguanid
+iguanid lizard
 indian cobra
 indian python
+indian rat snake
 indian star tortoise
 indigo snake
 inland taipan
 jackson's chameleon
 japanese rat snake
 jeweled lacerta
+joint snake
 king cobra
 king snake
 knight anole
 knob-tailed gecko
 komodo dragon
+komodo lizard
 lace monitor
+lacerta agilis
+lacerta viridis
+lacertid
+lacertid lizard
+lampropeltis getulus
+lampropeltis triangulum
+lanthanotus borneensis
+leaf-nosed snake
 leaf-tailed gecko
+leatherback
 leatherback sea turtle
+leatherback turtle
+leathery turtle
 legless lizard
 leopard gecko
 leopard tortoise
+lepidochelys kempii
+lepidochelys olivacea
+leptotyphlops humilis
+lichanura trivirgata
+lined snake
 lizard
+loggerhead
 loggerhead sea turtle
+loggerhead turtle
 long-nosed leopard lizard
 long-tailed grass lizard
+lyre snake
+macroclemys temmincki
+malaclemys centrata
 mamba
 mangrove monitor
 mangrove snake
+maniraptor
 marine iguana
+marine turtle
+massasauga rattler
+masticophis bilineatus
+masticophis flagellum
+masticophis lateralis
 mata mata turtle
+megalosaur
+megalosaurus
 mexican beaded lizard
 mexican black king snake
+micruroides euryxanthus
+micrurus fulvius
+milk adder
 milk snake
 mojave rattlesnake
+moloch
+moloch horridus
+monitor
 monitor lizard
 monkey-tailed skink
 monocled cobra
+mononychus olecranus
 morelet's crocodile
+morelia spilotes variegatus
+morlett's crocodile
+mountain blacksnake
+mountain devil
 mountain horned dragon
+mountain skink
 mourning gecko
 mud snake
 mud turtle
 musk turtle
+naja haje
+naja hannah
+naja naja
+naja nigricollis
+natrix maura
+natrix natrix
+natrix sipedon
+nerodia sipedon
+new world coral snake
+night lizard
 nile crocodile
 nile monitor
+non-avian dinosaur
+notechis scutatus
+nothosaur
+old world coral snake
 olive python
+olive ridley
 olive ridley sea turtle
+opheodrys aestivus
+opheodrys vernalis
+ophidian
+ophiophagus hannah
 ornate box turtle
+ornithischian
+ornithischian dinosaur
+ornithomimid
+ornithopod
+ornithopod dinosaur
+oviraptorid
+oxyuranus scutellatus
+pachycephalosaur
+pacific ridley
+painted terrapin
+painted tortoise
 painted turtle
 pancake tortoise
+pancake turtle
 panther chameleon
 parson's chameleon
+pelycosaur
 perentie
 philippine sailfin lizard
+phrynosoma cornutum
 pig-nosed turtle
+pilot blacksnake
+pine lizard
 pine snake
+pisanosaur
+pisanosaurus
+pituophis melanoleucus
+plateau striped whiptail
 plated lizard
+plesiosaur
+plesiosaurus
+potamophis striatula
+prairie rattler
 prehensile-tailed skink
+protoceratops
+protomammal
+pseudechis porphyriacus
+pseudemys concinna
+pseudemys rubriventris
+pseudemys scripta
+psittacosaur
+pterosaur
+ptyas mucosus
+ptychozoon homalocephalum
 puff adder
 pygmy chameleon
 pygmy rattlesnake
 python
+python molurus
+python reticulatus
+python sebae
+python variegatus
+racer
+racerunner
 radiated tortoise
 rainbow boa
 rat snake
+rattler
 rattlesnake
 red diamond rattlesnake
+red rat snake
 red tegu
 red-bellied black snake
+red-bellied snake
+red-bellied terrapin
+red-bellied turtle
 red-eared slider
 red-footed tortoise
 red-tailed boa
+redbelly
+reptile
+reptilian
 reticulated python
 rhino viper
 rhinoceros iguana
+rhynchoelaps australis
 ribbon snake
+ridley
+ring snake
 ring-necked snake
+ringed snake
+ringhals
+ringneck snake
+rinkhals
+river cooter
 rock python
+rock rattlesnake
+rock snake
 rosy boa
 rough green snake
 rubber boa
 russell's viper
 russian tortoise
+sagebrush lizard
 saltwater crocodile
 sand boa
 sand lizard
+sand snake
+saurian
+saurischian
+saurischian dinosaur
+sauromalus obesus
+sauropod
+sauropod dinosaur
 savannah monitor
 saw-scaled viper
+sceloporus graciosus
+sceloporus occidentalis
+sceloporus undulatus
+scincid
+scincid lizard
 sea krait
 sea snake
 sea turtle
+seismosaur
+serpent
 shingleback skink
+side-blotched lizard
 sidewinder
+sistrurus catenatus
+sistrurus miliaris
+six-lined racerunner
 skink
+slider
 slow worm
+smooth softshell
 snake
 snake-necked turtle
+snapper
 snapping turtle
+soft-shelled turtle
 softshell turtle
+sonora semiannulata
+sonoran lyre snake
+sonoran whipsnake
+speckled rattlesnake
 spectacled caiman
+sphenodon punctatum
+sphenodon punctatus
 spider tortoise
+spiny lizard
+spiny softshell
 spiny softshell turtle
 spiny-tailed iguana
 spitting cobra
+spitting snake
 spotted python
 spotted turtle
+staurikosaur
+staurikosaurus
+stegosaur
+stegosaurus stenops
+stenopterygius
+stenopterygius quadrisicissus
+stinkpot
 stinkpot turtle
+storeria occipitamaculata
+striped racer
+styracosaur
+subclass diapsida
 sulcata tortoise
 sunbeam snake
+superslasher
+swift
+synapsid
+synapsid reptile
 taipan
 tegu
+teiid
+teiid lizard
+teju
 tentacled snake
+terrapene ornata
+terrapin
+testudo graeca
 texas horned lizard
+texas tortoise
+thamnophis proximus
+thamnophis sauritus
+thamnophis sirtalis
+thecodont
+thecodont reptile
+therapsid
+theropod
+theropod dinosaur
 thorny devil
 three-toed box turtle
+thunder lizard
+thunder snake
 tiger snake
 timber rattlesnake
 titanoboa
+titanosaur
+titanosaurian
 tokay gecko
+tomistoma schlegeli
 tortoise
+tortoiseshell turtle
+tow-headed snake
+trachodon
+trachodont
 tree boa
+tree lizard
 tree monitor
+trimorphodon lambda
+trionyx muticus
+trionyx spiniferus
+tropidoclonion lineatum
 tuatara
 turtle
+tyrannosaur
+tyrannosaurus
+uma notata
 uromastyx
+urosaurus ornatus
+uta stansburiana
+varan
+varanus komodoensis
+varanus niloticus
 veiled chameleon
+venomous lizard
 viper
+vipera aspis
+vipera berus
+viperine grass snake
 water dragon
 water moccasin
 water monitor
 water python
 water snake
+western box turtle
+western coral snake
+western diamondback
+western fence lizard
 western hognose snake
+western rattlesnake
+western ribbon snake
+western skink
+western whiptail
+whip-snake
+whiptail
 whiptail lizard
 white-lipped python
 woma python
 wood turtle
+worm lizard
 yellow anaconda
 yellow-bellied sea turtle
+yellow-bellied terrapin
 yellow-footed tortoise
 zebra skink
+zebra-tailed lizard

--- a/lists/animal/worm.yml
+++ b/lists/animal/worm.yml
@@ -1,0 +1,95 @@
+---
+title: Worms
+category: animal
+description: "Earthworms, flatworms, roundworms, marine worms, and related animals"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acanthocephalan
+angleworm
+anguillula aceti
+annelid
+annelid worm
+archiannelid
+arrowworm
+ascaridia galli
+ascaris lumbricoides
+beard worm
+blood fluke
+bloodsucker
+bloodworm
+cestode
+chaetognath
+chicken roundworm
+common roundworm
+crawler
+dew worm
+dracunculus medinensis
+echinococcus
+eelworm
+enterobius vermicularis
+fasciola hepatica
+fasciolopsis buski
+filaria
+fishing worm
+fishworm
+flatworm
+fluke
+guinea worm
+helminth
+hirudinean
+hirudo medicinalis
+hookworm
+horseleech
+liver fluke
+lobworm
+lug
+lugworm
+medicinal leech
+nematode
+nematode worm
+nemertean
+nemertine
+nightcrawler
+nightwalker
+oligochaete
+oligochaete worm
+parasitic worm
+pinworm
+planaria
+planarian
+platyhelminth
+pogonophoran
+polychaete
+polychaete worm
+polychete
+polychete worm
+proboscis worm
+red worm
+ribbon worm
+roundworm
+sagitta
+schistosome
+sea mouse
+segmented worm
+spiny-headed worm
+taenia
+tapeworm
+threadworm
+trematode
+trematode worm
+trichina
+trichinella spiralis
+turbatrix aceti
+tylenchus tritici
+vinegar eel
+vinegar worm
+wheat eel
+wheat eelworm
+wheatworm
+wiggler
+woodworm


### PR DESCRIPTION
## Summary

- add 6,173 moderated, category-unique animal terms from Open English WordNet 2025
- remove the pre-existing generic `human` entry from the animal category
- expand the existing mammal, bird, reptile, amphibian, insect, and all-animal lists
- add focused fish, arachnid, crustacean, mollusk, worm, and marine-invertebrate lists
- grow the animal category from 4,846 to 11,018 unique entries

## Source and method

The vocabulary is adapted from the animal hierarchy in [Open English WordNet 2025](https://en-word.net/downloads), using its common-noun release rather than the separate proper-name edition.

Source archive SHA-256: `38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93`

Terms were assigned to their nearest useful zoological branch, normalized to lowercase prompt phrases, and deduplicated against every existing animal list. Exact duplicates and punctuation/hyphen variants are excluded.

A moderation filter removes sexual/slur-shaped or deprecated surface forms even where they are historically valid animal names. Generic human and fossil-human labels are excluded from the animal category.

Open English WordNet is published by the Open English WordNet Community under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) and derives from Princeton WordNet 3.1. The six new files carry explicit source, license, archive hash and attribution frontmatter; the six expanded mixed-source files carry the same data under semantically precise additionalSource fields.

## Validation

- 6,173 additions / 6,173 exact and punctuation-normalized unique terms
- one pre-existing miscategorized entry removed: `human`
- zero exact or punctuation-normalized collisions with the existing animal category
- all entries lowercase and non-empty
- moderation-token audit clean across every added line
- generic human terms absent from the resulting category
- every changed/new list imports through the package API
- isolated `npm run build` succeeds
- `npm run lint` succeeds
- `git diff --check` clean

Generated indexes are intentionally omitted per the repository content-PR contract; the post-merge workflow regenerates them.

