### PR TITLE
Expand nature category with 12,099 sourced flora terms

### DIFF
--- a/lists/nature/aquatic-plant.yml
+++ b/lists/nature/aquatic-plant.yml
@@ -1,0 +1,309 @@
+---
+title: Aquatic plants
+category: nature
+description: "Floating, submerged, emergent, and water-edge plants"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acorus calamus
+alisma plantago-aquatica
+american brooklime
+american centaury
+american featherfoil
+american frogbit
+american lotus
+aquatic plant
+arrow arum
+arrow grass
+awlwort
+bitter floom
+blue lotus
+bog myrtle
+bog plant
+bog star
+bogbean
+bogmat
+brasenia schreberi
+brooklime
+brookweed
+buckbean
+bullrush
+bulrush
+burweed marsh elder
+cabomba caroliniana
+calla palustris
+caltha palustris
+canadian pondweed
+carex arenaria
+carex pseudocyperus
+cat's-tail
+cattail
+chelone glabra
+chinese water chestnut
+chrysosplenium americanum
+chufa
+common cotton grass
+common duckweed
+common rush
+common wolffia
+cotton grass
+cotton rush
+cow lily
+creeping spike rush
+cryptocoryne
+curled leaf pondweed
+curly pondweed
+cyperus alternifolius
+cyperus esculentus
+cyperus longus
+cyperus papyrus
+cyperus rotundus
+cypress sedge
+dense-leaved elodea
+duckweed
+earth almond
+eelgrass
+egeria densa
+egyptian paper reed
+egyptian paper rush
+egyptian water lily
+eichhornia crassipes
+eichhornia spesiosa
+eleocharis acicularis
+eleocharis dulcis
+eleocharis palustris
+elodea canadensis
+elodea densa
+eriocaulon aquaticum
+eriophorum angustifolium
+european brooklime
+european white lily
+false ragweed
+fanwort
+feather-foil
+featherfoil
+flagroot
+foetid pothos
+fragrant water lily
+frog's lettuce
+frog's-bit
+frogbit
+galingale
+golden club
+golden saxifrage
+golden spleen
+grass wrack
+grass-of-parnassus
+great duckweed
+greater spearwort
+greater water parsnip
+green arrow arum
+ground almond
+hair grass
+hard rush
+hardstem bulrush
+hardstemmed bulrush
+heteranthera dubia
+horned pondweed
+hornwort
+hottonia inflata
+hottonia palustris
+hydrilla
+hydrilla verticillata
+hydrocharis morsus-ranae
+hydrophyte
+hydrophytic plant
+indian lotus
+iva
+iva xanthifolia
+jesuits' nut
+jointed rush
+juncus articulatus
+juncus bufonius
+juncus effusus
+juncus inflexus
+juncus leseurii
+juncus tenuis
+lemna minor
+lemna trisulca
+lesser bullrush
+lesser duckweed
+lesser spearwort
+limnodium spongia
+ling ko
+lizard's-tail
+loddon pondweed
+lotus
+lysichiton americanum
+marsh elder
+marsh marigold
+marsh pink
+marsh plant
+marsh trefoil
+may blob
+meadow bright
+menyanthes trifoliata
+mud midget
+mud plantain
+myrtle flag
+naiad
+nailrod
+narrow-leaf cattail
+narrow-leaved reedmace
+narrow-leaved water plantain
+needle rush
+needle spike rush
+nelumbo lutea
+nelumbo nucifera
+nuphar advena
+nuphar lutea
+nuphar sagittifolium
+nut grass
+nut sedge
+nutgrass
+nutsedge
+nymphaea alba
+nymphaea caerulea
+nymphaea lotus
+nymphaea odorata
+nymphaea stellata
+orontium aquaticum
+paper plant
+paper rush
+papyrus
+parnassia
+parnassia palustris
+peltandra virginica
+pickerel weed
+pickerelweed
+pipewort
+pistia
+pistia stratiotes
+pistia stratoites
+polecat weed
+pond lily
+pondweed
+pontederia cordata
+potamogeton americanus
+potamogeton crispus
+potamogeton gramineous
+potamogeton gramineus
+potamogeton nodosus
+prairie sabbatia
+ranunculus aquatilis
+ranunculus flammula
+ranunculus lingua
+reed mace
+reedmace
+ribbon-leaved water plantain
+rose pink
+rush
+rush nut
+sabatia campestris
+sabbatia
+sabbatia angularis
+sabbatia campestris
+sabbatia stellaris
+sacred lotus
+salt rush
+samolus floribundus
+samolus parviflorus
+samolus valerandii
+sand reed
+sand sedge
+saururus cernuus
+scirpus acutus
+scirpus cyperinus
+sea wrack
+sedge
+shell-flower
+sium latifolium
+sium sisarum
+sium suave
+skirret
+skunk cabbage
+slender rush
+slender spike rush
+snake-head
+snakehead
+soft flag
+soft rush
+southern spatterdock
+spatterdock
+spike rush
+spirodela polyrrhiza
+star-duckweed
+subularia aquatica
+swamp lily
+swamp plant
+sweet calamus
+sweet flag
+symplocarpus foetidus
+tall yellow-eye
+tape grass
+toad rush
+trapa bicornis
+trapa natans
+triglochin maritima
+tuckahoe
+turtlehead
+typha angustifolia
+typha latifolia
+umbrella sedge
+vallisneria spiralis
+variously-leaved pondweed
+veronica americana
+veronica anagallis-aquatica
+veronica beccabunga
+veronica michauxii
+wampee
+water arum
+water buttercup
+water cabbage
+water caltrop
+water carpet
+water chestnut
+water chestnut plant
+water chinquapin
+water crowfoot
+water dragon
+water flaxseed
+water gillyflower
+water hyacinth
+water lettuce
+water lily
+water mat
+water milfoil
+water nymph
+water orchid
+water parsnip
+water pimpernel
+water plant
+water plantain
+water shamrock
+water speedwell
+water star grass
+water starwort
+water trumpet
+water violet
+water-shield
+water-target
+watermeal
+waterweed
+white lily
+white lotus
+wild calla
+wolffia columbiana
+wolffiella gladiata
+xyris operculata
+yanquapin
+yellow nutgrass
+yellow pond lily
+yellow water lily
+yellow-eyed grass
+zannichellia palustris
+zostera marina

--- a/lists/nature/bulbous-plant.yml
+++ b/lists/nature/bulbous-plant.yml
@@ -1,0 +1,439 @@
+---
+title: Bulbous plants
+category: nature
+description: "Plants growing from bulbs and similar underground structures"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+adobe lily
+african lily
+african tulip
+agapanthus
+agapanthus africanus
+ague grass
+ague root
+albuca
+aletris aurea
+aletris farinosa
+alkali grass
+alliaceous plant
+allium acuminatum
+allium ampeloprasum
+allium ascalonicum
+allium canadense
+allium carinatum
+allium cepa
+allium cepa aggregatum
+allium cepa viviparum
+allium cernuum
+allium fistulosum
+allium haematochiton
+allium neopolitanum
+allium paradoxum
+allium porrum
+allium sativum
+allium schoenoprasum
+allium scorodoprasum
+allium sphaerocephalum
+allium tricoccum
+allium triquetrum
+allium tuberosum
+allium ursinum
+allium vineale
+alstroemeria
+alstroemeria pelegrina
+amaryllis
+amaryllis belladonna
+amber lily
+amberbell
+american bog asphodel
+american hellebore
+amianthum muscaetoxicum
+amianthum muscitoxicum
+andrew's clintonia
+annunciation lily
+anthericum liliago
+anthericum torreyi
+asphodel
+asphodeline lutea
+autumn crocus
+avalanche lily
+aztec lily
+bath asparagus
+bearded iris
+beardless iris
+belamcanda chinensis
+belladonna lily
+bermuda lily
+birthroot
+black fritillary
+blackberry-lily
+blonde lilian
+blood lily
+bloomeria crocea
+blue african lily
+blue flag
+blue-eyed grass
+bog asphodel
+bride's bonnet
+brodiaea
+brodiaea elegans
+brown bells
+bugbane
+bulbous iris
+bulbous plant
+calochortus albus
+calochortus amabilis
+calochortus amoenus
+calochortus elegans
+calochortus kennedyi
+calochortus luteus
+calochortus macrocarpus
+calochortus nuttallii
+camas
+camash
+camass
+camassia leichtlinii
+camassia quamash
+camassia scilloides
+camosh
+canada garlic
+canada lily
+candlestick tulip
+cape hyacinth
+cape tulip
+cat's-ear
+checkered daffodil
+checkered lily
+chincherinchee
+chinese chive
+chive
+chives
+cive
+clinton's lily
+clintonia
+clintonia andrewsiana
+clintonia borealis
+clintonia uniflora
+coast lily
+colchicum autumnale
+colic root
+colicroot
+columbia tiger lily
+common camas
+common grape hyacinth
+common hyacinth
+convallaria majalis
+corn lily
+cottage tulip
+crocus
+crocus sativus
+crow corn
+crow garlic
+crown imperial
+daffodil
+daffodil garlic
+dalmatian iris
+darwin tulip
+daylily
+death camas
+desert mariposa tulip
+devil lily
+dog's-tooth violet
+dogtooth
+dogtooth violet
+dutch iris
+dwarf iris
+dwarf tulip
+dwarf-white trillium
+early wake-robin
+easter lily
+egyptian onion
+elegant brodiaea
+elegant cat's ears
+english iris
+erythronium albidum
+erythronium americanum
+erythronium californicum
+erythronium dens-canis
+erythronium grandiflorum
+erythronium montanum
+eschalot
+european bog asphodel
+european dogtooth
+fairy lantern
+false asphodel
+false garlic
+false hellebore
+false lily of the valley
+fawn lily
+few-flowered leek
+field garlic
+flag
+fleur-de-lis
+florentine iris
+flowering onion
+fly poison
+freesia
+fritillaria affinis
+fritillaria agrestis
+fritillaria biflora
+fritillaria imperialis
+fritillaria lanceolata
+fritillaria liliaceae
+fritillaria meleagris
+fritillaria micrantha
+fritillaria mutica
+fritillaria parviflora
+fritillaria pluriflora
+fritillaria recurva
+fritillary
+galtonia candicans
+garlic
+garlic chive
+german iris
+giant garlic
+glacier lily
+glad
+gladdon
+gladdon iris
+gladiola
+gladiolus
+globe lily
+golden fairy lantern
+golden star
+golden stars
+grape hyacinth
+grassy death camas
+great solomon's-seal
+guinea-hen flower
+haemanthus coccineus
+hellebore
+hemerocallis flava
+hemerocallis lilio-asphodelus
+hippeastrum
+hippeastrum puniceum
+hooker's onion
+hyacinth
+hyacinthoides nonscripta
+hyacinthus candicans
+hyacinthus orientalis
+hyacinthus orientalis albulus
+indigo squill
+iridaceous plant
+iris
+iris cristata
+iris filifolia
+iris florentina
+iris foetidissima
+iris germanica
+iris germanica florentina
+iris kaempferi
+iris kochii
+iris pallida
+iris persica
+iris pseudacorus
+iris tingitana
+iris verna
+iris versicolor
+iris virginica
+iris xiphioides
+iris xiphium
+jacob's rod
+jacobean lily
+japanese iris
+japanese leek
+jonquil
+keeled garlic
+kentan
+king's spear
+kurrat
+lady tulip
+lady's leek
+leek
+leichtlin's camas
+lemon lily
+lent lily
+leopard lily
+leper lily
+levant garlic
+liliaceous plant
+lilium auratum
+lilium canadense
+lilium candidum
+lilium catesbaei
+lilium columbianum
+lilium lancifolium
+lilium longiflorum
+lilium maritinum
+lilium martagon
+lilium michiganense
+lilium pardalinum
+lilium philadelphicum
+lilium superbum
+lily
+lily of the incas
+lily of the nile
+lily of the valley
+lily turf
+lilyturf
+liriope muscari
+madonna lily
+maianthemum bifolium
+maianthemum canadense
+mariposa
+mariposa lily
+mariposa tulip
+martagon
+may lily
+meadow leek
+meadow lily
+meadow saffron
+michigan lily
+mission bells
+multiplier onion
+muscari comosum
+muscari neglectum
+naples garlic
+narcissus
+narcissus jonquilla
+narcissus papyraceus
+narcissus pseudonarcissus
+narthecium americanum
+narthecium ossifragum
+nodding onion
+nodding wild onion
+onion
+onion plant
+oregon lily
+ornithogalum pyrenaicum
+ornithogalum thyrsoides
+ornithogalum umbellatum
+orris
+panther lily
+paper white
+persian iris
+peruvian lily
+pine lily
+pink fritillary
+poison camas
+polygonatum biflorum
+polygonatum commutatum
+prairie trillium
+prairie wake-robin
+prussian asparagus
+purple trillium
+quamash
+queen's cup
+ramp
+ramsons
+red clintonia
+red trillium
+red-skinned onion
+rice-grain fritillary
+roast beef plant
+rocambole
+roman hyacinth
+rose globe lily
+rose leek
+round-headed leek
+saffron
+saffron crocus
+sagebrush mariposa tulip
+saint-bernard's-lily
+sand leek
+scallion
+scarlet fritillary
+schnittlaugh
+scilla
+scilla nonscripta
+scilla verna
+scotch asphodel
+sea onion
+sea squill
+sego lily
+sessile trillium
+shallot
+snow lily
+snow trillium
+solomon's-seal
+southern blue flag
+spanish garlic
+spanish iris
+spring squill
+squill
+stag's garlic
+star tulip
+star-of-bethlehem
+starflower
+stink bell
+stinking gladwyn
+stinking iris
+strekelia formosissima
+summer hyacinth
+summer snowflake
+sword lily
+tassel hyacinth
+three-cornered leek
+tiger lily
+toadshade
+tofieldia pusilla
+top onion
+tree onion
+trillium
+trillium erectum
+trillium recurvatum
+trillium sessile
+triquetrous leek
+trout lily
+tulip
+tulipa armena
+tulipa clusiana
+tulipa gesneriana
+tulipa suaveolens
+turk's cap-lily
+turk's-cap
+unicorn root
+urginea maritima
+veratrum viride
+vernal iris
+welsh onion
+white camas
+white dog's-tooth violet
+white dogtooth violet
+white fairy lantern
+white fritillary
+white globe lily
+white hellebore
+white trumpet lily
+wild garlic
+wild hyacinth
+wild leek
+wild meadow lily
+wild onion
+wild yellow lily
+wonder flower
+wood garlic
+wood hyacinth
+wood lily
+xerophyllum tenax
+xiphium iris
+yellow adder's tongue
+yellow asphodel
+yellow clintonia
+yellow colicroot
+yellow flag
+yellow globe lily
+yellow iris
+yellow mariposa tulip
+yellow water flag
+zigadene
+zigadenus elegans
+zigadenus glaucus
+zigadenus nuttalli
+zigadenus venenosus
+zigadenus venenosus gramineus

--- a/lists/nature/fern.yml
+++ b/lists/nature/fern.yml
@@ -1,0 +1,435 @@
+---
+title: Ferns
+category: nature
+description: "Ferns, fronds, and fern growth forms"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acrostichum aureum
+adder's fern
+adder's tongue
+adder's tongue fern
+adiantum bellum
+adiantum capillus-veneris
+adiantum pedatum
+adiantum tenerum
+adiantum tenerum farleyense
+aglaomorpha meyeniana
+alabama lip fern
+alpine lady fern
+alpine woodsia
+american maidenhair fern
+american parsley fern
+american rock brake
+american wall fern
+anemia adiantifolia
+angiopteris
+angiopteris evecta
+annual fern
+anogramma leptophylla
+aquatic fern
+asplenium adiantum-nigrum
+asplenium billotii
+asplenium bradleyi
+asplenium ceterach
+asplenium montanum
+asplenium nidus
+asplenium nigripes
+asplenium pinnatifidum
+asplenium platyneuron
+asplenium rhizophyllum
+asplenium ruta-muraria
+asplenium scolopendrium
+asplenium trichomanes
+asplenium viride
+athyrium distentifolium
+athyrium filix-femina
+athyrium pycnocarpon
+athyrium thelypteroides
+australian hare's foot
+azolla caroliniana
+ball fern
+bamboo fern
+barbados maidenhair
+basket fern
+bead fern
+bear's-paw fern
+beech fern
+bermuda maidenhair
+bermuda maidenhair fern
+berry fern
+bird's-foot fern
+black spleenwort
+black tree fern
+black-stem spleenwort
+black-stemmed spleenwort
+bladder fern
+blechnum spicant
+botrychium lunaria
+botrychium matricariifolium
+botrychium multifidum
+botrychium virginianum
+boulder fern
+bracken
+bradley's spleenwort
+brake
+braun's holly fern
+bristle fern
+brittle bladder fern
+brittle fern
+brittle maidenhair
+brittle maidenhair fern
+broad beech fern
+broad buckler-fern
+buckler fern
+bulblet bladder fern
+bulblet fern
+button fern
+camptosorus rhizophyllus
+campyloneurum augustifolium
+canary island hare's foot fern
+canker brake
+carolina pond fern
+central american strap fern
+ceratopteris pteridioides
+ceratopteris thalictroides
+ceterach officinarum
+chain fern
+cheilanthes alabamensis
+cheilanthes eatonii
+cheilanthes gracillima
+cheilanthes lanosa
+christella
+christmas fern
+cibotium barometz
+cinnamon fern
+cliff brake
+climbing bird's nest fern
+clover fern
+coast polypody
+coffee fern
+common maidenhair
+common moonwort
+common nardoo
+common polypody
+common staghorn fern
+coniogramme japonica
+cow-tongue fern
+crape fern
+crepe fern
+cryptogramma acrostichoides
+cryptogramma crispa
+culcita dubia
+curly grass
+curly grass fern
+cyathea medullaris
+cyclophorus lingua
+cyrtomium aculeatum
+cystopteris bulbifera
+cystopteris fragilis
+cystopteris montana
+dagger fern
+daisy-leaved grape fern
+daisyleaf grape fern
+davalia bullata
+davalia bullata mariesii
+davallia
+davallia canariensis
+davallia mariesii
+davallia pyxidata
+deer fern
+dennstaedtia punctilobula
+deparia acrostichoides
+dicksonia antarctica
+diplazium pycnocarpon
+diplopterygium longissimum
+ditch fern
+doodia
+doryopteris pedata
+drynaria rigidula
+dryopteris dilatata
+dryopteris filix-mas
+dryopteris fragrans
+dryopteris goldiana
+dryopteris hexagonoptera
+dryopteris marginalis
+dryopteris noveboracensis
+dryopteris oreades
+dryopteris oreopteris
+dryopteris phegopteris
+dryopteris thelypteris
+dryopteris thelypteris pubescens
+ebony spleenwort
+elkhorn fern
+european parsley fern
+evergreen wood fern
+false bracken
+fan fern
+farley maidenhair
+farley maidenhair fern
+felt fern
+fiddlehead
+fiddlehead fern
+film fern
+filmy fern
+five-fingered maidenhair fern
+floating fern
+floating-moss
+florida strap fern
+flower-cup fern
+flowering fern
+fragile fern
+fragrant cliff fern
+fragrant shield fern
+fragrant wood fern
+fragrant woodsia
+french bracken
+giant fern
+giant scrambling fern
+glade fern
+gleichenia flabellata
+glory fern
+gold fern
+golden fern
+golden maidenhair
+golden polypody
+goldie's fern
+goldie's shield fern
+goldie's wood fern
+grape fern
+grass fern
+gray polypody
+green spleenwort
+grey polypody
+gymnocarpium dryopteris
+gymnocarpium robertianum
+hairy lip fern
+hand fern
+hard fern
+hare's-foot bristle fern
+hare's-foot fern
+hart's-tongue
+hart's-tongue fern
+hay-scented
+hay-scented fern
+helminthostachys zeylanica
+holly fern
+indian button fern
+interrupted fern
+jersey fern
+kidney fern
+killarney fern
+king fern
+lace fern
+lady fern
+lanceolate spleenwort
+leather fern
+leatherleaf fern
+leatherleaf wood fern
+leathery grape fern
+leathery polypody
+lecanopteris
+leptopteris superba
+licorice fern
+limestone fern
+lip fern
+lipfern
+little ebony spleenwort
+lobed spleenwort
+long beech fern
+maidenhair
+maidenhair spleenwort
+male fern
+marattia salicina
+marginal wood fern
+marsh fern
+marsilea drummondii
+marsilea quadrifolia
+massachusetts fern
+matteuccia struthiopteris
+meadow fern
+microgramma piloselloides
+microsorium punctatum
+mohria caffrorum
+moonwort
+mosquito fern
+mountain bladder fern
+mountain fern
+mountain male fern
+mountain parsley fern
+mountain spleenwort
+nardo
+nardoo
+narrow beech fern
+narrow-leaved spleenwort
+narrow-leaved strap fern
+nephrolepis exaltata
+nephrolepis exaltata bostoniensis
+nephrolepis pectinata
+new york fern
+northern beech fern
+northern holly fern
+northern oak fern
+northern woodsia
+oak fern
+oblong woodsia
+oleander fern
+oleandra mollis
+oleandra neriiformis
+olfersia cervina
+onoclea sensibilis
+onoclea struthiopteris
+ophioglossum pendulum
+oreopteris limbosperma
+osmund
+osmunda cinnamonea
+osmunda clatonia
+osmunda regalis
+ostrich fern
+parathelypteris novae-boracensis
+parathelypteris simulata
+pasture brake
+pecopteris
+pellaea andromedifolia
+pellaea atropurpurea
+pellaea mucronata
+pellaea ornithopus
+pellaea rotundifolia
+phegopteris connectilis
+phegopteris hexagonoptera
+phlebodium aureum
+phyllitis scolopendrium
+pillwort
+pilularia globulifera
+pine fern
+pityrogramma argentea
+pityrogramma calomelanos
+pityrogramma calomelanos aureoflava
+pityrogramma chrysophylla
+platycerium alcicorne
+platycerium andinum
+platycerium bifurcatum
+polybotria cervina
+polybotrya cervina
+polypodium aureum
+polypodium glycyrrhiza
+polypodium polypodioides
+polypodium scouleri
+polypodium virgianum
+polypodium vulgare
+polypody
+polystichum acrostichoides
+polystichum aculeatum
+polystichum adiantiformis
+polystichum braunii
+polystichum lonchitis
+polystichum scopulinum
+polystichum setiferum
+potato fern
+prickly shield fern
+prince-of-wales feather
+prince-of-wales fern
+prince-of-wales plume
+pteretis struthiopteris
+pteridium aquilinum
+pteridium esculentum
+pteris cretica
+pteris multifida
+pteris serrulata
+purple rock brake
+pyrrosia lingua
+rabbit's-foot fern
+rasp fern
+rattlesnake fern
+regnellidium
+regnellidium diphyllum
+resurrection fern
+ribbon fern
+rock brake
+rock polypody
+royal fern
+royal osmund
+rumohra adiantiformis
+rusty woodsia
+sago fern
+salvinia auriculata
+salvinia rotundifolia
+scale fern
+scaly fern
+schaffneria nigripes
+schizaea pusilla
+scolopendrium
+scolopendrium nigripes
+scott's spleenwort
+scythian lamb
+sensitive fern
+serpent fern
+shield fern
+shuttlecock fern
+silver fern
+silver tree fern
+silvery spleenwort
+smooth lip fern
+smooth woodsia
+snake polypody
+snuffbox fern
+soft shield fern
+soft tree fern
+solanopteris bifrons
+south american staghorn
+southern beech fern
+southern maidenhair
+southwestern lip fern
+spider brake
+spider fern
+spleenwort
+squirrel's-foot fern
+sticherus flabellatus
+strap fern
+sword fern
+tectaria cicutaria
+tectaria macrodonta
+ten-day fern
+thelypteris dryopteris
+thelypteris hexagonoptera
+thelypteris palustris
+thelypteris palustris pubescens
+thelypteris phegopteris
+thelypteris simulata
+thyrsopteris
+thyrsopteris elegans
+todea barbara
+todea superba
+tongue fern
+toothed sword fern
+tree fern
+trichomanes boschianum
+trichomanes reniforme
+trichomanes speciosum
+umbrella fern
+venus maidenhair
+venus'-hair fern
+venushair
+virginia chain fern
+vittaria lineata
+walking fern
+walking leaf
+wall fern
+wall rue
+wall rue spleenwort
+water clover
+water fern
+water sprite
+western holly fern
+wood fern
+woodfern
+woodsia
+woodsia alpina
+woodsia glabella
+woodsia ilvensis
+woodwardia virginica
+wooly lip fern

--- a/lists/nature/flower.yml
+++ b/lists/nature/flower.yml
@@ -2,106 +2,304 @@
 title: Flowers
 category: nature
 description: "Various flowering plants, herbs, and ornamental garden blooms"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 acanthus (acanthus mollis)
+achimenes
 aconite (aconitum)
+acroclinium roseum
+actinomeris alternifolia
+adam-and-eve
+adonis annua
 aegopodium (aegopodium podagraria)
+aerides
+african daisy
+african marigold
 african tulip tree (spathodea campanulata)
+african violet
 agapanthus (agapanthus africanus)
+ageratum
 ageratum (ageratum houstonianum)
+ageratum houstonianum
+ague weed
+agueweed
+alaska rein orchid
 alkanet (anchusa)
 allium (allium)
+alpine anemone
 alpine aster (aster alpinus)
 alpine forget-me-not (myosotis alpestris)
 alpine pasqueflower (pulsatilla alpina)
+alsobia dianthiflora
 alstroemeria (alstroemeria)
 amaranth (amaranthus)
 amaryllis (hippeastrum)
 amazon lily (eucharis grandiflora)
+amberboa moschata
+ammobium
+ammobium alatum
+anaphalis margaritacea
+anemone
 anemone (anemone coronaria)
 anemone (anemone)
+anemone canadensis
+anemone cylindrica
+anemone nemorosa
+anemone quinquefolia
+anemone riparia
+anemone sylvestris
+anemone tetonensis
+anemone virginiana
+anemonella thalictroides
 angel trumpet (brugmansia)
+angel-wing begonia
 angel's trumpet (brugmansia)
 angelonia (angelonia)
+angrecum
+annual salt-marsh aster
+anthemis arvensis
+anthemis cotula
+anthemis tinctoria
 anthurium (anthurium)
+antirrhinum coulterianum
+antirrhinum filipes
+antirrhinum majus
+aplectrum hyemale
+aquilege
+aquilegia
+aquilegia caerulea
+aquilegia canadensis
+aquilegia scopulorum calcarea
+aquilegia vulgaris
+arctic poppy
+arctotis stoechadifolia
+arctotis venusta
+arenaria caroliniana
+arenaria groenlandica
+arenaria peploides
+arenaria serpyllifolia
+arenaria stricta
+arethusa
+arethusa bulbosa
 arisaema (arisaema)
 aristolochia (aristolochia)
+aromatic aster
+arrow leaved aster
 arum (arum maculatum)
+arum lily
 arum lily (zantedeschia)
 asphodel (asphodelus)
+aster
 aster (aster)
+aster acuminatus
+aster arenosus
+aster cordifolius
+aster divaricatus
+aster dumosus
+aster ericoides
+aster falcatus
+aster linarifolius
+aster linosyris
+aster macrophyllus
+aster novae-angliae
+aster novi-belgii
+aster ptarmicoides
+aster shortii
+aster tripolium
+aster turbinellis
 azalea (rhododendron)
+aztec marigold
+azure aster
 babiana (babiana)
+babies'-breath
+baby's breath
 baby's breath (gypsophila paniculata)
+bachelor's button
 bachelor's button (centaurea cyanus)
 balloon flower (platycodon grandiflorus)
 baobab (adansonia digitata)
+barberton daisy
+bartonia
 bearded iris (iris germanica)
 bee balm (monarda)
 bee orchid
+beefsteak begonia
+beefsteak geranium
 begonia (begonia)
+begonia cheimantha
+begonia cocchinea
+begonia dregei
+begonia erythrophylla
+begonia feastii
+begonia heracleifolia
+begonia rex
+begonia semperflorens
+begonia socotrana
+begonia tuberhybrida
 belladonna lily (amaryllis belladonna)
 bellflower (campanula)
+bellis perennis
+bellwort
+bessera elegans
+big marigold
+billy buttons
 bird of paradise (strelitzia reginae)
+bird's eye
 black bat flower
 black bat flower (tacca chantrieri)
+black caraway
 black orchid (maxillaria)
 black-eyed susan
 black-eyed susan (rudbeckia hirta)
 black-eyed susan vine (thunbergia alata)
 blackthorn (prunus spinosa)
+bladder campion
 blanket flower (gaillardia)
+blazing star
 bleeding heart
+bletia
+bletia striata
+bletilla striata
+blind gentian
 blood lily (scadoxus multiflorus)
+bloomer
+blooming-fool begonia
 blue cohosh (caulophyllum thalictroides)
+blue columbine
+blue daisy
 blue eyed grass (sisyrinchium)
 blue flag (iris versicolor)
 blue flag iris (iris versicolor)
+blue marguerite
+blue orchid
+blue poppy
 blue poppy (meconopsis betonicifolia)
+blue succory
+blue toadflax
+blue-eyed african daisy
 bluebell (hyacinthoides non-scripta)
 bluebell of scotland (campanula rotundifolia)
 bluebells (hyacinthoides non-scripta)
+bluebottle
+bog aster
+bog candles
+bog rein orchid
+bog rose
+bottle gentian
 bottlebrush (callistemon citrinus)
 bottlebrush (callistemon)
 bougainvillea (bougainvillea glabra)
 bougainvillea (bougainvillea spectabilis)
+bouncing bess
+bouncing bet
+brachycome iberidifolia
+brass buttons
+brassia lawrenceana
 brassia orchid (brassia)
+brassia verrucosa
+broad leaved centaury
+broad-leaved twayblade
 brodiaea (brodiaea)
 bromeliad (bromeliaceae)
 bromeliad tillandsia (tillandsia)
+brompton stock
 broom (cytisus scoparius)
+browallia
 bugleweed (ajuga)
 bulbine (bulbine frutescens)
 burnet (sanguisorba)
+bush violet
+bushy aster
+butter daisy
+butter-and-eggs
 buttercup (ranunculus)
 butterfly bush (buddleia davidii)
 butterfly bush (buddleja)
+butterfly orchid
+butterfly orchis
 butterfly pea (clitoria ternatea)
+butterfly plant
+button pink
 cactus dahlia (dahlia coccinea)
 cactus flower (cactaceae)
+caladenia
+caladenia cairnsiana
+calanthe
+calathian violet
+calceolaria
 calceolaria (calceolaria)
 calendula
+calendula officinalis
+calico aster
+california bluebell
+california four o'clock
+california lady's slipper
+california poppy
+calla
+calla lily
 calla lily (zantedeschia aethiopica)
+callistephus chinensis
+calopogon pulchellum
+calopogon tuberosum
 caltha (caltha palustris)
+calypso
+calypso bulbosa
 camellia (camellia japonica)
 camellia (camellia)
 campanula (campanula)
+campion
 campion (silene)
+canada anemone
+candytuft
 canna (canna indica)
 canterbury bells (campanula medium)
 cape fuchsia (phygelius capensis)
 cape jasmine (gardenia jasminoides)
+cape marigold
+cape primrose
 cardinal climber (ipomoea x multifida)
 cardinal flower (lobelia cardinalis)
 cardoon (cynara cardunculus)
+carnation
 carnation (dianthus caryophyllus)
+carolina spring beauty
+cascade everlasting
 cassia fistula
+catananche
+catananche caerulea
+catasetum macrocarpum
+catchfly
 catmint (nepeta cataria)
 catmint (nepeta)
+cattleya citrina
+celandine
 celandine (chelidonium majus)
+celandine poppy
 celosia (celosia argentea)
+centaurea cyanus
+centaurea imperialis
+centaurea moschata
+centaurium calycosum
+centaurium minus
+centaurium scilloides
+centranthus ruber
+cephalanthera rubra
+chafeweed
+chatterbox
+cheddar pink
+cheiranthus allionii
+cheiranthus asperus
+cheiranthus cheiri
+chelidonium majus
 chilean bellflower (lapageria rosea)
+china aster
 china aster (callistephus chinensis)
+china pink
 chinese fringe flower (loropetalum chinense)
 chinese lantern (physalis alkekengi)
 chinese lantern tree (abutilon megapotamicum)
@@ -110,75 +308,196 @@ chives (allium schoenoprasum)
 chocolate cosmos
 chocolate cosmos (cosmos atrosanguineus)
 chocolate flower (berlandiera lyrata)
+chop-suey greens
+christmas begonia
+christmas bells
 christmas cactus (schlumbergera)
 christmas rose (helleborus niger)
+chrysanthemum
 chrysanthemum (chrysanthemum)
+chrysanthemum coccineum
+chrysanthemum coronarium
+chrysanthemum coronarium spatiosum
+chrysanthemum lacustre
+chrysanthemum leucanthemum
+chrysanthemum maximum
+chrysanthemum maximum maximum
+chrysanthemum morifolium
+chrysanthemum ptarmiciflorum
+chrysanthemum segetum
 cimicifuga (cimicifuga racemosa)
+cineraria
 cineraria (cineraria)
+clatonia lanceolata
+claytonia caroliniana
+claytonia virginica
+cleistes divaricata
+cleistes rosea
 clematis (clematis)
 clerodendrum thomsoniae
 clethra (clethra alnifolia)
 clivia (clivia miniata)
+closed gentian
+clove pink
+clustered lady's slipper
+coastal rein orchid
 cobra lily (darlingtonia californica)
 cockscomb (celosia cristata)
+coeloglossum bracteatum
+coeloglossum viride
+coelogyne
 coffee plant (coffea arabica)
 colocasia (colocasia esculenta)
+colorado four o'clock
+columbine
 columbine (aquilegia)
+commelina
+common ageratum
+common daisy
+common four-o'clock
+common lady's-slipper
+common marigold
+common speedwell
+common spotted orchid
+common sunflower
+common valerian
+compass flower
+composite
+composite plant
 coneflower
 coneflower (echinacea purpurea)
+conoclinium coelestinum
+consolida ambigua
 convallaria (convallaria majalis)
 coral bells (heuchera sanguinea)
 coral bells (heuchera)
+coral drops
+coral root
 coral vine (antigonon leptopus)
+corallorhiza maculata
+corallorhiza striata
+corallorhiza trifida
 coreopsis (coreopsis)
+corn chamomile
+corn marigold
+corn mayweed
+corn poppy
 corn poppy (papaver rhoeas)
+corn speedwell
+cornflower
 cornflower (centaurea cyanus)
+cornflower aster
 corpse flower
+corydalis
+cosmea
 cosmos
 cosmos (cosmos bipinnatus)
 cosmos bipinnatus (cosmos bipinnatus)
+cottage pink
 cotton plant (gossypium)
+cottonweed
 cottonwood (populus deltoides)
+cotula coronopifolia
+cow cockle
+cowherb
+cowpen daisy
 cowslip (primula veris)
 cranesbill (geranium macrorrhizum)
 crape myrtle (lagerstroemia indica)
+creamcups
+crested coral root
 crocosmia (crocosmia)
 crocus (crocus sativus)
 crocus (crocus)
+crooked-stemmed aster
+crown daisy
 crown imperial (fritillaria imperialis)
+crown-beard
+crownbeard
+cuckoo flower
 cuckoo flower (cardamine pratensis)
 cup and saucer vine (cobaea scandens)
 cuphea (cuphea)
+cupid's dart
 cupid's dart (catananche caerulea)
 curcuma (curcuma longa)
+cutleaved coneflower
+cyclamen
 cyclamen (cyclamen persicum)
+cyclamen hederifolium
+cyclamen neopolitanum
+cyclamen purpurascens
+cymbid
+cypripedia
+cypripedium acaule
+cypripedium album
+cypripedium arietinum
+cypripedium calceolus
+cypripedium calceolus pubescens
+cypripedium californicum
+cypripedium fasciculatum
+cypripedium montanum
+cypripedium parviflorum
+cypripedium reginae
+dactylorhiza fuchsii
+dactylorhiza maculata fuchsii
 daffodil (narcissus pseudonarcissus)
 daffodil (narcissus)
 dahlia
 dahlia (dahlia)
+dahlia pinnata
+daisy
 daisy (bellis perennis)
 daisy (leucanthemum vulgare)
+damask violet
+dame's violet
+dancing lady orchid
 dandelion (taraxacum officinale)
 daphne (daphne)
 datura (datura)
 dayflower (commelina)
 daylily (hemerocallis)
 deinanthe (deinanthe caerulea)
+delphinium
 delphinium (delphinium elatum)
 delphinium (delphinium)
+delphinium ajacis
+dendranthema grandifloruom
 dendrobium orchid (dendrobium)
+desert four o'clock
 desert marigold (baileya multiradiata)
 desert rose (adenium obesum)
 devil's claw (proboscidea louisianica)
+devil's flax
 dianthus (dianthus)
+dianthus barbatus
+dianthus caryophyllus
+dianthus chinensis
+dianthus chinensis heddewigii
+dianthus deltoides
+dianthus gratianopolitanus
+dianthus latifolius
+dianthus plumarius
+dianthus superbus
 dictamnus (dictamnus albus)
 digitalis (digitalis purpurea)
+disa
+dog fennel
 double camellia (camellia japonica)
+double gold
 dragon's head (dracocephalum moldavicum)
+dragon's mouth
 dutch iris (iris hollandica)
+dyers' chamomile
+early coral root
+early purple orchid
+early spider orchid
 easter cactus (hatiora gaertneri)
+easter daisy
 easter lily (lilium longiflorum)
 easter lily cactus (echinopsis)
+eastern silvery aster
+eburophyton austinae
 echinacea
 echinacea (echinacea purpurea)
 echium (echium)
@@ -186,109 +505,285 @@ ecuadorian begonia (begonia ecuadoriana)
 ecuadorian orchid (brassavola nodosa)
 edelweiss (leontopodium alpinum)
 egyptian star cluster (pentas lanceolata)
+elegant habenaria
 elephant ears (colocasia esculenta)
 emerald creeper (asarina procumbens)
+encyclia citrina
 encyclia orchid (encyclia)
+encyclia tampensis
+encyclia venosa
 english bluebell (hyacinthoides non-scripta)
+english daisy
+epidendron
+epidendrum tampense
+epidendrum venosum
+epipactis gigantea
+epipactis helleborine
 epiphyllum orchid cactus (epiphyllum)
+episcia dianthiflora
 eremurus (eremurus)
 eryngium (eryngium)
+erysimum allionii
+erysimum arkansanum
+erysimum asperum
+erysimum cheiri
 erythrina (erythrina)
+eschscholtzia californica
 eucalyptus (eucalyptus globulus)
 eucomis (eucomis)
+eupatorium coelestinum
 euphorbia (euphorbia)
+european ladies' tresses
+evening lychnis
 evening primrose (oenothera biennis)
+everlasting
+everlasting flower
+explorer's gentian
+fairy-slipper
 false bird of paradise (heliconia rostrata)
 false indigo (baptisia australis)
 false queen anne's lace (ammi majus)
 false sunflower (heliopsis helianthoides)
+felicia amelloides
+felicia bergeriana
+felwort
+fen orchid
+fen orchis
+fennel flower
+fibrous-rooted begonia
 fiddlehead fern (matteuccia struthiopteris)
+fiddleneck
+field chamomile
+field marigold
+field poppy
+field scabious
+field speedwell
+fig marigold
+filago
+filago germanica
 fire lily
+fire pink
 firebush (hamelia patens)
 firecracker plant (cuphea ignea)
 firecracker plant (russelia equisetiformis)
+five-flowered gentian
 flame lily (gloriosa superba)
+flaming poppy
 flaming sword (vriesea splendens)
 flamingo flower (anthurium andraeanum)
 flamingo flower (anthurium)
+flanders poppy
+flat-topped white aster
 fleabane (erigeron)
 fleur de lis (iris pseudacorus)
+florist's chrysanthemum
+florist's cineraria
+florists' chrysanthemum
+flower
+fly orchid
 flying duck orchid
 forget-me-not (myosotis sylvatica)
 forget-me-not (myosotis)
 forsythia (forsythia)
+four o'clock
 four o'clock (mirabilis jalapa)
 foxglove (digitalis purpurea)
 foxglove beardtongue (penstemon digitalis)
 foxtail lily (eremurus)
+foxtail orchid
+fragrant orchid
 frangipani (plumeria rubra)
 frangipani (plumeria)
 franklin tree flower
 freesia (freesia)
+french marigold
+fringed gentian
+fringed orchid
+fringed orchis
+fringed pink
+frog orchid
 frost flower (helianthemum)
 fuchsia (fuchsia)
+funnel-crest rosebud orchid
+garden heliotrope
+garden pink
+gardener's delight
 gardenia (gardenia jasminoides)
 gaura (gaura lindheimeri)
+gazania
 gazania (gazania rigens)
+gazania rigens
+gentian
 gentian (gentiana)
+gentiana acaulis
+gentiana andrewsii
+gentiana calycosa
+gentiana clausa
+gentiana crinita
+gentiana detonsa
+gentiana holopetala
+gentiana lutea
+gentiana pneumonanthe
+gentiana procera
+gentiana quinquefolia
+gentiana saponaria
+gentiana thermalis
+gentiana villosa
+gentianella
+gentianella amarella
+gentianella quinquefolia
+gentianopsid procera
+gentianopsis crinita
+gentianopsis detonsa
+gentianopsis holopetala
+gentianopsis thermalis
 geranium (pelargonium)
+gerardia
 gerbera daisy (gerbera jamesonii)
+gerbera jamesonii
+germander speedwell
 ghost orchid
 ghost plant (monotropa uniflora)
 giant cactus (epiphyllum oxypetalum)
+giant helleborine
 giant himalayan lily (cardiocrinum giganteum)
+giant sunflower
 gibraltar campion
+gillyflower
+girasol
 gladiolus (gladiolus)
+glaucium flavum
+globe amaranth
 globe amaranth (gomphrena globosa)
 globe thistle (echinops)
 gloriosa (gloriosa superba)
 gloriosa lily (gloriosa superba)
 glory-of-the-snow (chionodoxa luciliae)
 gloxinia (sinningia speciosa)
+gnaphalium sylvaticum
+golden buttons
+golden calla
+golden crown beard
+golden crownbeard
+golden cup
+golden everlasting
+golden glow
+golden honey plant
+golden ironweed
+golden marguerite
 golden penda (xanthostemon chrysanthus)
 golden ray (rhodanthe manglesii)
 golden trumpet (allamanda cathartica)
 goldenrod (solidago virgaurea)
 goldenrod (solidago)
 goldenseal (hydrastis canadensis)
+goldilocks
+goldilocks aster
 gomphrena (gomphrena globosa)
+gomphrena globosa
+granny's bonnets
 grape hyacinth (muscari armeniacum)
+grape-leaf begonia
+grass pink
+gravelweed
+great yellow gentian
+greater butterfly orchid
+greater celandine
+green adder's mouth
+green fringed orchis
 green spider orchid (caladenia caerulea)
+greenhood
+gymnadenia conopsea
+gymnadenia odoratissima
+gypsophila paniculata
+habenaria albiflora
+habenaria bifolia
+habenaria chlorantha
+habenaria dilatata
+habenaria elegans
+habenaria fimbriata
+habenaria greenei
+habenaria hookeri
+habenaria lacera
+habenaria leucophaea
+habenaria nivea
+habenaria orbiculata
+habenaria peramoena
+habenaria psycodes
+habenaria unalascensis
 harebell (campanula rotundifolia)
 harlequin glorybower (clerodendrum trichotomum)
 heart leaf (caladium)
+heart-leaved aster
 heart's-ease (viola tricolor)
+heath aster
 heather (calluna vulgaris)
 hebe (hebe)
+hedge pink
+helianthus
+helianthus angustifolius
+helianthus annuus
+helianthus giganteus
+helianthus laetiflorus
+helianthus maximilianii
+helianthus petiolaris
+helianthus tuberosus
+helichrysum bracteatum
+helichrysum secundiflorum
 heliconia (heliconia)
+heliophila
+helipterum manglesii
 hellebore (helleborus)
+helleborine
+helmet orchid
+helmetflower
 hepatica (hepatica)
+herba impia
+hesperis matronalis
+hexalectris spicata
+hexalectris warnockii
 hibbertia (hibbertia)
 hibiscus (hibiscus rosa-sinensis)
 hibiscus (hibiscus syriacus)
 himalayan blue poppy (meconopsis betonicifolia)
 himalayan blue poppy (meconopsis)
+himantoglossum hircinum
 hollyhock (alcea rosea)
 honeysuckle (lonicera periclymenum)
 honeysuckle (lonicera)
+hooded ladies' tresses
 hooded pitcher plant (sarracenia minor)
 hooker's lips
 hooker's lips (psychotria elata)
+hooker's orchid
+horn poppy
+horned poppy
+horse thistle
 hosta (hosta)
+hot water plant
 hoya (hoya)
+hunnemania fumariifolia
 hyacinth (hyacinthus orientalis)
 hyacinth (hyacinthus)
+hybrid petunia
+hybrid tuberous begonia
 hydrangea (hydrangea macrophylla)
 hydrangea (hydrangea)
 iberis (iberis)
+ice plant
 ice plant (delosperma cooperi)
+iceland poppy
 iceland poppy (papaver nudicaule)
+icicle plant
+immortelle
 impatiens (impatiens walleriana)
 impatiens (impatiens)
 inca lily (alstroemeria aurea)
 indian cress (tropaeolum majus)
+indian crocus
 indian paintbrush (castilleja)
 indian pipe (monotropa uniflora)
+indian potato
 iris (iris germanica)
 iris (iris)
 jacaranda (jacaranda mimosifolia)
@@ -299,93 +794,246 @@ jade vine
 japanese anemone (anemone hupehensis)
 japanese iris (iris ensata)
 japanese lantern (physalis alkekengi)
+japanese pink
 jasmine (jasminum officinale)
 jasmine (jasminum)
+jerusalem artichoke
+jerusalem artichoke sunflower
+jewel orchid
 jewelweed (impatiens capensis)
 joe-pye weed (eupatorium maculatum)
 johnny jump-up (viola tricolor)
+jumping orchid
 kadupul flower
 kaffir lily (clivia miniata)
 kalanchoe (kalanchoe)
 kalmia (kalmia latifolia)
 kangaroo paw (anigozanthos manglesii)
 kangaroo paw (anigozanthos)
+kidney begonia
+king begonia
+kingfisher daisy
 koki'o
+lace-flower vine
+lactuca scariola
+lactuca serriola
+ladies' slipper
+ladies' tresses
 lady slipper orchid (cypripedium)
+lady-slipper
 lady's mantle (alchemilla mollis)
+lady's slipper
 lady's slipper (cypripedium acaule)
 lady's slipper (cypripedium)
 lady's slipper orchid
 lady's slipper orchid (cypripedium)
+lady's tresses
 lamb's ears (stachys byzantina)
 lamprocapnos spectabilis
 lantana (lantana camara)
 lantern flower (abutilon)
+large white petunia
+large yellow lady's slipper
+large-leaved aster
+larkspur
 larkspur (consolida ajacis)
 larkspur (consolida)
+late purple aster
 lavatera (lavatera)
 lavender (lavandula angustifolia)
 lavender (lavandula)
+layia platyglossa
 lemon balm (melissa officinalis)
+lesser butterfly orchid
+lesser celandine
+lesser centaury
+lesser twayblade
+leucanthemum lacustre
+leucanthemum maximum
+leucanthemum superbum
+leucanthemum vulgare
 lilac (syringa vulgaris)
 lily (lilium)
 lily of the incas (alstroemeria)
 lily of the nile (agapanthus africanus)
 lily of the valley (convallaria majalis)
 lily turf (liriope muscari)
+linaria canadensis
+linaria vulgaris
+lindheimera texana
+linosyris vulgaris
+liparis
+liparis loeselii
 lipstick plant (aeschynanthus radicans)
+listera convallarioides
+listera cordata
+listera ovata
+lithophragma affine
+lithophragma affinis
+little golden zinnia
+lizard orchid
 lobelia (lobelia erinus)
 lobelia (lobelia)
+lobularia maritima
+lonas annua
+lonas inodora
+longheaded thimbleweed
+longroot
 lonicera (lonicera)
 lotus (nelumbo nucifera)
+love-in-a-mist
+lychnis
+lychnis alba
+lychnis chalcedonica
+lychnis coronaria
+lychnis dioica
+lychnis flos-cuculi
+lychnis floscuculi
+macleaya cordata
 magnolia (magnolia grandiflora)
 magnolia (magnolia)
+maiden pink
 maidenhair fern (adiantum)
+malaxis ophioglossoides
+malaxis unifolia
+malcolm stock
+malcolmia maritima
+male orchis
+maltese cross
 mandevilla (mandevilla)
 manuka (leptospermum scoparium)
+maple-leaf begonia
+maravilla
 marigold
 marigold (tagetes)
 marigold tree (tithonia rotundifolia)
+marsh gentian
 marsh marigold (caltha palustris)
+marsh orchid
+marvel-of-peru
+matthiola incana
+maximilian's sunflower
+mayweed
 meadow rue (thalictrum aquilegifolium)
+meconopsis betonicifolia
+meconopsis cambrica
+mediterranean snapdragon
+meeting house
+mentzelia laevicaulis
+mentzelia lindleyi
+mentzelia livicaulis
+merry bells
+mesembryanthemum crystallinum
 mexican marigold (tagetes erecta)
 mexican shellflower (tigridia pavonia)
+mexican sunflower
 mexican sunflower (tithonia rotundifolia)
+mexican tulip poppy
+michaelmas daisy
 milkweed (asclepias syriaca)
 mimosa (acacia dealbata)
 mimosa (mimosa pudica)
+mirabilis californica
+mirabilis jalapa
+mirabilis laevis
+mirabilis longiflora
+mirabilis multiflora
+mirabilis oblongifolia
+mirabilis uniflora
+mirasol
+mist-flower
+mistflower
+moccasin flower
+moehringia lateriflora
+moehringia mucosa
 monkey brush vine (combretum rotundifolium)
 monkey orchid
 monkey's tail cactus (hildewintera colademononis)
 monkeyflower (mimulus)
 montbretia (crocosmia)
+moon daisy
 moonflower (ipomoea alba)
 morning glory (ipomoea purpurea)
 morning glory (ipomoea)
+moss campion
 moss rose (portulaca grandiflora)
+moth orchid
+moth plant
+mountain anemone
+mountain daisy
+mountain four o'clock
+mountain lady's slipper
 mountain laurel (kalmia latifolia)
+mountain sandwort
+mountain starwort
+mournful widow
+mullein pink
+mum
 narcissus (narcissus)
+narrow-leaved white-topped aster
 nasturtium (tropaeolum majus)
 nasturtium (tropaeolum)
 nemesia (nemesia)
 nerine (nerine bowdenii)
+nerveroot
+new england aster
 new england aster (symphyotrichum novae-angliae)
+new york aster
 nicotiana (nicotiana)
+nigella
 nigella (nigella damascena)
+nigella damascena
+nigella hispanica
+nigella sativa
 night blooming cereus (hylocereus undatus)
 night-blooming cereus
+nutmeg flower
+nyctaginia capitata
 obedient plant (physostegia virginiana)
+oconee bells
 odontoglossum orchid (odontoglossum)
+old maid
+old maid flower
+old-field toadflax
 oncidium orchid (oncidium)
+oncidium papilio
+oncidium papilio kramerianum
+ophrys apifera
+ophrys insectifera
+ophrys muscifera
+ophrys sphegodes
+orange-blossom orchid
 orchid (orchidaceae)
+orchidaceous plant
+orchis
+orchis mascula
+orchis papilionaceae
+orchis spectabilis
 ornithogalum (ornithogalum)
 osmanthus (osmanthus)
 osteospermum (osteospermum)
+ox-eyed daisy
 oxalis (oxalis)
+oxeye daisy
 oxeye daisy (leucanthemum vulgare)
+ozothamnus secundiflorus
 paeonia (paeonia)
+paeony
+painted daisy
+painted-leaf begonia
+pale coral root
+panicled aster
 pansy (viola tricolor)
+pansy orchid
 papaver (papaver)
+papaver alpinum
+papaver argemone
+papaver californicum
+papaver heterophyllum
+papaver nudicaule
+papaver orientale
+papaver rhoeas
+papaver somniferum
 paperwhite (narcissus papyraceus)
 parrot's beak
 parrot's beak (lotus berthelotii)
@@ -393,33 +1041,94 @@ passion flower (passiflora caerulea)
 passion flower (passiflora)
 passion vine (passiflora incarnata)
 peacock flower (caesalpinia pulcherrima)
+pearly everlasting
+pebble plant
+peony
 peony (paeonia)
 peppermint (mentha × piperita)
+perennial salt marsh aster
+pericallis cruenta
+pericallis hybrida
 persian buttercup (ranunculus asiaticus)
 persian shield (strobilanthes dyerianus)
+petunia
 petunia (petunia hybrida)
 petunia (petunia)
+petunia axillaris
+petunia hybrida
+petunia integrifolia
+phacelia
+phacelia campanularia
+phacelia minor
+phacelia tanacetifolia
+phacelia whitlavia
+phaius
 phalaenopsis (phalaenopsis)
+phalaenopsis amabilis
+phantom orchid
+pheasant's-eye
 phlox (phlox paniculata)
+pilewort
+pincushion flower
 pincushion flower (scabiosa)
+pine-barren sandwort
 pineapple lily (eucomis comosa)
 pineapple sage (salvia elegans)
+pink
 pink (dianthus)
+pink calla
+pink paper daisy
+pink-and-white everlasting
 pitcher plant (sarracenia)
+platanthera bifolia
+platanthera chlorantha
+platanthera leucophea
+platystemon californicus
+pleurothallis
+plume poppy
 plumeria (plumeria rubra)
+pogonia
+pogonia divaricata
+pogonia rosea
 poison ivy (toxicodendron radicans)
 poison sumac (toxicodendron vernix)
+polianthes tuberosa
 polygala (polygala)
+poor man's orchid
+poppy
 poppy (papaver)
 portulaca (portulaca grandiflora)
+portulaca grandiflora
+pot marigold
 pothos (epipremnum aureum)
+prairie aster
 prairie coneflower (ratibida columnifera)
+prairie orchid
+prairie rocket
+prairie sunflower
+prairie white-fringed orchid
+prairie white-fringed orchis
+prickly lettuce
+prickly poppy
 pride of madeira (echium candicans)
 primrose (primula vulgaris)
 primrose (primula)
 protea (protea cynaroides)
+psychopsis krameriana
+psychopsis papilio
 purple coneflower (echinacea purpurea)
+purple fringeless orchid
+purple fringeless orchis
 purple loosestrife (lythrum salicaria)
+purple orchis
+purple-fringed orchid
+purple-fringed orchis
+purple-hooded orchis
+purple-stemmed aster
+purslane speedwell
+puttyroot
+pyrenees daisy
+pyrethrum
 pyrethrum (pyrethrum)
 queen anne's lace (daucus carota)
 queen of the night
@@ -428,125 +1137,393 @@ queen of the night (selenicereus grandiflorus)
 quillwort (isoetes)
 rafflesia
 rafflesia (rafflesia arnoldii)
+ragged orchid
+ragged orchis
+ragged robin
+ragged-fringed orchid
+rainbow pink
+ram's-head
+ram's-head lady's slipper
 ranunculus (ranunculus asiaticus)
+ranunculus ficaria
+rattlesnake orchid
+rattlesnake plantain
+red bird's eye
+red campion
+red helleborine
 red hot poker (kniphofia uvaria)
 red hot poker (kniphofia)
+red valerian
 red valerian (centranthus ruber)
 redbud (cercis canadensis)
+rein orchid
+rein orchis
 resurrection lily (kaempferia)
+rex begonia
+rhizomatous begonia
+rhodanthe
+rhodanthe manglesii
 rhododendron (rhododendron)
 rock cress (arabis caucasica)
 rock rose (cistus ladanifer)
+rock sandwort
 rock soapwort (saponaria ocymoides)
+rocket larkspur
+roman coriander
 rosa rugosa (rosa rugosa)
 rose (rosa)
+rose campion
+rose moss
 rose of sharon (hibiscus syriacus)
+rosebud orchid
+rosinweed
 rosinweed (silphium)
+rosita
+rough-leaved aster
+round-leaved rein orchid
 rudbeckia
 rudbeckia (rudbeckia hirta)
 rudbeckia (rudbeckia)
+rudbeckia laciniata
+rudbeckia laciniata hortensia
+rudbeckia serotina
+ruddles
+rue anemone
+rush aster
 russian sage (perovskia atriplicifolia)
 sage (salvia officinalis)
+saintpaulia ionantha
 salvia (salvia nemorosa)
 salvia (salvia)
+sandwort
 sanguinaria (sanguinaria canadensis)
 sanguinaria canadensis
+saponaria officinalis
+saponaria vaccaria
+sarcochilus falcatus
+satyr orchid
 saxifrage (saxifraga)
+scabiosa
 scabiosa (scabiosa caucasica)
+scabiosa arvensis
+scabiosa atropurpurea
+scabious
+scarlet lychnis
+scarlet musk flower
 scarlet pimpernel (anagallis arvensis)
 scarlet sage (salvia splendens)
+scented fern
+schizanthus
+schizopetalon
+schizopetalon walkeri
+schreiber's aster
 scilla (scilla)
+scorpion weed
+scorpionweed
 scotch heather (calluna vulgaris)
+scotch marigold
+screw augur
+sea aster
 sea holly (eryngium planum)
 sea holly (eryngium)
 sea lavender (limonium latifolium)
 sea poison tree flower
+sea poppy
+sea starwort
+seabeach sandwort
+seaside centaury
+senecio cruentus
+shasta daisy
 shasta daisy (leucanthemum × superbum)
 shasta daisy (leucanthemum x superbum)
 shooting star (dodecatheon)
+short-spurred fragrant orchid
+short's aster
+shortia
+shortia galacifolia
+showy lady slipper
+showy lady's-slipper
+showy orchis
+showy sunflower
 shrimp plant (justicia brandegeeana)
+shun giku
+siberian wall flower
+silene
 silene (silene)
+silene acaulis
+silene caroliniana
+silene dioica
+silene latifolia
+silene uniflora
+silene virginica
+silene vulgaris
+silphium laciniatum
 silver thistle (carlina acaulis)
+silver-lace
 sky blue aster (symphyotrichum oolentangiense)
+slender centaury
+slipper orchid
+slipperwort
+small white aster
+smooth aster
 snake's head fritillary
 snake's head fritillary (fritillaria meleagris)
+snapdragon
 snapdragon (antirrhinum majus)
 snapdragon (antirrhinum)
 snapdragon vine (maurandya barclayana)
+snow orchid
+snowdrop
 snowdrop (galanthus nivalis)
 snowdrop (galanthus)
+snowdrop anemone
+snowdrop windflower
+snowy orchid
+soapwort
 soapwort (saponaria)
+soapwort gentian
+sobralia
+socotra begonia
 solomon's seal (polygonatum biflorum)
 solomon's seal (polygonatum)
+southern aster
+sowbread
+sparaxis tricolor
+spathe flower
+speedwell
 spider flower (cleome hassleriana)
 spider lily (hymenocallis)
+spider orchid
 spiderwort (tradescantia virginiana)
 spiderwort (tradescantia)
 spike speedwell (veronica spicata)
+spiranthes cernua
+spiranthes porrifolia
+spiranthes romanzoffiana
+spiranthes spiralis
+spotted coral root
 spotted orchid (dactylorhiza maculata)
+spreading pogonia
+spring beauty
 spring beauty (claytonia virginica)
+spurred gentian
+stanhopea
+star begonia
 star jasmine (trachelospermum jasminoides)
 star of bethlehem (ornithogalum umbellatum)
+star of the veldt
+star-leaf begonia
 starflower (trientalis borealis)
+starved aster
 statice (limonium sinuatum)
 statice (limonium)
+stelis
+stemless daisy
 sticky monkey flower (mimulus aurantiacus)
+stiff aster
+stiff gentian
+stinking chamomile
+stinking mayweed
+stock
+stokes' aster
 stokesia (stokesia laevis)
+stokesia laevis
 stonecrop (sedum spectabile)
+strawflower
 strawflower (xerochrysum bracteatum)
+stream orchid
+striped coral root
+striped gentian
+stylomecon heterophyllum
+stylophorum diphyllum
+sun marigold
+sun plant
 sunflower
 sunflower (helianthus annuus)
 swaddled babies orchid
+swallow wort
+swallowwort
+swamp sunflower
+swan orchid
+swan river daisy
+swan river everlasting
+swan-flower
+swan-neck
+swanflower
+swanneck
+sweet alison
+sweet alyssum
 sweet alyssum (lobularia maritima)
+sweet four o'clock
 sweet pea (lathyrus odoratus)
 sweet pea bush (polygala myrtifolia)
+sweet rocket
+sweet scabious
+sweet sultan
+sweet william
 sweet william (dianthus barbatus)
 sword lily (gladiolus)
+tagetes erecta
+tagetes patula
+tall sunflower
+tanacetum coccineum
+tanacetum ptarmiciflorum
+tanacetum vulgare
+tangle orchid
+tansy
 tansy (tanacetum vulgare)
+tellima affinis
+texas purple spike
+texas star
 thalictrum (thalictrum)
+thimbleweed
 thistle (cirsium)
+thyme-leaved sandwort
+thyme-leaved speedwell
+tidy tips
+tidytips
 tiger lily (lilium lancifolium)
+tithonia
 toad lily (tricyrtis hirta)
+toadflax
+tong ho
+tongue-flower
+tongueflower
 torch ginger (etlingera elatior)
+townsendia exscapa
+tradescant's aster
+transvaal daisy
+treasure flower
 trillium (trillium)
 trumpet creeper (campsis radicans)
 trumpet vine (campsis radicans)
+tuberose
 tuberose (polianthes tuberosa)
+tuberous begonia
+tufted centaury
+tufted gentian
 tulip (tulipa)
+tulip orchid
 tulip tree (liriodendron tulipifera)
 turk's cap lily (lilium martagon)
 turtlehead (chelone glabra)
+twayblade
 twinflower (linnaea borealis)
+umbrellawort
+upland white aster
 upright lobelia (lobelia erinus)
+ursinia
+uvularia grandiflora
+vaccaria hispanica
+vaccaria pyramidata
+valerian
+valeriana officinalis
+vanda
+vanda caerulea
+vanilla
+vanilla orchid
+vanilla planifolia
 velvet leaf (abutilon theophrasti)
 venus flytrap (dionaea muscipula)
+venus' slipper
+venus's shoe
+venus's slipper
 verbascum (verbascum)
+verbena
 verbena (verbena bonariensis)
 verbena (verbena)
+verbesina alternifolia
+verbesina encelioides
+verbesina helianthoides
+verbesina virginica
+veronica
 veronica (veronica spicata)
+veronica agrestis
+veronica arvensis
+veronica chamaedrys
+veronica officinalis
+veronica peregrina
+veronica serpyllifolia
+vervain
 viola (viola odorata)
+violet-flowered petunia
 virginia bluebell (mertensia virginica)
 virginia creeper (parthenocissus quinquefolia)
+virginia crownbeard
+virginia spring beauty
+virginia stock
+virginia thimbleweed
+virginian stock
+wallflower
 wallflower (erysimum cheiri)
+wandflower
 water lily (nymphaea)
+wavy-leaved aster
+wax begonia
 wax flower (hoya carnosa)
 weigela (weigela florida)
+welsh poppy
+western ladies' tresses
+western poppy
+western silvery aster
+western wall flower
 whirling butterflies (gaura lindheimeri)
+white campion
+white cockle
+white daisy
+white fringed orchid
+white fringed orchis
+white prairie aster
+white snapdragon
+white wood aster
+white zinnia
+white-topped aster
+whitlavia
+whorled aster
 wild ginger (asarum canadense)
+wild oats
+wild pink
 wild rose (rosa acicularis)
+wild snapdragon
+willow aster
+wind poppy
+windflower
 windflower (anemone blanda)
+winged everlasting
+wingstem
 witch hazel (hamamelis virginiana)
+wood anemone
 wood anemone (anemone nemorosa)
+wood aster
+wood cudweed
+wood poppy
 woodland phlox (phlox divaricata)
+woodland star
+xeranthemum
+xeranthemum annuum
+ximenesia encelioides
 yarrow (achillea millefolium)
+yellow ageratum
 yellow archangel (lamiastrum galeobdolon)
 yellow bell (tecoma stans)
+yellow chamomile
 yellow flag iris (iris pseudacorus)
+yellow horned poppy
 yellow iris (iris pseudacorus)
+yellow ironweed
+yellow lady-slipper
+yellow lady's slipper
+yellow paper daisy
 yellow poppy (eschscholzia californica)
 yellow trillium (trillium luteum)
+yellow twining snapdragon
 yucca (yucca filamentosa)
 zantedeschia (zantedeschia aethiopica)
+zantedeschia aethiopica
+zantedeschia rehmanii
+zebra orchid
 zephyr lily (zephyranthes candida)
 zinnia
 zinnia (zinnia elegans)
+zinnia acerosa
+zinnia grandiflora

--- a/lists/nature/fungus.yml
+++ b/lists/nature/fungus.yml
@@ -2,124 +2,405 @@
 title: Fungus and mushrooms
 category: nature
 description: "Assorted species of wild mushrooms and fungi"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+acellular slime mold
 acetabula cup fungus
+agaric
+agaricus arvensis
+agaricus campestris
+albatrellus dispansus
+albatrellus ovinus
+aleuria aurantia
+amanita caesarea
+amanita mappa
+amanita muscaria
+amanita phalloides
+amanita rubescens
+amanita verna
 american dapperling mushroom
+american parasol
 amethyst deceiver mushroom
 angel's wings mushroom
+apple rust
+armillaria caligata
+armillaria ponderosa
+armillaria zelleri
+armillariella mellea
 artist's bracket fungus
+ascomycete
+ascomycetous fungus
+aspergillus fumigatus
+astreus hygrometricus
+astreus pteridis
+auricularia auricula
+baker's yeast
+basidiomycete
+basidiomycetous fungi
 bay bolete mushroom
 beefsteak fungus
+beefsteak morel
+bell morel
 bicolored deceiver mushroom
 birch bolete mushroom
 birch polypore fungus
+bird's-nest fungus
 bitter bolete mushroom
 bitter oyster mushroom
+black felt cup
+black morel
+black root rot fungus
 black tooth fungus
 black trumpet mushroom
 blackening chanterelle mushroom
+blastomycete
 bleeding fairy helmet mushroom
 bleeding tooth fungus
+blewits
+blister rust
+blood cup
+blue mold fungus
 blue oyster mushroom
 blue tooth fungus
+blusher
 blusher mushroom
+blushing mushroom
+boil smut
+bolete
+boletellus russellii
+boletus chrysenteron
+boletus edulis
+boletus frostii
+boletus luridus
+boletus mirabilis
+boletus pallidus
+boletus pulcherrimus
+boletus pulverulentus
+boletus roxanae
+boletus subvelutipes
+boletus variipes
+boletus zelleri
+booted armillaria
+bottom rot fungus
+bracket fungus
 brain mushroom
+bread mold
+brewer's yeast
 brick cap mushroom
+brown cup
 brown roll-rim mushroom
+brown root rot fungus
+bunt
 butter cap mushroom
 button mushroom
+caesar's agaric
 caesar's mushroom
+california false morel
+caloscypha fulgens
+calostoma cinnabarina
+calostoma lutescens
+calostoma ravenelii
+calvatia gigantea
+candida
+candida albicans
+cantharellus cibarius
+cantharellus cinnabarinus
+cantharellus clavatus
+cantharellus floccosus
+carrion fungus
 caterpillar fungus
 cauliflower coral fungus
 cauliflower fungus
+cedar-apple rust
+cellular slime mold
+ceratostomella ulmi
+cercospora kopkei
 chaga mushroom
+chantarelle
+chanterelle
 chanterelle mushroom
 charbonnier mushroom
 charcoal burner mushroom
+charred pancake cup
 chestnut bolete mushroom
 chicken of the woods mushroom
+chinese black mushroom
+chinese mushroom
+chlorophyllum molybdites
 cinnabar bracket fungus
+cinnabar chanterelle
+claviceps purpurea
+clavicipitaceae
+clitocybe clavipes
+clitocybe dealbata
+clitocybe inornata
+clitocybe irina
+clitocybe nuda
+clitocybe robusta
+clitocybe subconnexa
 cloud ear fungus
+club fungus
+clubroot fungus
+clytocybe alba
+coffee fungus
 collared earthstar fungus
 collared parachute mushroom
 common bonnet mushroom
 common earthball fungus
 common funnel mushroom
 common ink cap mushroom
+common morel
 common puffball
+common stinkhorn
 common stump brittlestem mushroom
+conic morel
+conic verpa
+conic waxycap
 conifer tuft mushroom
+coprinus atramentarius
+coprinus comatus
+coral fungus
 coral tooth fungus
+corn smut
+cornsmut
+corticium salmonicolor
+corticium solani
+cortinarius armillatus
+cortinarius atkinsonianus
+cortinarius corrugatus
+cortinarius gentilis
+cortinarius mutabilis
+cortinarius semisanguineus
+cortinarius subfoetidus
+cortinarius violaceus
+covered smut
+cow's head
 crimson waxcap mushroom
+cronartium ribicola
+cup fungus
+cup morel
+damping off fungus
 dark cep mushroom
 dark-scaled knight mushroom
 dead man's fingers
+dead-men's-fingers
 deadly webcap mushroom
+death angel
+death cap
 death cap mushroom
+death cup
 deceiver mushroom
 deceiving knight mushroom
 deer mushroom
+destroying angel
 destroying angel mushroom
 devil's cigar
 devil's fingers
+devil's urn
+dictostylium
+dictyostelium
+discina
+discina macrospora
+disciotis venosa
+discomycete
 dog stinkhorn
+downy mildew
+dry rot
 dryad's saddle mushroom
+dutch elm fungus
 dyeball fungus
 dyer's polypore fungus
+ear fungus
+early morel
 early morel mushroom
 earpick fungus
 earth star fungus
+earth-ball
+earth-tongue
+earthball
 earthfan fungus
+earthstar
+earthtongue
 enoki mushroom
+entoloma aprile
+entoloma lividum
+entoloma sinuatum
+ergot
 fairy ring mushroom
+false deathcap
+false mildew
+false morel
 false morel mushroom
 false parasol mushroom
+false truffle
+felt fungus
 field mushroom
+fischer's slime mushroom
+fistulina hepatica
+flag smut fungus
+flammulina velutipes
+flax rust
+flax rust fungus
+floccose chanterelle
+fly agaric
 fly agaric mushroom
+fomes igniarius
 fool's webcap mushroom
+frost's bolete
+fungus
 funnel chanterelle mushroom
+fuscoboletinus paluster
+fuscoboletinus serotinus
+galiella rufa
 garlic parachute mushroom
+gasteromycete
+gastroboletus scabrosus
+gastroboletus turbinatus
+gastrocybe lateritia
+gastromycete
+geastrum coronatum
+geglossaceae
+genus sphacelotheca
 giant polypore fungus
 giant puffball
 gilded brittlegill mushroom
+gill fungus
 glistening inkcap mushroom
 golden jelly fungus
+golden oak mushroom
 golden oyster mushroom
+golden pholiota
 golden scalycap mushroom
+grainy club
+grainy club mushrooms
 granulated bolete mushroom
 green elfcup
+green mushroom pimple
+green smut fungus
 green-cracking russula mushroom
+grifola frondosa
+gymnopilus spectabilis
+gymnopilus validipes
+gymnopilus ventricosus
+gymnosporangium juniperi-virginianae
+gyromitra
+gyromitra brunnea
+gyromitra californica
+gyromitra esculenta
+gyromitra fastigiata
+gyromitra gigas
+gyromitra infula
+gyromitra sphaerospora
 hairy bracket fungus
 hairy curtain crust fungus
+half-free morel
+hard-skinned puffball
 hare's ear fungus
+head smut
 heath navel mushroom
+helvella
+helvella acetabulum
+helvella crispa
+helvella sulcata
 hen of the woods mushroom
+hen-of-the-woods
 honey fungus
+honey mushroom
 hooded false morel mushroom
 horse mushroom
+hygrocybe acutoconica
+hygrophorus borealis
+hygrophorus caeruleus
+hygrophorus inocybiformis
+hygrophorus kauffmanii
+hygrophorus marzuolus
+hygrophorus purpurascens
+hygrophorus russula
+hygrophorus sordidus
+hygrophorus tennesseensis
+hygrophorus turundus
+hygrotrama foetens
 indigo milk cap mushroom
+inky cap
+inky-cap mushroom
 ivory funnel mushroom
+jack-a-lantern
+jack-o-lantern
+jack-o-lantern fungus
 jack-o'-lantern mushroom
+jafnea semitosta
 jelly antler fungus
 jelly babies fungus
 jelly ear fungus
+jelly fungus
 jersey cow bolete mushroom
 king oyster mushroom
+lactarius deliciosus
 larch bolete mushroom
+leccinum fibrillosum
+lentinus edodes
+lentinus lepideus
+leotia lubrica
+lepiota
+lepiota americana
+lepiota cepaestipes
+lepiota clypeolaria
+lepiota morgani
+lepiota naucina
+lepiota procera
+lepiota rhacodes
+lepiota rubrotincta
+lepista irina
 liberty cap mushroom
 lilac bonnet mushroom
 lion shield mushroom
 lion's mane mushroom
 livid pinkgill mushroom
 lobster mushroom
+loose smut
+lorchel
 lurid bolete mushroom
+macowanites americanus
 magpie inkcap mushroom
+man-on-a-horse
+marasmius oreades
 marsh pax mushroom
 matsutake mushroom
+meadow mushroom
 meadow puffball
+melampsora lini
+mildew
+milkcap
+miter mushroom
+mitrula elegans
+mold
+monilia
+monilia albicans
+morchella angusticeps
+morchella conica
+morchella crassipes
+morchella esculenta
+morchella semilibera
+morel
 morel mushroom
+mould
+mucor
 multicolor gill polypore fungus
+mushroom
+mushroom pimple
+mutinus caninus
+myxomycete
+nameko
+narrowhead morel
+neohygrophorus angelesianus
+neolentinus ponderosus
 netted rhodotus mushroom
+nigroporus vinosus
 oak bolete mushroom
 oak bracket fungus
 oakbug milkcap mushroom
@@ -127,7 +408,17 @@ ochre bracket fungus
 ochre brittlegill mushroom
 octopus stinkhorn
 old man of the woods mushroom
+old-man-of-the-woods
+oligoporus leucospongia
+olive-tree agaric
+omphalotus illudens
+onion mildew
+onion smut
+onion stem
+orange mushroom pimple
 orange peel fungus
+oyster agaric
+oyster fungus
 oyster mushroom
 paddy straw mushroom
 pale brittlestem mushroom
@@ -135,75 +426,238 @@ panther cap mushroom
 parasol mushroom
 parrot waxcap mushroom
 pear-shaped puffball
+pellicularia filamentosa
+pellicularia koleroga
 peppery bolete mushroom
+peronospora destructor
+peronospora hyoscyami
+peronospora tabacina
+peziza coccinea
+peziza domicilina
+phallus impudicus
+phallus ravenelii
+pholiota astragalina
+pholiota aurea
+pholiota destruens
+pholiota flammans
+pholiota flavida
+pholiota nameko
+pholiota squarrosa
+pholiota squarrosa-adiposa
+pholiota squarrosoides
+phylloporus boletinoides
+phytophthora citrophthora
+phytophthora infestans
+pig's ears
+pink disease fungus
 pink oyster mushroom
 plantpot dapperling mushroom
+plasmodial slime mold
+plasmodiophora brassicae
+pleurotus ostreatus
+pleurotus phosphoreus
+pluteus aurantiorugosus
+pluteus cervinus
+pluteus magnus
+podaxaceae
 poison pie mushroom
+poisonous parasol
+polypore
+polyporus frondosus
+polyporus squamosus
+polyporus tenuiculus
+pond-scum parasite
 poplar oysterling mushroom
 porcelain fungus
 porcini mushroom
+pore fungus
+pore mushroom
+potato fungus
+potato wart fungus
+powdery mildew
+pseudocolus fusiformis
+psilocybin mushroom
+psychedlic mushroom
+puccinia graminis
+puffball
+purple-staining cortinarius
 purplepore bracket fungus
+pythium
+pythium debaryanum
+radiigera fuscogleba
 red cage fungus
 red-belted polypore fungus
 red-capped scaber stalk mushroom
 red-cracked bolete mushroom
 reishi mushroom
+rhizoctinia
+rhizoctinia solani
+rhizopogon idahoensis
+rhizopus
+rhizopus nigricans
 rooting shank mushroom
+round-spored gyromitra
+royal agaric
 ruby bonnet mushroom
+rufous rubber cup
+rust fungus
+rye ergot
+sac fungus
+saccharomyces cerevisiae
+saccharomyces ellipsoides
+sacred mushroom
+saddled-shaped false morel
 saffron milk cap mushroom
+sandy mushroom
+saprolegnia ferax
+sarcoscypha coccinea
+sarcosomataceae
+sawdust mushroom
 scaly earthball fungus
+scaly lentinus
+scaly pholiota
+scaly polypore
 scaly tooth fungus
+scarlet cup
 scarlet elf cup fungus
 scarlet waxcap mushroom
+scleroderma aurantium
+scleroderma bovista
+scleroderma citrinum
+scleroderma flavidium
+sclerotinia
 scurfy deceiver mushroom
 scurfy twiglet mushroom
+septobasidium pseudopedicellatum
+shaggy cap
 shaggy ink cap mushroom
 shaggy parasol mushroom
 shaggy scalycap mushroom
+shaggymane
+shaggymane mushroom
 sheathed woodtuft mushroom
+sheep polypore
+shelf fungus
+shiitake
 shiitake mushroom
 shingled hedgehog mushroom
+shoestring fungus
+shroom
 slender parasol mushroom
+slime mold
+slime mould
+slime mushroom
 slimy spike mushroom
 slippery jack mushroom
 small stagshorn fungus
+smooth earthball
+smut
+smut fungus
 snow fungus
+snow mushroom
 soapy knight mushroom
+soldier grainy club
 spectacular rustgill mushroom
+sphacelotheca
+sphacelotheca reiliana
 spiny puffball
 split gill mushroom
+sponge morel
+sponge mushroom
 spotted toughshank mushroom
 st. george's mushroom
+stalked puffball
+star earthball
+stinkhorn
 stinkhorn mushroom
+stinking smut
+stinky squid
+straw mushroom
+strobilomyces floccopus
+stropharia ambigua
+stropharia hornemannii
+stropharia rugoso-annulata
+suillus albivelatus
 sulfur tuft mushroom
 summer bolete mushroom
 surprise webcap mushroom
+synchytrium endobioticum
 tawny grisette mushroom
-the gypsy mushroom
 the miller mushroom
 the prince mushroom
 the sickener mushroom
+thick-footed morel
+thielavia basicola
 tiger sawgill mushroom
+tilletia caries
+tilletia foetida
 tinder fungus
+toadstool
+tobacco mildew
+tooth fungus
 toothed jelly fungus
+tremella foliacea
+tremella fuciformis
+tremella lutescens
+tremella reticulata
+tricholoma aurantium
+tricholoma flavovirens
+tricholoma irinum
+tricholoma pardinum
+tricholoma pessundatum
+tricholoma populinum
+tricholoma sejunctum
+tricholoma vaccinum
+tricholoma venenata
+true fungus
+true puffball
+true slime mold
+truffle
+truncocolumella citrina
 turkey tail fungus
 umbrella polypore fungus
 upright coral fungus
+urn fungus
+urnula craterium
+urocystis cepulae
+urocystis tritici
+ustilaginoidea virens
+ustilago maydis
 veiled lady mushroom
 veiled oyster mushroom
 velvet shank mushroom
 verdigris agaric mushroom
+verpa
+verpa bohemica
+verpa conica
+verticillium
 violet webcap mushroom
+viscid mushroom
+volvaria bombycina
+volvariella bombycina
+volvariella volvacea
+water mold
+waxycap
+wheat flag smut
+wheat rust
 white dapperling mushroom
 white fibercap mushroom
+white fungus
 white hedgehog mushroom
+white matsutake
+white rust
 white saddle mushroom
+white slime mushroom
 whitelaced shank mushroom
 willow shield mushroom
 wine cap stropharia mushroom
+wine-maker's yeast
+winter mushroom
 winter polypore fungus
+winter urn
 witch's butter fungus
 witch's hat mushroom
+witches' butter
 witches' butter fungus
 wolf's milk slime mold
 wood blewit mushroom
@@ -211,7 +665,13 @@ wood ear fungus
 wood hedgehog mushroom
 wood mushroom
 woolly milk cap mushroom
+wynnea americana
+wynnea sparassoides
+xylaria mali
+xylaria polymorpha
+yeast
 yellow false truffle
+yellow spot fungus
 yellow stagshorn fungus
 yellow-cracked bolete mushroom
 yellow-staining mushroom

--- a/lists/nature/grass.yml
+++ b/lists/nature/grass.yml
@@ -1,0 +1,474 @@
+---
+title: Grasses
+category: nature
+description: "Grasses and closely related narrow-leaved plants"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+aegilops triuncalis
+african love grass
+african millet
+agropyron cristatum
+agropyron intermedium
+agropyron pauciflorum
+agropyron repens
+agropyron smithii
+agropyron subsecundum
+agropyron trachycaulum
+agrostis alba
+agrostis canina
+agrostis nebulosa
+agrostis palustris
+aleppo grass
+alopecurus pratensis
+andropogon furcatus
+andropogon gerardii
+andropogon scoparius
+andropogon virginicus
+animated oat
+arrhenatherum elatius
+arundo richardii
+australian reed grass
+avena barbata
+avena fatua
+avena sativa
+avena sterilis
+avene sterilis
+awnless bromegrass
+bahama grass
+bahia grass
+barley
+barley grass
+barn grass
+barn millet
+barnyard grass
+bay grass
+beach grass
+bearded darnel
+bearded wheatgrass
+bent
+bent grass
+bermuda grass
+billion-dollar grass
+birdseed grass
+black grama
+blackseed
+blue grama
+blue grass
+blue stem
+bluegrass
+bluestem
+bluestem wheatgrass
+bottle-grass
+bouteloua eriopoda
+bouteloua gracilis
+bristle grass
+bristlegrass
+brome
+bromegrass
+bromus arvensis
+bromus inermis
+bromus japonicus
+bromus secalinus
+bromus tectorum
+broom beard grass
+broom grass
+broom sedge
+broomcorn
+broomcorn millet
+brown bent
+buchloe dactyloides
+buffalo grass
+buffel grass
+bulrush millet
+bunch grass
+bunchgrass
+bur grass
+burgrass
+calamagrostic quadriseta
+calamagrostis acutiflora
+canada wild rye
+canary grass
+carpet grass
+cattail millet
+cenchrus ciliaris
+cenchrus tribuloides
+cereal
+cereal grass
+cereal oat
+cheat
+cheatgrass
+chess
+chloris gayana
+chloris truncata
+cloud grass
+cocksfoot
+common barley
+common wheat
+coracan
+corakan
+cord grass
+cordgrass
+corn
+cortaderia richardii
+cortaderia selloana
+couch grass
+crab grass
+crabgrass
+creeping bent
+creeping bentgrass
+creeping soft grass
+creeping windmill grass
+crested wheat grass
+crested wheatgrass
+crowfoot grass
+cultivated rice
+cynodon dactylon
+cynodon plectostachyum
+dactylis glomerata
+dactyloctenium aegypticum
+dallis grass
+dallisgrass
+darnel
+dent corn
+devil grass
+digitaria ischaemum
+digitaria sanguinalis
+dog bent
+dog grass
+doob
+doura
+dourah
+downy brome
+downy bromegrass
+downy cheat
+downy chess
+drooping brome
+drop-seed
+dropseed
+durra
+durum
+durum wheat
+echinochloa crusgalli
+echinochloa frumentacea
+egyptian corn
+egyptian grass
+eleusine coracana
+eleusine indica
+elymus arenarius
+elymus canadensis
+elymus caput-medusae
+elymus condensatus
+elymus hispidus
+elymus trachycaulos
+emmer
+english ryegrass
+eragrostic abyssinica
+eragrostis curvula
+eragrostis tef
+erianthus ravennae
+european dune grass
+evergreen grass
+evergreen millet
+fairway crested wheat grass
+false oat
+feather reed grass
+feathertop
+feathertop grass
+federita
+fescue
+fescue grass
+festuca elatior
+festuca ovina
+feterita
+field brome
+field corn
+field sandbur
+finger grass
+finger millet
+flint corn
+flint maize
+flour corn
+fountain grass
+foxtail
+foxtail barley
+foxtail grass
+foxtail millet
+french rye
+freshwater cordgrass
+gardener's garters
+german millet
+giant foxtail
+giant ryegrass
+giant star grass
+glaucous bristlegrass
+glyceria grandis
+goat grass
+golden wonder millet
+grain
+grain sorghum
+grama
+grama grass
+gramma
+gramma grass
+great millet
+green bristlegrass
+green corn
+green foxtail
+guinea corn
+hairy finger grass
+hard wheat
+harding grass
+hardinggrass
+hegari
+herd's grass
+hog millet
+holcus lanatus
+holcus mollis
+hordeum jubatum
+hordeum murinum
+hordeum pusillum
+hordeum vulgare
+hungarian grass
+indian corn
+indian millet
+intermediate wheatgrass
+italian millet
+italian rye
+italian ryegrass
+japanese barnyard millet
+japanese brome
+japanese carpet grass
+japanese chess
+japanese lawn grass
+japanese millet
+johnson grass
+june grass
+kaffir
+kaffir corn
+kafir corn
+kaoliang
+kentucky blue
+kentucky bluegrass
+kentucy blue grass
+knotgrass
+korean lawn grass
+korean velvet grass
+kurakkan
+kweek
+lady's laces
+large crabgrass
+lemon grass
+lemongrass
+leymus arenaria
+leymus condensatus
+little barley
+lolium multiflorum
+lolium perenne
+lolium temulentum
+love grass
+lyme grass
+macaroni wheat
+maize
+manila grass
+manna grass
+mascarene grass
+meadow fescue
+meadow foxtail
+meadow grass
+meadowgrass
+means grass
+midgrass
+millet
+milo
+milo maize
+mountain rice
+muhlenbergia schreberi
+munj
+munja
+nimble will
+nimblewill
+oat
+old witch grass
+old witchgrass
+orchard grass
+oryza sativa
+oryzopsis hymenoides
+oryzopsis miliacea
+pampas grass
+panic grass
+panicum capillare
+panicum miliaceum
+panicum texanum
+panicum virgatum
+paspalum
+paspalum dilatatum
+paspalum distichum
+paspalum notatum
+pearl millet
+pennisetum americanum
+pennisetum cenchroides
+pennisetum glaucum
+pennisetum ruppelii
+pennisetum setaceum
+pennistum villosum
+perennial ryegrass
+phalaris aquatica
+phalaris arundinacea
+phalaris canariensis
+phalaris tuberosa
+phleum pratense
+plume grass
+plumed tussock
+poa nemoralis
+poa pratensis
+popcorn
+prairie cordgrass
+prairie grass
+quack grass
+quackgrass
+quick grass
+ragee
+ragi
+ravenna grass
+reed canary grass
+reed grass
+reed meadow grass
+rhode island bent
+rhodes grass
+ribbon grass
+rice
+rice grass
+ricegrass
+rough bristlegrass
+rush grass
+rye
+rye grass
+ryegrass
+saccharum bengalense
+saccharum munja
+salt reed grass
+sand dropseed
+sandbur
+sandspur
+sanwa millet
+schizachyrium scoparium
+scutch grass
+sea lyme grass
+secale cereale
+setaria glauca
+setaria italica
+setaria italica rubrofructa
+setaria italica stramineofructa
+setaria viridis
+shallu
+sheep fescue
+sheep's fescue
+short-grass
+shortgrass
+siberian millet
+silk grass
+silkgrass
+silver grass
+slender wheatgrass
+slender wild oat
+slough grass
+smilo
+smilo grass
+smooth crabgrass
+smut grass
+soft corn
+soft wheat
+sorgho
+sorghum
+sorghum bicolor
+sorghum halepense
+sorghum vulgare caudatum
+sorghum vulgare roxburghii
+sorghum vulgare technicum
+sorgo
+spartina cynosuroides
+spartina pectinata
+spelt
+sporobolus cryptandrus
+sporobolus poiretii
+squirreltail barley
+squirreltail grass
+st. augustine grass
+star grass
+starch wheat
+stenotaphrum secundatum
+sugar corn
+sugar sorghum
+sweet corn
+sweet corn plant
+sweet grass
+sweet sorghum
+switch grass
+sword grass
+tall meadow grass
+tall oat grass
+tall-grass
+tallgrass
+tare
+teff
+teff grass
+texas millet
+timothy
+toe toe
+toetoe
+toowomba canary grass
+triticum aestivum
+triticum aestivum spelta
+triticum dicoccum
+triticum dicoccum dicoccoides
+triticum durum
+triticum spelta
+triticum turgidum
+tumble grass
+two-grain spelt
+velvet bent
+velvet bent grass
+velvet grass
+wall barley
+weeping love grass
+western wheatgrass
+wheat
+wheat-grass
+wheatgrass
+wild emmer
+wild oat
+wild oat grass
+wild red oat
+wild rice
+wild rye
+wild wheat
+windmill grass
+wire grass
+witch grass
+witchgrass
+wood meadowgrass
+wool grass
+yankee corn
+yard grass
+yardgrass
+yellow bristle grass
+yellow bristlegrass
+yellow foxtail
+yorkshire fog
+zea mays
+zea mays amylacea
+zea mays everta
+zea mays indentata
+zea mays indurata
+zea mays rugosa
+zea saccharata
+zizania aquatica
+zoysia
+zoysia japonica
+zoysia matrella
+zoysia tenuifolia

--- a/lists/nature/herb.yml
+++ b/lists/nature/herb.yml
@@ -1,0 +1,2290 @@
+---
+title: Herbs
+category: nature
+description: "Herbaceous, culinary, medicinal, and non-woody plants"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+aaron's rod
+abaca
+abelmoschus esculentus
+abyssinian banana
+acanthus
+acanthus mollis
+achillea
+achillea millefolium
+achillea ptarmica
+achira
+acinos arvensis
+adsuki bean
+adzuki bean
+aframomum melegueta
+agastache foeniculum
+agastache mexicana
+agastache nepetoides
+ageratina altissima
+agrimonia
+agrimonia eupatoria
+agrimonia procera
+agrimony
+ajuga chamaepitys
+ajuga genevensis
+ajuga pyramidalis
+ajuga reptans
+aldrovanda vesiculosa
+alecost
+alexander
+alexanders
+alfalfa
+alfilaria
+alfileria
+alkanet
+allgood
+alliaria officinalis
+alocasia macrorrhiza
+alpine clover
+alpine coltsfoot
+alpine enchanter's nightshade
+alpine mouse-ear
+alpinia galanga
+alpinia officinalis
+alpinia officinarum
+alpinia purpurata
+alpinia speciosa
+alpinia zerumbet
+alumbloom
+alumroot
+alyssum
+amaranth
+amaranthus albus
+amaranthus caudatus
+amaranthus cruentus
+amaranthus graecizans
+amaranthus hybridus erythrostachys
+amaranthus hybridus hypochondriacus
+amaranthus hypochondriacus
+amaranthus spinosus
+american arrowroot
+american columbo
+american cress
+american dog violet
+american gentian
+american ginseng
+american licorice
+american liquorice
+american pennyroyal
+american rattlebox
+american watercress
+american wormseed
+amorphophallus
+amorphophallus campanulatus
+amorphophallus paeonifolius
+amorphophallus rivieri
+amorphophallus titanum
+amsinckia grandiflora
+amsinckia intermedia
+anacyclus pyrethrum
+anagallis arvensis
+anagallis tenella
+ananas comosus
+anastatica hierochuntica
+anchusa
+anchusa capensis
+anchusa officinalis
+anchusa riparia
+andryala
+anemopsis californica
+anethum graveolens
+angelica
+angelica archangelica
+angelica sylvestris
+angelique
+anigozanthus manglesii
+anise
+anise hyssop
+anise plant
+antennaria dioica
+antennaria plantaginifolia
+anthemis nobilis
+anthriscus cereifolium
+anthriscus sylvestris
+anthyllis vulneraria
+apium graveolens
+apium graveolens dulce
+apium graveolens rapaceum
+apple geranium
+apple mint
+applemint
+arabidopsis lyrata
+arabidopsis thaliana
+arabis canadensis
+arabis glabra
+arabis turrita
+arachis hypogaea
+archangel
+arctic mouse-ear
+argemone
+argemone mexicana
+arisaema atrorubens
+arisaema dracontium
+arisaema triphyllum
+arisarum vulgare
+armoracia rusticana
+arnica
+arnoseris minima
+aroid
+arrowroot
+artichoke
+artichoke plant
+arugula
+arum
+arum maculatum
+arum palaestinum
+arundinaria gigantea
+arundinaria tecta
+arundo conspicua
+arundo donax
+asarabacca
+asarum canadense
+asarum europaeum
+asarum shuttleworthii
+asarum virginicum
+asclepia meadii
+asclepiad
+asclepias albicans
+asclepias curassavica
+asclepias exaltata
+asclepias incarnata
+asclepias meadii
+asclepias purpurascens
+asclepias speciosa
+asclepias subverticillata
+asclepias tuberosa
+asclepias verticillata
+asparagus
+asparagus bean
+asparagus fern
+asparagus officinalis
+asparagus pea
+asparagus plumosus
+asparagus setaceous
+asperula odorata
+aspidistra
+aspidistra elatio
+aspidistra elatior
+astilbe
+astilbe biternata
+astilbe chinensis pumila
+astilbe japonica
+astrantia
+astrantia major
+atriplex hortensis
+atriplex mexicana
+atropa belladonna
+aubergine
+aureolaria pedicularia
+aureolaria virginica
+auricula
+australian pitcher plant
+australian sword lily
+austrian winter pea
+autumn sneezeweed
+ayapana
+ayapana triplinervis
+baby blue-eyes
+ballota nigra
+balsam herb
+balsamroot
+bambusa vulgaris
+banana tree
+bar-room plant
+barbarea praecox
+barbarea verna
+barrenwort
+basil
+basil balm
+basil mint
+basil thyme
+beach pea
+beach strawberry
+beaked parsley
+bean
+bean plant
+bear's breech
+bear's breeches
+bear's ear
+bedding geranium
+bedstraw
+bee balm
+beebalm
+beet
+beetleweed
+beetroot
+bella sombra
+belladonna
+belladonna plant
+belle isle cress
+bellflower
+bells of ireland
+benne
+benni
+benny
+bergamot mint
+bergenia
+bermuda buttercup
+berteroa incana
+beta vulgaris
+beta vulgaris cicla
+beta vulgaris rubra
+beta vulgaris vulgaris
+bible leaf
+bird vetch
+bird's-foot violet
+bishop's cap
+bishop's hat
+bitter cress
+bitter dock
+bitter vetch
+bittercress
+black archangel
+black bamboo
+black calla
+black henbane
+black horehound
+black lovage
+black medick
+black mustard
+black salsify
+black saltwort
+black snakeroot
+black-eyed pea
+bladder cherry
+bladderpod
+bladderwort
+blephilia ciliata
+blephilia hirsuta
+blessed thistle
+blinking chickweed
+blinks
+blood flower
+bloodroot
+bloodwort
+blowball
+blue bugle
+blue cardinal flower
+blue devil
+blue pimpernel
+blue skullcap
+blue thistle
+bluebell
+blueweed
+boehmeria nivea
+bog hemp
+bog pimpernel
+bog rhubarb
+bok choi
+bok choy
+boneset
+borage
+borago officinalis
+borecole
+bowiea volubilis
+boys-and-girls
+brassica hirta
+brassica juncea
+brassica kaber
+brassica napus
+brassica napus napobrassica
+brassica nigra
+brassica oleracea
+brassica oleracea acephala
+brassica oleracea botrytis
+brassica oleracea capitata
+brassica oleracea gemmifera
+brassica oleracea gongylodes
+brassica oleracea italica
+brassica perviridis
+brassica rapa
+brassica rapa chinensis
+brassica rapa pekinensis
+brassica rapa perviridis
+brassica rapa ruvo
+breadroot
+breakstone
+brinjal
+broad bean
+broad-bean plant
+broad-leaved dock
+broad-leaved montia
+broad-leaved plantain
+broccoli
+broccoli raab
+broccoli rabe
+brussels sprout
+buckwheat
+buffalo clover
+bugle
+bugleweed
+bugloss
+bur reed
+burnet bloodwort
+bush bean
+bush nasturtium
+bush pea
+bush vetch
+butter bean
+butter-bean plant
+butter-flower
+butterbur
+buttercup
+butterflower
+butterfly weed
+butterweed
+butterwort
+button snakeroot
+cabbage
+cacalia javanica
+cacalia lutea
+cakile maritima
+caladium bicolor
+calamint
+calamintha grandiflora
+calamintha nepeta
+calamintha nepeta glantulosa
+calamintha sylvatica
+caley pea
+california pitcher plant
+california yellow bells
+calliopsis
+calnada pea
+calvary clover
+camelina sativa
+camomile
+campanula
+campanula americana
+campanula aparinoides
+campanula carpatica
+campanula divaricata
+campanula glomerata
+campanula medium
+campanula persicifolia
+campanula pyramidalis
+campanula rapunculoides
+campanula rapunculus
+campanula rotundifolia
+campanula trachelium
+camphor dune tansy
+canada ginger
+canada violet
+canary creeper
+canarybird flower
+canarybird vine
+cancer weed
+cancerweed
+cane reed
+cankerweed
+canna
+canna edulis
+canna generalis
+canna lily
+canterbury bell
+canton ginger
+cape dagga
+cape forget-me-not
+cape gooseberry
+cape periwinkle
+capsella bursa-pastoris
+caraway
+cardamine bulbifera
+cardamine bulbosa
+cardamine diphylla
+cardamine douglasii
+cardamine pratensis
+cardamine rotundifolia
+cardamom
+cardamon
+cardinal flower
+cardoon
+carnivorous plant
+carolina lupine
+carrion flower
+carrizo
+carrot
+cart-track plant
+carthamus tinctorius
+carum carvi
+caryophyllaceous plant
+cassia marilandica
+cat's feet
+cat's foot
+catchweed
+catharanthus roseus
+catmint
+catnip
+cauliflower
+cayenne jasmine
+celeriac
+celery
+celery cabbage
+celery root
+celery-leaved buttercup
+celosia argentea
+celosia argentea cristata
+celosia cristata
+celtuce
+cephalotus follicularis
+cerastium alpinum
+cerastium arvense
+cerastium tomentosum
+chadlock
+chaenactis
+chamaemelum nobilis
+chamois cress
+chamomile
+chaparral sage
+chard
+chard plant
+charity
+charlock
+chenopodium album
+chenopodium ambrosioides
+chenopodium bonus-henricus
+chenopodium botrys
+chenopodium capitatum
+chenopodium glaucum
+chenopodium hybridum
+chenopodium murale
+chenopodium rubrum
+chenopodium vulvaria
+cherry tomato
+chervil
+chickpea
+chickpea plant
+chickweed
+chickweed phlox
+chicory
+chicory plant
+chigger flower
+chiggerflower
+chile tarweed
+chilean strawberry
+chimaphila corymbosa
+chimaphila umbellata
+chimney bellflower
+chimney plant
+china grass
+chinese cabbage
+chinese forget-me-not
+chinese lantern plant
+chinese mustard
+chinese parsley
+chinese primrose
+chinese rhubarb
+chinese silk plant
+chinese white cabbage
+chionochloa conspicua
+chrysanthemum balsamita
+chrysanthemum cinerariifolium
+chrysanthemum parthenium
+cicer arietinum
+cichorium endivia
+cichorium intybus
+cilantro
+circaea alpina
+circaea lutetiana
+clammy chickweed
+clammyweed
+clary
+clary sage
+cleavers
+cleome
+cleome hassleriana
+cleome serrulata
+climbing onion
+clinopodium grandiflorum
+clinopodium vulgare
+clivers
+clocks
+clover
+cluster bean
+clustered bellflower
+cnidoscolus urens
+cochlearia officinalis
+cockscomb
+codlins-and-cream
+cole
+coleus amboinicus
+coleus aromaticus
+coleus blumei
+colewort
+collard
+collinsonia canadensis
+colocasia esculenta
+colorado river hemp
+coltsfoot
+columbo
+colza
+comfrey
+common amsinckia
+common bamboo
+common basil
+common bean
+common bean plant
+common beet
+common buttercup
+common calamint
+common chickweed
+common cockscomb
+common comfrey
+common corn salad
+common dandelion
+common devil's claw
+common evening primrose
+common fennel
+common foxglove
+common garden cress
+common ginger
+common horehound
+common lettuce
+common mullein
+common pea
+common pitcher plant
+common plantain
+common purslane
+common reed
+common sage
+common scurvy grass
+common teasel
+common thyme
+common tobacco
+common unicorn plant
+common vetchling
+common watercress
+common wood sorrel
+conopodium denudatum
+coolwart
+coptis groenlandica
+coptis trifolia groenlandica
+coral necklace
+coral-root bittercress
+coralbells
+coralroot
+coralwort
+coreopsis
+coreopsis gigantea
+coreopsis maritima
+coreopsis tinctoria
+coriander
+coriander plant
+coriandrum sativum
+corkscrew flower
+corn mint
+corn salad
+cos lettuce
+costmary
+costusroot
+country borage
+cow parsley
+cow parsnip
+cowpea
+cowpea plant
+cowslip
+crambe maritima
+crane's bill
+cranesbill
+crazy weed
+crazyweed
+cream violet
+creeping bellflower
+creeping bugle
+creeping buttercup
+creeping charlie
+creeping crowfoot
+creeping jenny
+creeping oxalis
+creeping thyme
+creeping wood sorrel
+creeping zinnia
+cress
+cress plant
+cretan dittany
+crete dittany
+crimson clover
+crinkle-root
+crinkleroot
+crotalaria
+crotalaria sagitallis
+crotalaria spectabilis
+crowfoot
+crucifer
+cruciferous plant
+cuban spinach
+cuckoo bread
+cuckooflower
+cuckoopint
+cultivated cabbage
+cultivated carrot
+cultivated celery
+cultivated parsnip
+cultivated strawberry
+cumfrey
+cumin
+cuminum cyminum
+cup and saucer
+curcuma domestica
+curcuma longa
+curlycup gumweed
+cursed crowfoot
+cushion calamint
+cyamopsis psoraloides
+cyamopsis tetragonolobus
+cynara cardunculus
+cynara scolymus
+cynoglossum amabile
+cynoglossum officinale
+cynoglossum virginaticum
+cynoglossum virginianum
+dagga
+daikon
+daily dew
+dalmatia pyrethrum
+dalmatian pyrethrum
+dalo
+dandelion
+darlingtonia californica
+darmera peltata
+dasheen
+daucus carota sativa
+day lily
+dayflower
+dead nettle
+deadly nightshade
+deer's-ear
+deer's-ears
+dendrocalamus giganteus
+dentaria bulbifera
+dentaria diphylla
+descurainia pinnata
+desmanthus illinoensis
+devil nettle
+devil's apples
+devil's claw
+devil's fig
+devil's tongue
+dicentra canadensis
+dicentra cucullaria
+dicentra spectabilis
+dictamnus alba
+dieffenbachia sequine
+digitalis
+digitalis lutea
+digitalis purpurea
+dill
+dionaea muscipula
+diplotaxis erucoides
+diplotaxis muralis
+diplotaxis tenuifolia
+dipsacus fullonum
+dipsacus sativus
+dipsacus sylvestris
+ditch reed
+dittany
+dittany of crete
+dog mercury
+dog violet
+dog's mercury
+dolichos biflorus
+dove's foot geranium
+downy ground cherry
+downy wood mint
+downy yellow violet
+draba
+draba verna
+dracocephalum parviflorum
+dracontium
+dracunculus vulgaris
+dragon arum
+dragon's head
+dragonhead
+drosophyllum lusitanicum
+drypis
+dutch case-knife bean
+dutch clover
+dutchman's breeches
+dwarf astilbe
+dwarf banana
+dwarf cape gooseberry
+dwarf dandelion
+dwarf nipplewort
+dwarf phlox
+dyer's mignonette
+dyer's rocket
+dyer's woad
+early winter cress
+earthnut
+eau de cologne mint
+echium vulgare
+edible asparagus
+edible banana
+edible-pod pea
+edible-podded pea
+eggplant
+eggplant bush
+egyptian henbane
+egyptian pea
+elecampane
+elephant ear
+elephant yam
+elephant-tusk
+elephant's-foot
+elettaria cardamomum
+elsholtzia
+emilia coccinea
+emilia flammea
+emilia javanica
+emilia sagitta
+emmanthe penduliflora
+enchanter's nightshade
+endive
+english bean
+english plantain
+english primrose
+english violet
+english-weed
+ensete ventricosum
+epilobium angustifolium
+epilobium hirsutum
+epimedium grandiflorum
+eranthis hyemalis
+erect bugle
+erodium cicutarium
+erodium moschatum
+erodium texanum
+eruca sativa
+eruca vesicaria sativa
+eryngium aquaticum
+esparcet
+ethiopian banana
+eupatorium aya-pana
+eupatorium cannabinum
+eupatorium capillifolium
+eupatorium maculatum
+eupatorium perfoliatum
+eupatorium purpureum
+eupatorium rugosum
+euphorbia hirta
+european bean
+european sanicle
+evening primrose
+evening-snow
+fagopyrum esculentum
+fair-maids-of-france
+fairy bell
+fairy cup
+false baby's breath
+false bugbane
+false dragon head
+false dragonhead
+false foxglove
+false goatsbeard
+false gromwell
+false lupine
+false miterwort
+false mitrewort
+false nettle
+false rue
+false rue anemone
+false saffron
+false wintergreen
+fat hen
+feather geranium
+fennel
+fenugreek
+fetid horehound
+feverfew
+feverroot
+field balm
+field bean
+field chickweed
+field mint
+field mouse-ear
+field mustard
+field pansy
+field pea
+field-pea plant
+fiesta flower
+filaree
+filaria
+finger-flower
+finger-root
+fingerflower
+fingerroot
+fireweed
+fish geranium
+fishpole bamboo
+five-point bishop's cap
+five-spot
+flame flower
+flame nettle
+flameflower
+flannel leaf
+flannel mullein
+flat-leaf parsley
+flax
+fleabane
+fleabane mullet
+fleawort
+florence fennel
+flowering tobacco
+foamflower
+foeniculum dulce
+foeniculum vulgare
+foeniculum vulgare dulce
+footsteps-of-spring
+forget-me-not
+foxglove
+fragaria ananassa
+fragaria chiloensis
+fragaria vesca
+fragaria virginiana
+fragrant agrimony
+fragrant bedstraw
+frasera speciosa
+fraxinella
+french sorrel
+french spinach
+friar's-cowl
+frijol
+frijole
+fringed loosestrife
+fringepod
+fuller's teasel
+fumaria officinalis
+fumeroot
+fumewort
+fumitory
+gai choi
+galangal
+galax
+galax urceolata
+galaxy
+galega officinalis
+galeopsis tetrahit
+galium aparine
+galium boreale
+galium lanceolatum
+galium mollugo
+galium odoratum
+galium verum
+gall of the earth
+garden angelica
+garden balm
+garden egg
+garden forget-me-not
+garden lettuce
+garden loosestrife
+garden nasturtium
+garden orache
+garden pea
+garden pea plant
+garden pepper cress
+garden peppergrass
+garden rhubarb
+garden rocket
+garden sorrel
+garden strawberry
+garden violet
+garget
+garlic mustard
+gas plant
+genlisea
+gentleman's-cane
+geranium
+geranium maculatum
+geranium molle
+geranium pratense
+geranium richardsonii
+geranium robertianum
+geranium viscosissimum
+gerardia pedicularia
+gerardia virginica
+german chamomile
+german rampion
+gesneria
+giant bamboo
+giant buttercup
+giant cane
+giant coreopsis
+giant hyssop
+giant reed
+giant taro
+giant timber bamboo
+giant willowherb
+ginger
+ginseng
+gipsywort
+glaux maritima
+globe artichoke
+globe flower
+globe thistle
+globeflower
+glycine max
+glycyrrhiza glabra
+glycyrrhiza lepidota
+goat rue
+goat's foot
+goatsfoot
+gold of pleasure
+goldcup
+golden groundsel
+golden pea
+golden ragwort
+golden seal
+golden thread
+goldenseal
+goldthread
+good-king-henry
+goosefoot
+gooseneck loosestrife
+gosan-chiku
+grains of paradise
+graminaceous plant
+gramineous plant
+great lobelia
+great mullein
+great yellowcress
+greater masterwort
+greater stitchwort
+greek clover
+greek valerian
+green bean
+green dragon
+green gentian
+grindelia robusta
+grindelia squarrosa
+gromwell
+ground cherry
+ground pine
+ground pink
+guar
+guinea grains
+gum plant
+gumbo
+gumweed
+haastia pulvinaris
+hairy tare
+hairy vetch
+hairy willowherb
+hairy wood mint
+halogeton
+halogeton glomeratus
+halogeton souda
+hamburg parsley
+hanging geranium
+harebell
+haricot
+harvest-lice
+hawkweed
+head cabbage
+head cabbage plant
+head lettuce
+heal all
+heart-leaf
+heartleaf
+heartsease
+heath violet
+hedeoma pulegioides
+hedge garlic
+hedge mustard
+hedge nettle
+hedge violet
+helenium autumnale
+helenium hoopesii
+helenium puberulum
+hemp agrimony
+hemp nettle
+henbane
+henbit
+hepatica
+heracleum sphondylium
+herb
+herb mercury
+herb of grace
+herb paris
+herb robert
+herb roberts
+herbaceous plant
+herbage
+herbs mercury
+herbs robert
+heron's bill
+heuchera americana
+heuchera cylindrica
+heuchera sanguinea
+hibiscus esculentus
+hieracium pilocella
+hieracium pilosella
+hieracium venosum
+himalayan rhubarb
+hoary alison
+hoary alyssum
+hoary plantain
+hoary puccoon
+hogweed
+holy clover
+holy thistle
+homogyne alpina
+honesty
+hooded pitcher plant
+hop clover
+hop marjoram
+horehound
+horned violet
+horse balm
+horse gentian
+horse grain
+horse gram
+horse parsley
+horse radish
+horsemint
+horseradish
+horsetail milkweed
+horseweed
+hotei-chiku
+hound's-tongue
+hugueninia tanacetifolia
+huntsman's cup
+huntsman's cups
+huntsman's horn
+huntsman's horns
+husk tomato
+hydrastis canadensis
+hydrophyllum virginianum
+hyoscyamus muticus
+hyoscyamus niger
+hyssop
+hyssopus officinalis
+illecebrum verticillatum
+impatiens capensis
+indian arrowroot
+indian breadroot
+indian cress
+indian lettuce
+indian mustard
+indian paint
+indian paintbrush
+indian pink
+indian plantain
+indian poke
+indian rattlebox
+indian rhubarb
+indian salad
+indian shot
+indian tobacco
+indian turnip
+infant's-breath
+inula
+inula helenium
+ironweed
+isatis tinctoria
+isopyrum biternatum
+italian clover
+italian parsley
+ivy geranium
+ivy-leaved geranium
+jack-by-the-hedge
+jack-in-the-pulpit
+jacob's ladder
+jamberry
+japanese banana
+japanese radish
+jasmine tobacco
+jatropha stimulosus
+jatropha urens
+jerusalem oak
+jewelweed
+joe-pye weed
+john's cabbage
+johnny-jump-up
+joseph's coat
+kail
+kale
+kangaroo paw
+kangaroo-foot plant
+kangaroo's paw
+kangaroo's-foot
+kidney bean
+kidney vetch
+kingcup
+kniphofia
+kniphofia praecox
+kniphofia uvaria
+knob celery
+knotted marjoram
+kohlrabi
+kok-saghyz
+kok-sagyz
+krigia
+krigia bulbosa
+krigia dandelion
+krubi
+ku-chiku
+kuri-chiku
+kyo-chiku
+laccopetalum giganteum
+lacepod
+lactuca sativa
+lactuca sativa asparagina
+lactuca sativa capitata
+lactuca sativa crispa
+lactuca sativa longifolia
+ladies' tobacco
+lady's earrings
+lady's smock
+lady's thistle
+lady's tobacco
+lady's-finger
+lalthyrus tingitanus
+lamb succory
+lamb's lettuce
+lamb's-quarters
+lamium album
+lamium amplexicaule
+land cress
+languas speciosa
+large-flowered calamint
+large-flowered fiddleneck
+lathyrus hirsutus
+lathyrus japonicus
+lathyrus maritimus
+lathyrus palustris
+lathyrus pratensis
+lathyrus splendens
+leaf beet
+leaf lettuce
+leaf mustard
+legume
+leguminous plant
+lemon balm
+lemon geranium
+lemon mint
+lens culinaris
+lentil
+lentil plant
+leonotis leonurus
+leonotis nepetaefolia
+leonotis nepetifolia
+leonurus cardiaca
+leopard plant
+leopard's-bane
+leopardbane
+lepidium alpina
+lepidium sativum
+lesser calamint
+lesser galangal
+lesser wintergreen
+lesser yellow trefoil
+lettuce
+levisticum officinale
+licorice
+lima bean
+lima bean plant
+linanthus dianthiflorus
+linanthus dichotomus
+lion's foot
+lion's-ear
+liquorice
+lithospermum canescens
+lithospermum caroliniense
+lithospermum officinale
+live-forever
+livelong
+liverleaf
+loasa
+lobelia cardinalis
+lobelia dortmanna
+lobelia inflata
+lobelia siphilitica
+locoweed
+long-spurred violet
+lords-and-ladies
+lotus tetragonolobus
+lovage
+love apple
+love-in-idleness
+love-in-winter
+love-lies-bleeding
+lucerne
+lunaria annua
+lycopersicon esculentum
+lycopersicon esculentum cerasiforme
+lycopus americanus
+lycopus europaeus
+lycopus virginicus
+lyre-flower
+lyreflower
+lysimachia ciliatum
+lysimachia clethroides duby
+lysimachia nemorum
+lysimachia nummularia
+lysimachia quadrifolia
+lysimachia terrestris
+lysimachia vulgaris
+macrotyloma uniflorum
+mad apple
+mad-dog skullcap
+mad-dog weed
+madagascar periwinkle
+madake
+madia oil plant
+madia sativa
+madnep
+madwort
+majorana hortensis
+malanga
+malheur wire lettuce
+mandragora officinarum
+mandrake
+mangel-wurzel
+mangold
+mangold-wurzel
+manila hemp
+maranta arundinaceae
+marjoram
+marrubium vulgare
+marsh bellflower
+marsh cress
+marsh felwort
+marsh milkweed
+marsh pea
+martynia
+martynia annua
+martynia arenaria
+martynia fragrans
+masterwort
+matricaria chamomilla
+matricaria inodorum
+matricaria matricarioides
+matricaria oreades
+matricaria recutita
+matricaria tchihatchewii
+may apple
+mayapple
+mead's milkweed
+meadow buttercup
+meadow clary
+meadow cranesbill
+meadow cress
+meadow pea
+meadow saxifrage
+mealy sage
+medic
+medicago arborea
+medicago echinus
+medicago falcata
+medicago intertexta
+medicago lupulina
+medicago sativa
+medick
+melagueta pepper
+melissa officinalis
+melosa
+mentha aquatica
+mentha arvensis
+mentha citrata
+mentha longifolia
+mentha piperita
+mentha pulegium
+mentha rotundifolia
+mentha spicata
+mentha suaveolens
+mercurialis annua
+mercurialis perennis
+mertensia virginica
+mexican husk tomato
+mexican hyssop
+mexican mint
+mexican poppy
+mexican tea
+micromeria chamissonis
+micromeria douglasii
+micromeria juliana
+midsummer-men
+mignonette
+milfoil
+miltomate
+miner's lettuce
+mint
+mint geranium
+missouri primrose
+mitella diphylla
+mitella pentandra
+miterwort
+mitrewort
+molucca balm
+molucella laevis
+monarda
+monarda citriodora
+monarda clinopodia
+monarda didyma
+monarda fistulosa
+monarda pectinata
+monarda punctata
+monardella lanceolata
+moneses uniflora
+money plant
+moneywort
+montia chamissoi
+montia cordifolia
+montia lamprosperma
+montia perfoliata
+moon carrot
+moon trefoil
+moss phlox
+moss pink
+mossy saxifrage
+moth bean
+moth mullein
+mother of thyme
+mother-in-law plant
+mother-in-law's tongue
+mother-of-thousands
+motherwort
+mount cook lily
+mountain everlasting
+mountain lily
+mountain mint
+mountain phlox
+mountain spinach
+mountain watercress
+mouse ear
+mouse eared chickweed
+mouse-ear chickweed
+mouse-ear cress
+mouse-ear hawkweed
+mullein
+mung
+mung bean
+mung bean plant
+musa acuminata
+musa basjoo
+musa ensete
+musa paradisiaca
+musa paradisiaca sapientum
+musa textilis
+musk clover
+muskus grass
+mustang mint
+mustard
+myosotis scorpiodes
+myosotis sylvatica
+myrrhis odorata
+nabalus alba
+nabalus serpentarius
+napa
+narrow-leaved plantain
+nasturtium
+nasturtium amphibium
+nasturtium officinale
+nemophila
+nemophila aurita
+nemophila maculata
+nemophila menziesii
+nepeta cataria
+nephthytis
+nephthytis afzelii
+nettle-leaved bellflower
+nettle-leaved goosefoot
+nettleleaf goosefoot
+new zealand spinach
+nicandra physaloides
+nicotiana alata
+nicotiana glauca
+nicotiana rustica
+nicotiana tabacum
+nierembergia
+nierembergia frutescens
+nierembergia repens
+nierembergia rivularis
+nin-sin
+noble cane
+nonesuch clover
+northern bedstraw
+northern jacob's ladder
+northern snow bedstraw
+nutmeg geranium
+oak-leaved goosefoot
+oakleaf goosefoot
+obedience plant
+obedient plant
+oca
+ocimum basilicum
+oenothera biennis
+oenothera fruticosa
+oenothera macrocarpa
+oka
+okra
+okra plant
+ombu
+one-flowered pyrola
+one-flowered wintergreen
+onobrychis viciaefolia
+onobrychis viciifolia
+orach
+orache
+orange balsam
+orange milkweed
+orange sneezeweed
+oregano
+origanum
+origanum dictamnus
+origanum majorana
+origanum vulgare
+orpin
+orpine
+oswego tea
+our lady's bedstraw
+our lady's mild thistle
+owlclaws
+oxalis
+oxalis acetosella
+oxalis caprina
+oxalis cernua
+oxalis corniculata
+oxalis crenata
+oxalis pes-caprae
+oxalis tuberosa
+oxalis violacea
+oxlip
+oxytropis lambertii
+oyster plant
+ozark sundrops
+packera aurea
+paigle
+painted nettle
+painted tongue
+pak choi
+pakchoi
+pale violet
+panax ginseng
+panax pseudoginseng
+panax quinquefolius
+panax schinseng
+pansy
+pansy violet
+paradisea liliastrum
+parietaria difusa
+paris quadrifolia
+parochetus communis
+parsley
+parsnip
+pastinaca sativa
+pasturage
+pe-tsai
+pea
+pea plant
+peach bell
+peach bells
+peanut
+peanut vine
+pelargonium graveolens
+pelargonium hortorum
+pelargonium limoneum
+pelargonium odoratissimum
+pelargonium peltatum
+pellitory
+pellitory-of-spain
+pellitory-of-the-wall
+peltiphyllum peltatum
+pennyroyal
+peperomia argyreia
+peperomia sandersii
+pepper grass
+pepper root
+pepperwort
+perilla frutescens crispa
+petasites fragrans
+petasites hybridus
+petasites sagittatus
+petasites vulgaris
+petroselinum crispum
+petroselinum crispum neapolitanum
+petroselinum crispum tuberosum
+phaseolus aconitifolius
+phaseolus acutifolius latifolius
+phaseolus angularis
+phaseolus aureus
+phaseolus caracalla
+phaseolus coccineus
+phaseolus limensis
+phaseolus lunatus
+phaseolus multiflorus
+phaseolus vulgaris
+phlox
+phlox bifida
+phlox stellaria
+phlox subulata
+pholistoma auritum
+phragmites communis
+phyllostachys aurea
+phyllostachys bambusoides
+phyllostachys nigra
+physalis alkekengi
+physalis ixocarpa
+physalis peruviana
+physalis philadelphica
+physalis pruinosa
+physalis pubescens
+physalis viscosa
+physostegia
+physostegia virginiana
+phytolacca acinosa
+phytolacca americana
+phytolacca dioica
+pia
+pica-pica
+pickaback plant
+pie plant
+pigeon berry
+piggyback plant
+pigweed
+pilosella officinarum
+pimpernel
+pimpinella anisum
+pin clover
+pin grass
+pineapple
+pineapple plant
+pineapple weed
+pink of my john
+pipsissewa
+pisum arvense
+pisum sativum
+pisum sativum arvense
+pisum sativum macrocarpon
+plains lemon monarda
+plantago lanceolata
+plantago major
+plantago media
+plantago psyllium
+plantago rugelii
+plantago virginica
+plantain
+plantain lily
+plantain tree
+plectranthus amboinicus
+pleurisy root
+plum tomato
+plumbago
+podophyllum peltatum
+poison milkweed
+poke
+poke milkweed
+poker alumroot
+poker heuchera
+poker plant
+pokeweed
+polanisia dodecandra
+polanisia graveolens
+pole bean
+polemonium
+polemonium boreale
+polemonium caeruleum
+polemonium reptans
+polemonium van-bruntiae
+polemonium viscosum
+polyanthus
+polygonum fagopyrum
+polymonium caeruleum van-bruntiae
+pomme blanche
+pomme de prairie
+poor man's pulse
+poor man's weatherglass
+portulaca oleracea
+pot marjoram
+poterium sanguisorba
+prairie mimosa
+prenanthes alba
+prenanthes purpurea
+prenanthes serpentaria
+prickle-weed
+prickly-seeded spinach
+pride of california
+primrose
+primula
+primula auricula
+primula elatior
+primula polyantha
+primula sinensis
+primula veris
+primula vulgaris
+prince's pine
+pritzelago alpina
+proboscidea arenaria
+proboscidea fragrans
+proboscidea louisianica
+proboscis flower
+prunella vulgaris
+psoralea esculenta
+psyllium
+pteropogon
+pteropogon humboltianum
+puccoon
+pulicaria dysenterica
+pungapung
+purple amaranth
+purple boneset
+purple clover
+purple cress
+purple ground cherry
+purple loco
+purple locoweed
+purple mullein
+purple sage
+purple sanicle
+purple saxifrage
+purple silkweed
+purslane
+pussley
+pussly
+pycnanthemum virginianum
+pyramid bugle
+pyramid plant
+pyrola
+pyrola americana
+pyrola elliptica
+pyrola minor
+pyrola rotundifolia
+pyrola rotundifolia americana
+pyrola uniflora
+radish
+radish plant
+ram's horn
+ramee
+ramie
+ramona
+rampion
+rampion bellflower
+ranunculus acris
+ranunculus bulbosus
+ranunculus lyalii
+ranunculus occidentalis
+ranunculus repens
+ranunculus sceleratus
+raoulia australis
+raoulia lutescens
+rape
+raphanus sativus
+raphanus sativus longipinnatus
+rattlebox
+rattlesnake root
+rattlesnake weed
+rayless chamomile
+red amaranth
+red cabbage
+red clover
+red cole
+red dagga
+red fox
+red ginger
+red goosefoot
+red periwinkle
+red pimpernel
+red-hot poker
+red-veined pie plant
+redroot
+redstem storksbill
+reed
+reseda
+reseda luteola
+reseda odorata
+resurrection plant
+rheum australe
+rheum cultorum
+rheum emodi
+rheum palmatum
+rheum rhabarbarum
+rheum rhaponticum
+rhubarb
+rhubarb plant
+ribgrass
+ribwort
+richardson's geranium
+richweed
+ripple-grass
+rock cress
+rock geranium
+rock purslane
+rockcress
+rocket
+rocket salad
+rockfoil
+rocky mountain bee plant
+romaine lettuce
+root celery
+roquette
+roridula
+rorippa amphibia
+rorippa islandica
+rorippa nasturtium-aquaticum
+rose geranium
+rose of jericho
+rose periwinkle
+rose-root
+rosebay willowherb
+rosemary
+rosilla
+rosmarinus officinalis
+rough pea
+rue
+rugel's plantain
+rumex acetosa
+rumex acetosella
+rumex obtusifolius
+rumex scutatus
+runner bean
+russian dandelion
+ruta graveolens
+rutabaga
+rutabaga plant
+saccharum officinarum
+safflower
+sage
+sainfoin
+salad burnet
+salicornia europaea
+salpiglossis
+salpiglossis sinuata
+salsify
+salvia azurea
+salvia clarea
+salvia divinorum
+salvia lancifolia
+salvia leucophylla
+salvia lyrata
+salvia officinalis
+salvia pratensis
+salvia reflexa
+salvia sclarea
+salvia spathacea
+salvia verbenaca
+samphire
+sand devil's claw
+sand phlox
+sanfoin
+sang
+sanicle
+sanicula arctopoides
+sanicula bipinnatifida
+sanicula europaea
+sanvitalia procumbens
+sarracenia flava
+sarracenia minor
+sarracenia purpurea
+satin flower
+satinpod
+satureia hortensis
+satureia montana
+satureja acinos
+satureja calamintha glandulosa
+satureja calamintha officinalis
+satureja douglasii
+satureja grandiflora
+satureja hortensis
+satureja montana
+satureja nepeta
+satureja vulgaris
+sauce-alone
+saussurea costus
+saussurea lappa
+savory
+savoy cabbage
+sawwort
+saxifraga aizoides
+saxifraga granulata
+saxifraga hypnoides
+saxifraga occidentalis
+saxifraga oppositifolia
+saxifraga sarmentosam
+saxifraga stellaris
+saxifraga stolonifera
+saxifrage
+scarlet pimpernel
+scarlet runner
+scarlet runner bean
+scarlet strawberry
+scentless camomile
+scentless false camomile
+scentless hayweed
+scentless mayweed
+scoke
+scopolia carniolica
+scorzonera
+scorzonera hispanica
+scurvy grass
+scutellaria lateriflora
+sea cole
+sea dahlia
+sea kale
+sea milkwort
+sea pea
+sea trifoly
+sea-rocket
+sedum
+sedum acre
+sedum rosea
+sedum telephium
+self-heal
+senecio aureus
+senna marilandica
+serratula tinctoria
+sesame
+sesamum indicum
+sesbania
+sesbania exaltata
+shad-flower
+shadflower
+shall-flower
+shamrock
+shamrock pea
+shawnee salad
+shawny
+sheep plant
+sheep sorrel
+sheep's sorrel
+shell bean
+shell bean plant
+shell ginger
+shellflower
+shepherd's pouch
+shepherd's purse
+shinleaf
+shoo fly
+showy milkweed
+sickle alfalfa
+sickle lucerne
+sickle medick
+sieva bean
+silkweed
+silver dollar
+silybum marianum
+simple
+sinapis alba
+sinapis arvensis
+singletary pea
+sison amomum
+sisymbrium officinale
+sisymbrium tanacetifolia
+skullcap
+skunk-weed
+skunkweed
+small cane
+smyrnium olusatrum
+snail bean
+snail-flower
+snailflower
+snake palm
+snakeroot
+snap pea
+sneezeweed
+sneezeweed yarrow
+sneezewort
+snow pea
+soja
+soja bean
+solanum melongena
+solenostemon blumei
+solenostemon scutellarioides
+sour dock
+sour grass
+southern harebell
+sowbane
+soy
+soya
+soya bean
+soybean
+soybean plant
+spanish psyllium
+spanish tea
+spearmint
+spider flower
+spiderflower
+spiderwort
+spinach
+spinach beet
+spinach mustard
+spinach plant
+spinacia oleracea
+spoonflower
+spotted cranesbill
+spotted joe-pye weed
+spreading bellflower
+spring cleavers
+spring cress
+spring vetch
+spurge nettle
+squirrel corn
+st. barbara's herb
+st.-bruno's-lily
+stachys palustris
+stachys sylvatica
+stapelia
+stapelias asterias
+star saxifrage
+starfish flower
+starry saxifrage
+starwort
+stellaria holostea
+stellaria media
+stem ginger
+stem lettuce
+stephanomeria malheurensis
+stevia
+stickweed
+sticky geranium
+stinking clover
+stinking goosefoot
+stinking horehound
+stinking nightshade
+stitchwort
+stone cress
+stone parsley
+stone-root
+stonecress
+stonecrop
+stoneroot
+storksbill
+straw foxglove
+strawberry
+strawberry blite
+strawberry geranium
+strawberry pigweed
+strawberry saxifrage
+strawberry tomato
+strelitzia reginae
+striped violet
+succory
+sugar beet
+sugar cane
+sugar pea
+sugar snap pea
+sugarcane
+suksdorfia
+suksdorfia violaceae
+summer savory
+sun pitcher
+sundew plant
+sundrops
+swamp candles
+swamp milkweed
+swede
+swedish turnip
+sweet balm
+sweet basil
+sweet cicely
+sweet coltsfoot
+sweet false chamomile
+sweet marjoram
+sweet reseda
+sweet unicorn plant
+sweet violet
+sweet white violet
+sweet woodruff
+sweet-scented geranium
+swertia perennis
+swertia speciosa
+swiss chard
+switch cane
+symphytum officinale
+tacca leontopetaloides
+tacca pinnatifida
+tailwort
+tall bellflower
+tall buttercup
+tall crowfoot
+tall cupflower
+tall field buttercup
+tall white violet
+tanacetum balsamita
+tanacetum camphoratum
+tanacetum cinerariifolium
+tanacetum parthenium
+tangier pea
+tangier peavine
+tannia
+tansy mustard
+tansy-leaved rocket
+taraxacum kok-saghyz
+taraxacum officinale
+taraxacum ruderalia
+taro
+taro plant
+tarweed
+tassel flower
+teasel
+teasle
+teazel
+telingo potato
+tendergreen
+tepary bean
+tetragonia expansa
+tetragonia tetragonioides
+tetterwort
+texas storksbill
+thermopsis macrophylla
+thermopsis villosa
+thorny amaranth
+thoroughwort
+throatwort
+thyme
+thymus serpyllum
+thymus vulgaris
+tiarella cordifolia
+tick-weed
+tickseed
+tickweed
+tinker's root
+titan arum
+toad lily
+tobacco
+tobacco plant
+toitoi
+tolmiea menziesii
+tomatillo
+tomato
+tomato plant
+toothwort
+torch
+tower cress
+tower mustard
+tragopogon porrifolius
+trautvetteria carolinensis
+tread-softly
+tree tobacco
+trefoil
+trifolium alpinum
+trifolium dubium
+trifolium incarnatum
+trifolium pratense
+trifolium reflexum
+trifolium repens
+trifolium stoloniferum
+trigonella foenumgraecum
+trigonella ornithopodioides
+trilisa odoratissima
+triosteum perfoliatum
+triostium perfoliatum
+tripleurospermum inodorum
+tripleurospermum oreades tchihatchewii
+tripleurospermum tchihatchewii
+tritoma
+tropaeolum majus
+tropaeolum minus
+tropaeolum peregrinum
+tropical pitcher plant
+trumpet weed
+trumpets
+tuber root
+tufted pansy
+tufted vetch
+turfing daisy
+turmeric
+turmeric root
+turnip
+turnip cabbage
+turnip plant
+turnip-rooted celery
+turnip-rooted parsley
+turritis glabra
+tussilago alpina
+tussilago farfara
+tussock bellflower
+two-eyed violet
+umbellifer
+umbelliferous plant
+umbrella arum
+valerianella locusta
+valerianella olitoria
+vegetable
+vegetable oyster
+vegetable sheep
+velvet flower
+velvet plant
+venus's flytrap
+venus's flytraps
+verbascum blattaria
+verbascum lychnitis
+verbascum phoeniceum
+verbascum thapsus
+verdolaga
+verdolagas
+vernonia
+vervain sage
+vetch
+vicia cracca
+vicia faba
+vicia orobus
+vicia sativa
+vicia sepium
+vicia villosa
+vigna aconitifolia
+vigna angularis
+vigna caracalla
+vigna radiata
+vigna sesquipedalis
+vigna sinensis
+vigna unguiculata
+vigna unguiculata sesquipedalis
+vinca rosea
+viola
+viola arvensis
+viola blanda
+viola canadensis
+viola canina
+viola conspersa
+viola cornuta
+viola ocellata
+viola odorata
+viola pedata
+viola pubescens
+viola reichenbachiana
+viola rostrata
+viola striata
+viola sylvatica
+viola tricolor
+viola tricolor hortensis
+violet
+violet suksdorfia
+violet wood sorrel
+viper's bugloss
+viper's grass
+virginia bluebell
+virginia cowslip
+virginia strawberry
+virginia waterleaf
+wake-robin
+waldmeister
+wall pellitory
+wall pepper
+wall rocket
+wasabi
+water chickweed
+water horehound
+water lobelia
+water-mint
+watercress
+waterleaf
+watermelon begonia
+waterwheel plant
+wax bean
+weld
+western buttercup
+western prince's pine
+western saxifrage
+whispering bells
+white bedstraw
+white clover
+white dead nettle
+white horehound
+white lettuce
+white madder
+white milkweed
+white mullein
+white mustard
+white rocket
+white sanicle
+white snakeroot
+white turnip
+white violet
+white-man's foot
+white-stemmed filaree
+whitecup
+whiteman's foot
+whitlow grass
+whorled caraway
+whorled loosestrife
+whorled milkweed
+wickup
+wild angelica
+wild basil
+wild bergamot
+wild cabbage
+wild celery
+wild chamomile
+wild chervil
+wild clary
+wild coffee
+wild geranium
+wild ginger
+wild licorice
+wild lily of the valley
+wild liquorice
+wild madder
+wild mandrake
+wild marjoram
+wild mustard
+wild pansy
+wild parsley
+wild parsnip
+wild pea
+wild sage
+wild senna
+wild spinach
+wild strawberry
+wild teasel
+wild thyme
+wild tobacco
+wild vanilla
+wild winterpea
+wilde dagga
+willow bell
+willowherb
+winged pea
+winter aconite
+winter cherry
+winter cress
+winter heliotrope
+winter purslane
+winter savory
+witloof
+woad
+wood mint
+wood sorrel
+wood strawberry
+wood violet
+woodland white violet
+woolly mullein
+wormseed
+wort
+xanthosoma atrovirens
+xanthosoma sagittifolium
+yard-long bean
+yarrow
+yautia
+yellow bedstraw
+yellow bells
+yellow bugle
+yellow cleavers
+yellow dock
+yellow foxglove
+yellow giant hyssop
+yellow henbane
+yellow loosestrife
+yellow mountain saxifrage
+yellow pea
+yellow pimpernel
+yellow pitcher plant
+yellow root
+yellow trefoil
+yellow trumpet
+yellow vetchling
+yellow watercress
+yerba buena
+yerba mansa
+youth-on-age
+zingiber officinale
+zonal pelargonium

--- a/lists/nature/moss-and-lichen.yml
+++ b/lists/nature/moss-and-lichen.yml
@@ -1,0 +1,50 @@
+---
+title: Mosses and lichens
+category: nature
+description: "Mosses, liverworts, hornworts, and lichens"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acrocarp
+acrocarpous moss
+archil
+arctic moss
+ascolichen
+basidiolichen
+beard lichen
+beard moss
+bog moss
+bryophyte
+cetraria islandica
+cladonia rangiferina
+crotal
+crottal
+crottle
+hepatic
+horsehair lichen
+horsetail lichen
+iceland lichen
+iceland moss
+leafy liverwort
+lecanora
+lichen
+liverwort
+manna lichen
+marchantia polymorpha
+nonvascular plant
+orchil
+peat moss
+pleurocarp
+pleurocarpous moss
+reindeer lichen
+reindeer moss
+roccella
+roccella tinctoria
+scale moss
+sphagnum
+sphagnum moss
+usnea barbata

--- a/lists/nature/plant-part.yml
+++ b/lists/nature/plant-part.yml
@@ -1,0 +1,506 @@
+---
+title: Plant parts
+category: nature
+description: "Visible botanical structures, organs, tissues, and growth forms"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abruptly-pinnate leaf
+accessory fruit
+acerate leaf
+acervulus
+achene
+acinus
+acorn
+acorn cup
+acuminate leaf
+adventitious root
+aeciospore
+aecium
+agamete
+aggregate fruit
+algarobilla
+algarroba bean
+algarrobilla
+ament
+amphitropous ovule
+amplexicaul leaf
+anatropous ovule
+androecium
+annulus
+anther
+antheridiophore
+antheridium
+apetalous flower
+apical placentation
+apothecium
+apple nut
+archegonium
+aril
+ascoma
+ascospore
+ascus
+ash-key
+axile placentation
+axis
+babassu nut
+bacca
+baneberry
+basal placentation
+basidiocarp
+basidiospore
+basidium
+bast
+beanstalk
+berry
+betel leaf
+bijugate leaf
+bijugous leaf
+bipinnate leaf
+blade
+bloom
+blossom
+bole
+bonduc nut
+bough
+branch
+branchlet
+briarroot
+buckthorn berry
+bud
+buffalo nut
+bulb
+bulbil
+bulblet
+button
+calabar bean
+calyptra
+calyx tube
+cambium
+campylotropous ovule
+cane
+cap
+capitulum
+carob bean
+carpel
+carpophore
+carpospore
+caryopsis
+castor bean
+cataphyll
+catkin
+caudex
+cedar nut
+cembra nut
+chalaza
+chicory root
+chlamydospore
+chlamys
+chlorenchyma
+cirrhus
+cladode
+cladophyll
+cleistocarp
+cleistothecium
+cocoyam
+cohune nut
+cola nut
+compound leaf
+compound pistil
+cone
+conidiospore
+conidium
+conker
+coquilla nut
+cordate leaf
+corm
+corn silk
+corn stalk
+cornsilk
+cornstalk
+corona
+cortina
+corymb
+cottonseed
+cotyledon
+coumara nut
+crenate leaf
+crustose thallus
+culm
+cuneate leaf
+cup
+cupule
+cutting
+cyme
+cymule
+dandelion green
+deadwood
+decompound leaf
+deltoid leaf
+dentate leaf
+denticulate leaf
+domatium
+drupe
+drupelet
+duct
+ear
+eddo
+elf cup
+elk nut
+elliptic leaf
+elongate leaf
+emarginate leaf
+endosperm
+endospore
+ensiform leaf
+entire leaf
+episperm
+erose leaf
+eusporangium
+even-pinnate leaf
+falls
+false fruit
+fava bean
+fern seed
+fibrovascular bundle
+fig leaf
+filament
+fir cone
+flesh
+floral cup
+floral envelope
+floral leaf
+floret
+flower bud
+flower cluster
+flower head
+flower petal
+flower stalk
+floweret
+foliage
+free central placentation
+frond
+fructification
+fruit
+fruiting body
+fruitlet
+funicle
+funiculus
+galbulus
+galea
+gall
+gametangium
+gametoecium
+gametophore
+garbanzo
+gemma
+germ tube
+gill
+gleba
+glomerule
+golden gram
+green gram
+green soy
+greenery
+gynobase
+gynoecium
+gynophore
+gynostegium
+hagberry
+halm
+hastate leaf
+haulm
+head
+hip
+honey gland
+horseradish root
+hottentot bread
+hottentot's bread
+hymenium
+hypanthium
+hypobasidium
+inflorescence
+ivory nut
+job's tears
+jumping bean
+jumping seed
+juniper berry
+kernel
+key
+key fruit
+lamella
+lamellate placentation
+lanceolate leaf
+laticifer
+leaf
+leaf blade
+leaf bud
+leafage
+leaflet
+leafstalk
+leptosporangium
+licorice root
+lignum
+ligule
+lily pad
+limb
+linear leaf
+lip
+lobe
+lobed leaf
+locust bean
+locust pod
+loment
+lyrate leaf
+macrosporangium
+macrospore
+malacca
+mandrake root
+marginal placentation
+mash bean
+mast
+mealie
+meat
+medullary ray
+megasporangium
+megaspore
+megasporophyll
+mentum
+mericarp
+meristem
+mexican jumping bean
+microsporangium
+microspore
+microsporophyll
+midrib
+midvein
+mixed bud
+monggo
+moong
+multiple fruit
+munggo
+mycelium
+nectary
+needle
+neem seed
+nervure
+nicker nut
+nicker seed
+nucellus
+nut
+nutlet
+oak apple
+oblanceolate leaf
+oblong leaf
+obovate leaf
+obtuse leaf
+odd-pinnate leaf
+offset
+oil nut
+oil-rich seed
+oilseed
+oospore
+orbiculate leaf
+ordeal bean
+orrisroot
+orthotropous ovule
+ovary
+ovate leaf
+ovule
+pad
+palm kernel
+palm nut
+palmate leaf
+pandurate leaf
+panduriform leaf
+panicle
+parallel-veined leaf
+parenchyma
+parietal placentation
+parted leaf
+partial veil
+pedate leaf
+pedicel
+pedicle
+peduncle
+peltate leaf
+perfoliate leaf
+perianth
+perigone
+perigonium
+perisperm
+perithecium
+petal
+petiole
+petiolule
+phloem
+phylloclad
+phylloclade
+phyllode
+pinecone
+pinna
+pinnate leaf
+pinnule
+pip
+pistil
+pistillode
+pitcher
+pith
+placenta
+placentation
+plant organ
+plant part
+plant structure
+plant tissue
+pneumatophore
+pod
+pollen
+pollen tube
+pollinium
+pome
+prickly-edged leaf
+promycelium
+prop root
+prophyll
+pseudocarp
+pseudophloem
+pulp
+pycnidium
+pyrene
+pyxidium
+pyxis
+quickset
+quinoa
+quinquefoliate leaf
+raceme
+rachis
+rapeseed
+rattan cane
+ray
+ray floret
+ray flower
+receptacle
+reniform leaf
+reproductive structure
+resting spore
+rhizome
+root
+root cap
+root hair
+rootlet
+rootstalk
+rootstock
+rose hip
+rosebud
+rosehip
+rosette
+rowanberry
+runcinate leaf
+runner
+safflower seed
+sagittate-leaf
+sagittiform leaf
+samara
+sarsaparilla root
+scale
+scale leaf
+scape
+schizocarp
+sclerotium
+scorpioid cyme
+seed
+seed coat
+seed leaf
+seedpod
+sepal
+septum
+serrate leaf
+shoot
+sieve tube
+simple fruit
+simple leaf
+simple pistil
+skirt
+slip
+sorus
+spadix
+spatulate leaf
+spike
+spikelet
+sporangiophore
+sporangium
+spore
+spore case
+spore sac
+sporocarp
+sporophore
+sporophyl
+sporophyll
+sprig
+sprout
+squamule
+stalk
+stamen
+stele
+stem
+stick
+stigma
+stipe
+stipule
+stolon
+stone fruit
+stool
+strobile
+strobilus
+stroma
+stump
+style
+stylopodium
+sucker
+syconium
+syncarp
+taproot
+teliospore
+tendril
+tepal
+testa
+tetrasporangium
+tetraspore
+thallus
+thyrse
+thyrsus
+tiller
+tracheid
+tree branch
+tree stump
+tree trunk
+trifoliolate leaf
+trunk
+tuber
+twice-pinnate
+twig
+umbel
+universal veil
+vascular bundle
+vascular ray
+vascular strand
+vascular tissue
+vegetable ivory
+veil
+vein
+velum
+ventral placentation
+verdure
+volva
+wand
+wheat berry
+withe
+withy
+xylem
+yellow berry
+zoospore
+zygospore

--- a/lists/nature/plant.yml
+++ b/lists/nature/plant.yml
@@ -1,60 +1,893 @@
 ---
 title: Plants
 category: nature
-description: "Common indoor houseplants and decorative potted foliage"
+description: "Plants, botanical groups, and decorative foliage"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+abronia elliptica
+abronia fragrans
+abronia latifolia
+abronia maritima
+abronia umbellata
+abronia villosa
+acerola
+aconite
+aconitum lycoctonum
+aconitum napellus
+acrogen
+actaea alba
+actaea rubra
+aerophyte
+aeschynanthus radicans
+aethusa cynapium
+african bowstring hemp
+african holly
+agave
+agave americana
+agave atrovirens
+agave cantala
+agave sisalana
+agave tequilana
+aglaonema modestum
 air plant
+allionia incarnata
 aloe vera
+alpine besseya
+alpine clubmoss
+alpine gold
+alpine goldenrod
+alpine hulsea
+alpine milk vetch
+alpine sunflower
+american agave
+american aloe
+american bugbane
+american dewberry
+american pasqueflower
+american pulsatilla
+american raspberry
+american star grass
+anemone ludoviciana
+anemone occidentalis
+anemone pulsatilla
+angiocarp
+angiosperm
+annual
+antheropeas wallacei
 anthurium
+anthurium andraeanum
+anthurium scherzerianum
+apocynum androsaemifolium
+apocynum cannabinum
+apocynum pumilum
+apomict
+aquatic
+aralia
+arborescent plant
+arnica bud
+arnica cordifolia
+arnica montana
+arrowleaf groundsel
+astragalus alpinus
+astragalus danicus
+astragalus glycyphyllos
+autophyte
+autophytic plant
+autotroph
+autotrophic organism
+bakeapple
+baked-apple berry
+ball nettle
+ball nightshade
+balloon flower
+balsam
+baptisia australis
+baptisia lactea
+baptisia tinctoria
+barbados cherry
+basket spikemoss
+beach aster
+beach goldenrod
+beach pancake
+beach sand verbena
+bear's foot
+bedder
+bedding plant
 begonia
+besseya alpina
+bicolor lespediza
+biennial
+bignoniad
 bird's nest fern
+bitterroot
+bittersweet nightshade
+black cohosh
+black hellebore
+black moss
+black nightshade
+black raspberry
+blackberry
+blackberry bush
+blackcap
+blackcap raspberry
+blackfoot daisy
+blanket flower
+blood berry
+bloodberry
+blue false indigo
+blue fleabane
+blue mountain tea
+blue tulip
+blue-eyed mary
+bluebonnet
 bonsai
+boott's goldenrod
 boston fern
+bowstring hemp
+boykinia elata
+boykinia occidentalis
+boysenberry
+boysenberry bush
+bramble
+bramble bush
+brittle bush
+brittlebush
+broad leaved goldenrod
 bromeliad
+buffalo bur
+bull nettle
+buphthalmum salicifolium
+burrawong
+bush clover
+bush lawyer
+calandrinia ciliata
 calathea
+california fern
+calyptridium umbellatum
+camphor daisy
+canadian goldenrod
+cantala
+cascade penstemon
+cash crop
 cast iron plant
+castilleja chromosa
+castilleja miniata
+castilleja sessiliflora
+castilleja sulphurea
+catch crop
+century plant
+ceratozamia
+ceylon bowstring hemp
+chemoautotroph
+chemotrophic autotroph
 chinese evergreen
+chinese lacquer tree
 chinese money plant
+christmas green
+christmas rose
+chrysopsis mariana
+chrysopsis villosa
+cicuta virosa
+cimicifuga americana
+cimicifuga foetida
+cimicifuga racemosa
+cliff penstemon
+climbing lily
+climbing nightshade
+cloudberry
+club moss
+clusia insignis
+clusia major
+clusia rosea
+coast boykinia
+cohosh
+collinsia bicolor
+collinsia heterophylla
+collinsia parviflora
+collinsia verna
+combretum
+common arrowhead
+common dogbane
+common horsetail
+common madia
+common nightshade
+common snowberry
+common tarweed
+conium maculatum
+coontie
+cormous plant
+cover crop
+creeper
 creeping fig
+creeping lily
+crop
 croton
+cryptogam
+cultivar
+cultivated plant
+cycad
+cycas circinalis
+cycas revoluta
+cyrilla family
+cyrilliaceae
+daisy fleabane
+daucus carota
+davidson's penstemon
+deciduous plant
+dense blazing star
+desert paintbrush
+desert plant
+desert sand verbena
+desert selaginella
+desert sunflower
+dewberry
+dewberry bush
+dicot
+dicotyledon
 dieffenbachia
+dioon
+dogbane
+doll's eyes
+dotted gayfeather
 dracaena
+dracaena draco
+dragon tree
 dumb cane
+dwarf daisy
+dwarf hulsea
+dwarf lycopod
+dwarf mulberry
+dyer's weed
+eastern pasque flower
+eastern poison oak
 echeveria
+edelweiss
+egyptian lupine
+elliott's goldenrod
+embryo
+encelia farinosa
+enceliopsis nudicaulis
+encephalartos
+encephalartos caffer
+endogen
+engelmannia
 english ivy
+epiphyte
+epiphytic plant
+equisetum arvense
+equisetum fluviatile
+equisetum hyemale
+equisetum hyemale robustum
+equisetum palustre
+equisetum robustum
+equisetum sylvaticum
+equisetum variegatum
+erigeron acer
+erigeron annuus
+erigeron aurantiacus
+erigeron divergens
+erigeron glaucus
+erigeron philadelphicus
+erigeron pulchellus
+erigeron speciosus
+eriophyllum lanatum
+eriophyllum wallacei
+eryngium yuccifolium
+escape
+european dewberry
+european pasqueflower
+european raspberry
+eustoma grandiflorum
+evergreen
+evergreen plant
+exacum affine
+exogen
+ezo-yama-hagi
+fall dandelion
+false alumroot
+false beachdrops
+false chamomile
+false sago
+family cyrilliaceae
 fern
+fern ally
+fern palm
+fetid bugbane
 fiddle leaf fig
+field crop
+field horsetail
+field lupine
+figwort
+fir clubmoss
+fire wheel
+flamingo flower
+flamingo plant
+florida arrowroot
+florida selaginella
+florist's gloxinia
+flowering maple
+flowering plant
+flowering raspberry
+foetid bugbane
+fool's parsley
+framboise
+fringe cups
+fringed grass of parnassus
+gaillardia
+gaillardia pulchella
+gametophyte
+garden huckleberry
+garden plant
+gay-feather
+gayfeather
+geophyte
+gerea canescens
+gesneriad
+giant red paintbrush
+gloriosa
+gloriosa superba
+glory lily
+gloxinia
+gloxinia perennis
+gloxinia speciosa
+goatsbeard
+golden aster
+golden yarrow
+golden-beard penstemon
+goldenrod
+goldfields
+grass-leaved golden aster
+gray goldenrod
+great plains paintbrush
+green hellebore
+grey goldenrod
+ground cedar
+ground fir
+gymnosperm
+gynura aurantiaca
+hairy golden aster
+halophyte
+haplopappus acaulis
+haplopappus phyllocephalus
+haplopappus spinulosus
+hawk's-beard
+hawk's-beards
+hawkbit
 haworthia
+heartleaf arnica
+heliopsis
+helleborus foetidus
+helleborus niger
+helleborus orientalis
+helleborus viridis
+helmet flower
+hemiepiphyte
+hemlock water dropwort
+herb christopher
+heterotheca villosa
+holophyte
+horse nettle
+horsefly weed
+horsetail
+hot-rock penstemon
+houseplant
 hoya
+hulsea algida
+hulsea nana
+hygrophyte
+hymenoxys acaulis
+hymenoxys grandiflora
+hypoxis hirsuta
+incienso
+indian blanket
+indian madder
+indian pipe
+indigo broom
+innocense
 jade plant
+jap clover
+japan clover
+japanese clover
+japanese lacquer tree
+japanese leaf
+japanese sumac
+jerusalem cherry
+jewels-of-opar
+jiqui
+jones' penstemon
+kaffir bread
+kangaroo apple
+kitten-tails
+kohleria
+korean lespedeza
+lacquer tree
+lantana
+lasthenia chrysostoma
+lawyer bush
+lawyerbush
+leatherleaf saxifrage
+lenten rose
+leontodon autumnalis
+leontopodium alpinum
+leptarrhena pyrolifolia
+lespedeza
+lespedeza bicolor
+lespedeza cuneata
+lespedeza sericea
+lespedeza stipulacea
+lespedeza striata
+lesser hemlock
+leucogenes leontopodium
+lewisia cotyledon
+lewisia rediviva
+liatris punctata
+liatris pycnostachya
+ligneous plant
+lignosae
+liliopsid
+lion's beard
+lipstick plant
+lithophragma parviflorum
+lithophyte
+lithophytic plant
+little club moss
+little clubmoss
+loganberry
+long moss
+long-head coneflower
+lowbush penstemon
+lupin
+lupine
+lupinus albus
+lupinus luteus
+lupinus subcarnosus
+lupinus texensis
+lycopod
+lycopodium alopecuroides
+lycopodium alpinum
+lycopodium clavatum
+lycopodium complanatum
+lycopodium lucidulum
+lycopodium obscurum
+lycopodium selago
+machaeranthera bigelovii
+machaeranthera tanacetifolia
+machaeranthera tortifoloia
+macrozamia
+macrozamia communis
+macrozamia spiralis
+madder
+madderwort
+madeira winter cherry
+madia elegans
+magnoliopsid
+maguey
+maiden blue-eyed mary
 maidenhair fern
+malpighia glabra
+malpighia obovata
 maranta
+markweed
+marsh horsetail
+maryland golden aster
+meadow goldenrod
+meadow rue
+meadow salsify
+meadow spikemoss
+megagametophyte
+melampodium leucanthum
+melilot
+melilotus
+melilotus alba
+melilotus officinalis
+mesophyte
+mesophytic plant
+mexican hat
+microflora
+microgametophyte
+milk vetch
+missouri goldenrod
+mojave aster
+monkshood
+monocarp
+monocarpic plant
+monocarpous plant
+monocot
+monocotyledon
+monotropa hypopithys
+monotropa uniflora
 monstera
+mountain clubmoss
+mountain pride
+mule's ears
+munjeet
+myrmecophyte
+narrow goldenrod
+narrow-leaf penstemon
+narrow-leaved flame flower
+nebraska fern
+neophyte
+nerium oleander
 nerve plant
+nightshade
+nodding groundsel
+nolina microcarpa
+non-flowering plant
+nonflowering plant
+north island edelweiss
+northern dewberry
+northern dune tansy
+oenanthe aquatica
+oenanthe crocata
+ohio goldenrod
+old man of the mountain
+oleander
+orange daisy
+orange fleabane
 orchid
+ornamental
+oxeye
+painted cup
+parnassia fimbriata
+parry's penstemon
+pasque flower
+pasqueflower
 peace lily
+penstemon barbatus
+penstemon centranthifolius
+penstemon cyananthus
+penstemon davidsonii
+penstemon deustus
+penstemon dolius
+penstemon fruticosus
+penstemon linarioides
+penstemon newberryi
+penstemon palmeri
+penstemon parryi
+penstemon rupicola
+penstemon rydbergii
+penstemon serrulatus
+penstemon whippleanus
 peperomia
+perennial
+persian violet
+phanerogam
+philadelphia fleabane
 philodendron
+pigmy talinum
 pilea
+pinesap
+pink sand verbena
+pipturus argenteus
+pitch apple
 pitcher plant
+plantlet
+platte river penstemon
+plectranthus
+poison ash
+poison dogwood
+poison hemlock
+poison parsley
+poison sumac
+poison-berry
+poisonberry
+poisonous nightshade
+poisonous plant
+poroporo
+pot plant
 pothos
+prairie anemone
+prairie berry
+prairie coneflower
+prairie gentian
+prairie golden aster
+prairie star
 prayer plant
+princess pine
+progymnosperm
+psilophyte
+psilophyton
+psilotum nudum
+pteridophyte
+pteridosperm
+pulsatilla occidentalis
+pulsatilla patens
+pulsatilla vulgaris
+purple chinese houses
+purple milk vetch
+purple nightshade
+purple velvet plant
+purple-flowering raspberry
+queen anne's lace
+queensland grass-cloth plant
+quillwort
+ranunculus glaberrimus
+raspberry
+raspberry bush
+ratibida columnaris
+ratibida columnifera
+ratibida tagetes
+rattle weed
+rattle-top
+rattlesnake master
+rattlesnake's master
+ravenala
+ravenala madagascariensis
+red baneberry
+red maids
+red raspberry
+redmaids
+rheumatism weed
+rhus diversiloba
+rhus quercifolia
+rhus radicans
+rhus toxicodenedron
+rhus verniciflua
+rhus vernix
+rivina humilis
+robin's plantain
+rock penstemon
+rock pink
+rock plant
+rock spikemoss
+rocky mountain dogbane
+root crop
+rose bay
+rouge plant
+rougeberry
+rough horsetail
+rough-stemmed goldenrod
+royal velvet plant
 rubber plant
+rubia cordifolia
+rubia tinctorum
+rubiaceous plant
+rubus australis
+rubus caesius
+rubus canadensis
+rubus chamaemorus
+rubus cissoides
+rubus cuneifolius
+rubus flagellaris
+rubus fruticosus
+rubus hispidus
+rubus idaeus
+rubus idaeus strigosus
+rubus loganobaccus
+rubus occidentalis
+rubus odoratus
+rubus parviflorus
+rubus phoenicolasius
+rubus saxatilis
+rubus spectabilis
+rubus strigosus
+rubus trivialis
+rubus ursinus
+rubus ursinus loganobaccus
+running blackberry
+running pine
+rupestral plant
+rupestrine plant
+rupicolous plant
+rydberg's penstemon
+sagebrush buttercup
+salmon berry
+salmonberry
+sand blackberry
+sand verbena
+sansevieria guineensis
+sansevieria trifasciata
+sansevieria zeylanica
+sarcodes sanguinea
+saxicolous plant
+scarlet bugler
+scented penstemon
 schefflera
+scouring rush
+seaside daisy
+seaside goldenrod
+seed fern
+seed plant
+seedling
+selaginella apoda
+selaginella eatonii
+selaginella eremophila
+selaginella lepidophylla
+selaginella rupestris
+semiepiphyte
+seminole bread
 sempervivum
+senecio bigelovii
+senecio glabellus
+senecio triangularis
 sensitive plant
+sericea lespedeza
+setterwort
+shepherd's clock
+shining clubmoss
+showy daisy
+showy goldenrod
+shrubby penstemon
+sickleweed golden aster
+silver-leaved nettle
+silver-leaved nightshade
+silverleaf nightshade
+silverrod
+sinningia speciosa
+sisal
+siskiyou lewisia
+skeleton fork fern
 snake plant
+snakeberry
+snow plant
+snowball
+snowberry
+solanum aviculare
+solanum burbankii
+solanum carolinense
+solanum dulcamara
+solanum elaeagnifolium
+solanum giganteum
+solanum melanocerasum
+solanum nigrum
+solanum nigrum guineese
+solanum pseudocapsicum
+solanum rostratum
+solidago bicolor
+solidago canadensis
+solidago missouriensis
+solidago multiradiata
+solidago nemoralis
+solidago odora
+solidago rugosa
+solidago sempervirens
+solidago spathulata
+southern dewberry
+spanish moss
+spermatophyte
 spider plant
+spike moss
+spikemoss
+spiny talinum
+sporophyte
+spotted cowbane
+spotted hemlock
+spotted water hemlock
+spraguea umbellatum
+spreading dogbane
+spreading fleabane
 staghorn fern
+staghorn moss
+stemless golden weed
+stemless hymenoxys
+stenotus acaulis
+sticky aster
+stinking hellebore
+stone bramble
+strangler
+strangler tree
 string of hearts
 string of pearls
 succulent
+sulfur paintbrush
+summer cohosh
+sunberry
 sundew
+sunray
+swamp blackberry
+swamp dewberry
+swamp horsetail
 swedish ivy
+sweet clover
+sweet goldenrod
+sweet sand verbena
 swiss cheese plant
+symphoricarpos alba
+tahoka daisy
+tail-flower
+tailflower
+talinum augustissimum
+talinum aurantiacum
+talinum brevifolium
+talinum calycinum
+talinum paniculatum
+talinum spinescens
+tall goldenrod
+tanacetum douglasii
+tansy leaf aster
+tellima grandiflora
+tetraneuris acaulis
+tetraneuris grandiflora
+texas bluebonnet
+thallophyte
+thimbleberry
+tiarella unifoliata
 tillandsia
+tillandsia usneoides
+titi family
+toxicodendron diversilobum
+toxicodendron quercifolium
+toxicodendron radicans
+toxicodendron vernicifluum
+toxicodendron vernix
+tracheophyte
+tragopogon dubius
+tragopogon pratensis
+trailing four o'clock
+trailing windmills
+traveler's tree
+traveller's tree
+tree clubmoss
+trompillo
+true blackberry
+tuberous plant
+tulip gentian
 umbrella tree
+variegated horsetail
+variegated scouring rush
+vascular plant
 venus flytrap
+water dropwort
+water fennel
+water hemlock
+water horsetail
+welwitschia
+welwitschia mirabilis
+west indian cherry
+western blackberry
+western dewberry
+western pasqueflower
+western poison oak
+whipple's penstemon
+whisk fern
+white baneberry
+white bead
+white cohosh
+white false indigo
+white horse nettle
+white lupine
+white melilot
+white sweet clover
+white-rayed mule's ears
+wild carrot
+wild crocus
+wild flower
+wild indigo
+wild raspberry
+wildflower
+wilding
+winter fern
+winter rose
+wolf bean
+wolf's bane
+wolfbane
+wolfsbane
+wonderberry
+wood horsetail
+woodland oxeye
+woody nightshade
+woody plant
+woolly daisy
+woolly sunflower
+wyethia amplexicaulis
+wyethia helianthoides
+xerophile
+xerophilous plant
+xerophyte
+xerophytic plant
+yellow lupine
+yellow salsify
+yellow sand verbena
+yellow spiny daisy
+yellow sweet clover
 yucca
+zamia
+zamia pumila
 zebra plant
+zigzag goldenrod
 zz plant

--- a/lists/nature/shrub.yml
+++ b/lists/nature/shrub.yml
@@ -1,0 +1,2043 @@
+---
+title: Shrubs
+category: nature
+description: "Woody shrubs, bushes, and low-growing perennial plants"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abelia
+abelmoschus moschatus
+abelmosk
+absinthe
+abutilon theophrasti
+acalypha virginica
+action plant
+adam's apple
+adam's needle
+adam's needle-and-thread
+adenium multiflorum
+adenium obesum
+aeonium haworthii
+african hemp
+alder buckthorn
+alder dogwood
+alder-leaved serviceberry
+alderleaf juneberry
+alexandria senna
+alexandrian senna
+allegheny mountain spurge
+allegheny spurge
+alpine azalea
+alpine bearberry
+alpine golden chain
+alpine totara
+althaea
+althea
+althea officinalis
+althea rosea
+amatungulu
+amelanchier alnifolia
+amelanchier bartramiana
+american angelica tree
+american barberry
+american cranberry
+american cranberry bush
+american elder
+american feverfew
+american fly honeysuckle
+american germander
+american laurel
+american red elder
+american smokewood
+american spicebush
+american spikenard
+american twinflower
+amorpha
+amorpha californica
+amorpha canescens
+amorpha fruticosa
+amsonia tabernaemontana
+amur privet
+anadenanthera colubrina
+anagyris foetida
+andromeda
+andromeda glaucophylla
+andromeda polifolia
+angel's trumpet
+anil
+anthyllis barba-jovis
+apalachicola rosemary
+apple of peru
+arabian jasmine
+aralia elata
+aralia hispida
+aralia nudicaulis
+aralia racemosa
+aralia spinosa
+aralia stipulata
+arbutus
+arbutus menziesii
+arbutus unedo
+arctium lappa
+arctium minus
+arctostaphylos alpina
+arctostaphylos andersonii
+arctostaphylos manzanita
+arctostaphylos tomentosa
+arctostaphylos uva-ursi
+ardisia crenata
+ardisia escallonoides
+ardisia paniculata
+argyranthemum frutescens
+argyroxiphium sandwicense
+aristotelia racemosa
+aristotelia serrata
+arizona wild cotton
+armeria maritima
+arrow wood
+artemis pontica
+artemisia
+artemisia abrotanum
+artemisia absinthium
+artemisia annua
+artemisia californica
+artemisia campestris
+artemisia cana
+artemisia dracunculus
+artemisia filifolia
+artemisia frigida
+artemisia gnaphalodes
+artemisia ludoviciana
+artemisia maritima
+artemisia spinescens
+artemisia stelleriana
+artemisia tridentata
+artemisia vulgaris
+asiatic sweetleaf
+aspalathus cedcarbergensis
+aspalathus linearis
+asperula tinctoria
+astroloma humifusum
+atriplex hymenelytra
+atriplex lentiformis
+australian grass tree
+australian heath
+australian honeysuckle
+avaram
+avens
+axseed
+azalea
+babies' slippers
+baby rose
+baccharis halimifolia
+baccharis pilularis
+baccharis viminea
+bacon and eggs
+balibago
+banksia
+banksia integrifolia
+banksia rose
+barbasco
+barberry
+barilla
+bartram juneberry
+basket flower
+bassia scoparia
+bastard indigo
+bastard pennyroyal
+bastard pimpernel
+batis maritima
+batoko palm
+bauhinia monandra
+bay myrtle
+bay-leaved caper
+beach heather
+beach wormwood
+bean caper
+bean trefoil
+bear grass
+bear's grape
+bearwood
+beauty bush
+beef plant
+beefsteak plant
+beggar lice
+beggar-ticks
+beggar's lice
+beggar's-ticks
+beggarweed
+bell heather
+bell pepper
+belvedere
+bengal bean
+bengal rose
+benghal bean
+benjamin bush
+bennet
+benzoin odoriferum
+berberis canadensis
+berberis thunbergii
+berberis vulgaris
+bidens bipinnata
+bidens connata
+bidens coronata
+bidens trichosperma
+bidens tripartita
+big sagebrush
+bilberry
+bimli
+bimli hemp
+bird of paradise
+bird pepper
+bird-on-the-wing
+bird's foot clover
+bird's foot trefoil
+bird's-eye bush
+biscutella laevigata
+bitter cassava
+bitter pea
+bitter-bark
+black bead
+black bearberry
+black currant
+black elder
+black elderberry
+black greasewood
+black haw
+black huckleberry
+black knapweed
+black sage
+black sumac
+blackthorn
+bladder ketmia
+bladder senna
+blaeberry
+blolly
+bloodleaf
+blue cohosh
+blue curls
+blue elder
+blue elderberry
+blue mahoe
+blue sage
+blue star
+blueberry
+blueberry bush
+blueberry root
+blunt-leaf heath
+bog bilberry
+bog kalmia
+bog laurel
+bog rosemary
+bog whortleberry
+bombay hemp
+boojum tree
+bourtree
+box
+box huckleberry
+boxthorn
+boxwood
+bracelet wood
+brassaia actinophylla
+brazilian potato tree
+brewer's mountain heather
+briar
+bridal wreath
+brier
+bristly locust
+bristly sarsaparilla
+bristly sarsparilla
+broom
+broom snakeroot
+broom snakeweed
+broom tree
+broom-weed
+broomweed
+bruckenthalia spiculifolia
+brugmansia arborea
+brugmansia sanguinea
+brugmansia suaveolens
+brunfelsia americana
+bryanthus
+bryanthus taxifolius
+buckler mustard
+buckthorn
+bud brush
+bud sagebrush
+buddleia
+bumelia lanuginosa
+bumelia lycioides
+bur marigold
+burdock
+burning bush
+burr marigold
+bush
+bush hibiscus
+bush honeysuckle
+bush poppy
+bushman's poison
+butcher's broom
+butter-print
+butterfly bush
+butterfly flower
+buxus sempervirens
+cactus euphorbia
+caesalpinia decapetala
+caesalpinia gilliesii
+caesalpinia pulcherrima
+caesalpinia sepiaria
+cajan pea
+cajanus cajan
+calico bush
+california allspice
+california beauty
+california buckthorn
+california buckwheat
+california coffee
+california fuchsia
+california privet
+california redbud
+california romero
+california sage
+california sagebrush
+california tree poppy
+calliandra
+callirhoe digitata
+callirhoe involucrata
+callirhoe triangulata
+calluna vulgaris
+caltrop
+calycanthus floridus
+calycanthus occidentalis
+camelia
+camellia
+camellia japonica
+camellia sinensis
+camphorweed
+candelilla
+candleberry
+candlewood
+candyweed
+canella alba
+canella winterana
+cape jasmine
+cape jessamine
+caper
+caper spurge
+caper tree
+capparis arborea
+capparis cynophallophora
+capparis flexuosa
+capparis mitchellii
+capparis spinosa
+capsicum
+capsicum annuum cerasiforme
+capsicum annuum conoides
+capsicum annuum grossum
+capsicum annuum longum
+capsicum baccatum
+capsicum frutescens
+capsicum frutescens baccatum
+capsicum pepper plant
+caragana
+caragana arborescens
+caragana sinica
+caricature plant
+carissa
+carissa bispinosa
+carissa grandiflora
+carissa macrocarpa
+carolina allspice
+carolina buckthorn
+carpenteria
+carpenteria californica
+casava
+cascara buckthorn
+cascarilla
+cassava
+cassia acutifolia
+cassia alata
+cassia augustifolia
+cassia auriculata
+cassia fasciculata
+cassia occidentalis
+cassia tora
+cassiope mertensiana
+castor bean plant
+castor-oil plant
+cat thyme
+cat's-claw
+catclaw
+catgut
+catha edulis
+catjang pea
+caulophyllum thalictrioides
+caulophyllum thalictroides
+cayenne
+cayenne pepper
+centaurea americana
+centaurea calcitrapa
+centaurea cineraria
+centaurea gymnocarpa
+centaurea nigra
+centaurea scabiosa
+centauria calcitrapa
+centaury
+cercis occidentalis
+cestrum diurnum
+cestrum nocturnum
+chaenomeles japonica
+chaenomeles speciosa
+chaffweed
+chalice vine
+chamaecrista fasciculata
+chamaecytisus palmensis
+chamaedaphne calyculata
+chanal
+chanar
+chaparral broom
+chaparral mallow
+chaparral pea
+checkerberry
+checkerbloom
+cheese
+cheeseflower
+cherokee rose
+cherry pepper
+chile hazel
+chile nut
+chilean firebush
+chilean flameflower
+chilean hazelnut
+chilean nut
+chilean rimu
+chili pepper
+chilli pepper
+chilopsis linearis
+chimonanthus praecox
+china jute
+china rose
+chinese angelica
+chinese angelica tree
+chinese hibiscus
+chinese holly
+chinese pea tree
+chinese privet
+chiococca alba
+chittamwood
+chittimwood
+chocolate root
+christ plant
+christ thorn
+christ's-thorn
+christmas berry
+christmas flower
+christmas star
+christmasberry
+chrysanthemum frutescens
+chrysolepis sempervirens
+chrysothamnus nauseosus
+cineraria maritima
+cinquefoil
+cirio
+cistus albidus
+cistus ladanifer
+cistus ladanum
+cleome pinnata
+clethra alnifolia
+clianthus
+clianthus formosus
+clianthus puniceus
+clianthus speciosus
+cliff rose
+climbing hydrangea
+clotbur
+clover-root
+cloveroot
+clustered poppy mallow
+coachwhip
+coast banksia
+coast rhododendron
+cocklebur
+cockspur hawthorn
+cockspur thorn
+codariocalyx motorius
+codiaeum variegatum
+coffee rose
+coffee senna
+coffeeberry
+coloradillo
+columnea
+colutea arborescens
+combretum bracteosum
+common barberry
+common bearberry
+common bog rosemary
+common box
+common broom
+common burdock
+common caper
+common elder
+common flat pea
+common gum cistus
+common heath
+common jasmine
+common laburnum
+common lilac
+common mallow
+common matrimony vine
+common milkwort
+common mugwort
+common privet
+common rose mallow
+common spindle tree
+common st john's wort
+common thorn apple
+common wormwood
+compass plant
+comptonia asplenifolia
+comptonia peregrina
+cone pepper
+confederate rose
+confederate rose mallow
+connemara heath
+conradina glabra
+consumption weed
+coral bush
+coral gem
+coral honeysuckle
+coralberry
+corchorus
+cordyline terminalis
+corkwood
+corkwood tree
+cornish heath
+coronilla
+coronilla varia
+cotinus americanus
+cotinus coggygria
+cotinus obovatus
+cotoneaster
+cotoneaster dammeri
+cotoneaster horizontalis
+cotton
+cotton plant
+cotton rose
+cotton-seed tree
+coville
+cowage
+cowberry
+coyote brush
+coyote bush
+crampbark
+cranberry
+cranberry bush
+cranberry heath
+cranberry tree
+crape jasmine
+crape myrtle
+crataegus aestivalis
+crataegus apiifolia
+crataegus biltmoreana
+crataegus calpodendron
+crataegus coccinea
+crataegus coccinea mollis
+crataegus crus-galli
+crataegus laevigata
+crataegus marshallii
+crataegus mollis
+crataegus monogyna
+crataegus oxyacantha
+crataegus oxycantha
+crataegus pedicellata
+crataegus tomentosa
+creashak
+creeping snowberry
+creeping st john's wort
+creeping wintergreen
+creosote bush
+crepe flower
+crepe gardenia
+crepe jasmine
+crepe myrtle
+crocanthemum canadense
+cross-leaved heath
+croton eluteria
+croton tiglium
+crowberry
+crown of thorns
+crown vetch
+crystal tea
+cuban bast
+cube
+cudweed
+cupflower
+currant
+currant bush
+cushion flower
+cycloloma atriplicifolium
+cypress spurge
+cyrilla
+cyrilla racemiflora
+cytesis proliferus
+cytisus albus
+cytisus multiflorus
+cytisus ramentaceus
+cytisus scoparius
+daboecia cantabrica
+dacridium laxifolius
+dahl
+daisy-bush
+daisybush
+dalea spinosa
+dalmatian laburnum
+damask rose
+danewort
+dangle-berry
+dangleberry
+daphne
+daphne cneorum
+daphne laureola
+daphne mezereum
+darling pea
+datura arborea
+datura sanguinea
+datura stramonium
+datura suaveolens
+day jessamine
+deccan hemp
+decumaria barbara
+decumaria barbata
+decumary
+deer grass
+deerberry
+derris
+desert holly
+desert olive
+desert pea
+desert plume
+desert rose
+desert willow
+desmodium gyrans
+desmodium motorium
+desmodium purpureum
+desmodium tortuosum
+deutzia
+devil's milk
+devil's walking stick
+devil's weed
+dhal
+diapensia
+diervilla lonicera
+diervilla sessilifolia
+dirca palustris
+dog hobble
+dog laurel
+dog rose
+dombeya
+dovyalis caffra
+downy haw
+downy manzanita
+dryas octopetala
+dryland berry
+dryland blueberry
+duke of argyll's tea tree
+dusty miller
+dwarf bilberry
+dwarf blueberry
+dwarf elder
+dwarf golden chinkapin
+dwarf spurge
+dwarf sumac
+dyer's greenweed
+dyer's woodruff
+dyer's-broom
+dyeweed
+east indian rosebay
+eglantine
+egyptian cotton
+elaeagnus augustifolia
+elaeagnus commutata
+elaeagnus latifolia
+elder
+elderberry
+elderberry bush
+embothrium coccineum
+english hawthorn
+english lavender
+epacris
+epacris impressa
+epacris obtusifolia
+epacris purpurascens
+ephedra
+ephedra sinica
+epigaea repens
+epilobium canum canum
+erica
+erica arborea
+erica carnea
+erica cinerea
+erica lusitanica
+erica perspicua
+erica tetralix
+erica vagans
+erigonum fasciculatum
+eringo
+eriodictyon californicum
+eriogonum
+eriogonum allenii
+eryngium maritimum
+eryngo
+erythroxylon truxiuense
+estragon
+euonymous alatus
+euonymus alatus
+euonymus americanus
+euonymus atropurpureus
+euonymus europaeus
+euphorbia amygdaloides
+euphorbia antisyphilitica
+euphorbia caput-medusae
+euphorbia corollata
+euphorbia cyathophora
+euphorbia cyparissias
+euphorbia dentata
+euphorbia esula
+euphorbia exigua
+euphorbia fulgens
+euphorbia helioscopia
+euphorbia heterophylla
+euphorbia ingens
+euphorbia lathyris
+euphorbia marginata
+euphorbia medusae
+euphorbia milii
+euphorbia peplus
+euphorbia pulcherrima
+euphorbia villosa
+european barberry
+european beggar-ticks
+european black currant
+european box
+european cranberry
+european cranberry bush
+european cranberrybush
+european elder
+european fly honeysuckle
+european honeysuckle
+european red elder
+evergreen blueberry
+evergreen huckleberry
+evergreen thorn
+fabiana imbricata
+fall-blooming hydrangea
+false azalea
+false buckthorn
+false heather
+false indigo
+false mallow
+false pimpernel
+false sarsaparilla
+false tamarisk
+farkleberry
+february daphne
+feijoa
+feijoa bush
+fetter bush
+fetterbush
+field wormwood
+fine-leaved heath
+fire bush
+fire thorn
+fire-on-the-mountain
+firethorn
+five-finger
+flacourtia indica
+flamboyant tree
+flame bush
+flame pea
+flannel bush
+flannelbush
+flat pea
+florida bean
+flower-of-an-hour
+flowering hazel
+flowering quince
+flowering shrub
+flowering spurge
+flowering wintergreen
+flowers-of-an-hour
+fly honeysuckle
+fool's huckleberry
+forestiera
+forestiera neomexicana
+forsythia
+fothergilla
+fouquieria columnaris
+fouquieria splendens
+foxberry
+fragrant sumac
+francoa ramosa
+frangipani
+frangipanni
+french honeysuckle
+french lavender
+fringed polygala
+fringed poppy mallow
+frost-weed
+frostweed
+frostwort
+fuchsia
+fuchsia coccinea
+fuchsia excorticata
+furze
+gand flower
+ganja
+garden current
+gardenia
+gardenia augusta
+gardenia jasminoides
+gari
+garland flower
+gastrolobium
+gaultheria hispidula
+gaultheria procumbens
+gaultheria shallon
+gaylussacia baccata
+gaylussacia brachycera
+gaylussacia frondosa
+gaywings
+geebung
+genista anglica
+genista hispanica
+genista raetam
+genista tinctoria
+geoffroea decorticans
+georgia bark
+german tamarisk
+germander
+geum alleppicum strictum
+geum canadense
+geum macrophyllum
+geum rivale
+geum strictum
+geum triflorum
+geum urbanum
+geum virginianum
+ghost weed
+glade mallow
+glandular labrador tea
+glasswort
+globe mallow
+glory pea
+goat's rue
+golden chain
+golden heather
+golden rain
+goldenbush
+goose grass
+goose-tansy
+gooseberry
+gooseberry bush
+gorse
+gossypium arboreum
+gossypium barbadense
+gossypium herbaceum
+gossypium hirsutum
+gossypium peruvianum
+gossypium thurberi
+governor plum
+governor's plum
+graptophyllum pictum
+grass poly
+gray sage
+greasewood
+great burdock
+great knapweed
+great st john's wort
+greater burdock
+greater knapweed
+green broom
+greenweed
+grevillea
+grevillea banksii
+grevillea parallela
+grevillea robusta
+grevillea striata
+grewia asiatica
+grey sage
+griselinia littoralis
+griselinia lucida
+ground rose
+ground-berry
+groundberry
+groundsel bush
+groundsel tree
+grouse whortleberry
+grouse-berry
+grouseberry
+guayule
+guelder rose
+guevina avellana
+guevina heterophylla
+guinea flower
+guinea gold vine
+gutierrezia microcephala
+gutierrezia sarothrae
+gutierrezia texana
+hairy darling pea
+hairy honeysuckle
+hakea laurina
+hakea leucoptera
+hakea lissosperma
+halimodendron argenteum
+halimodendron halodendron
+hall's honeysuckle
+hamamelis vernalis
+hamamelis virginiana
+hamelia
+hamelia erecta
+hamelia patens
+hardheads
+haw
+hazardia cana
+he-huckleberry
+heartleaf manzanita
+heath
+heather
+heather bell
+hedge thorn
+hediondilla
+hedysarum boreale
+hedysarum coronarium
+helianthemum
+helianthemum canadense
+helianthemum scoparium
+helicteres isora
+herb bennet
+hermannia verticillata
+heteromeles arbutifolia
+hibiscus
+hibiscus cannabinus
+hibiscus elatus
+hibiscus farragei
+hibiscus heterophyllus
+hibiscus moschatus
+hibiscus moscheutos
+hibiscus mutabilis
+hibiscus sabdariffa
+hibiscus syriacus
+hibiscus tiliaceus
+hibiscus trionum
+hiccough nut
+hiccup nut
+high mallow
+high-bush blueberry
+highbush cranberry
+himalaya honeysuckle
+himalayan lilac
+hippocrepis comosa
+hoary golden bush
+hoary pea
+hog cranberry
+holly-leaves barberry
+hollygrape
+hollyhock
+honey bell
+honey mesquite
+honey-flower
+honeybells
+honeyflower
+honeypot
+honeysuckle
+horsebean
+horseshoe vetch
+hortensia
+hot pepper
+hovea
+huckleberry
+huckleberry oak
+hudsonia ericoides
+hudsonia tomentosa
+humble plant
+humming bird's trumpet
+hungarian lilac
+hydrangea
+hydrangea anomala
+hydrangea arborescens
+hydrangea macrophylla hortensis
+hydrangea paniculata
+hydrangea petiolaris
+hypericum androsaemum
+hypericum ascyron
+hypericum calycinum
+hypericum crux andrae
+hypericum gentianoides
+hypericum hypericoides
+hypericum maculatum
+hypericum perforatum
+hypericum prolificum
+hypericum pyramidatum
+hypericum spathulatum
+hypericum tetrapterum
+hypericum virginianum
+hyssop loosestrife
+ibolium privet
+ibota privet
+idria columnaris
+ilex cornuta
+iliamna acerifolia
+iliamna remota
+iliamna ruvularis
+impala lily
+indian beet
+indian cherry
+indian chocolate
+indian currant
+indian hemp
+indian mallow
+indian rhododendron
+indian senna
+indigo
+indigo plant
+indigofera anil
+indigofera suffruticosa
+indigofera tinctoria
+iresine herbstii
+iresine reticulata
+irish gorse
+irish strawberry
+italian honeysuckle
+italian woodbine
+jacob's staff
+jacquinia armillaris
+jacquinia keyensis
+jalapeno
+jamaica caper tree
+jamaica sorrel
+jamestown weed
+japan allspice
+japanese allspice
+japanese andromeda
+japanese angelica tree
+japanese barberry
+japanese honeysuckle
+japanese lilac
+japanese poinsettia
+japanese privet
+japanese quince
+japanese rose
+japanese snowbell
+japanese spurge
+japanese tree lilac
+japonica
+jasmine
+jasminum mesnyi
+jasminum nudiflorum
+jasminum officinale
+jasminum sambac
+jellyleaf
+jersey knapweed
+jerusalem sage
+jessamine
+jimson weed
+jimsonweed
+joewood
+joint fir
+jujube
+jujube bush
+juneberry
+juniper bush
+jupiter's beard
+kali
+kalmia
+kalmia angustifolia
+kalmia latifolia
+kalmia polifolia
+kanaf
+kapuka
+kei apple
+kei apple bush
+kelpwort
+kenaf
+kidney wort
+kiggelaria africana
+king protea
+kiss-me-over-the-garden-gate
+klammath weed
+knapweed
+kochia scoparia
+kolkwitzia amabilis
+konini
+kosteletzya virginica
+kudu lily
+labrador tea
+laburnum alpinum
+laburnum anagyroides
+lad's love
+ladies'-eardrop
+ladies'-eardrops
+lady-of-the-night
+lady's-eardrop
+lady's-eardrops
+lagerstroemia indica
+lambertia formosa
+lambkill
+large cranberry
+large periwinkle
+larrea tridentata
+lavandula angustifolia
+lavandula latifolia
+lavandula officinalis
+lavandula stoechas
+lavatera arborea
+lavender
+lavender cotton
+lead plant
+leadplant
+leadwort
+leafy spurge
+leatherleaf
+leatherwood
+ledum groenlandicum
+ledum palustre
+leiophyllum buxifolium
+leitneria floridana
+lemon sumac
+lentisk
+lepechinia calycina
+lepidothamnus fonkii
+lepidothamnus laxifolius
+lesser burdock
+lesser knapweed
+leucothoe
+leucothoe editorum
+leucothoe fontanesiana
+leucothoe racemosa
+levant cotton
+leycesteria formosa
+life-of-man
+ligustrum amurense
+ligustrum ibolium
+ligustrum japonicum
+ligustrum lucidum
+ligustrum obtusifolium
+ligustrum ovalifolium
+ligustrum vulgare
+lilac
+lily-of-the-valley tree
+lindera benzoin
+ling
+lingberry
+lingenberry
+lingonberry
+linnaea borealis
+linnaea borealis americana
+little-head snakeweed
+live-and-die
+lobster plant
+loiseleuria procumbens
+lomatia
+long pepper
+lonicera albiflora
+lonicera canadensis
+lonicera caprifolium
+lonicera dioica
+lonicera flava
+lonicera hirsuta
+lonicera involucrata
+lonicera japonica
+lonicera japonica halliana
+lonicera morrowii
+lonicera periclymenum
+lonicera sempervirens
+lonicera tatarica
+lonicera xylosteum
+loosestrife
+lotus americanus
+lotus berthelotii
+lotus corniculatus
+lotus tree
+low blueberry
+low st andrew's cross
+low-bush blueberry
+lupinus arboreus
+lupinus perennis
+lycium barbarum
+lycium carolinianum
+lycium halimifolium
+lyonia ligustrina
+lyonia lucida
+lyonia mariana
+lysiloma sabicu
+lythrum hyssopifolia
+lythrum salicaria
+madagascar jasmine
+madagascar plum
+madrona
+madrono
+mahagua
+mahernia verticillata
+mahoe
+mahonia aquifolium
+mahonia nervosa
+mahuang
+maidenhair berry
+maikoa
+majagua
+makomako
+malacothamnus fasciculatus
+male berry
+maleberry
+mallow
+malope
+malope trifida
+malosma laurina
+malva moschata
+malva neglecta
+malvastrum coccineum
+mandioc
+mandioca
+manihot dulcis
+manihot esculenta
+manihot utilissima
+manioc
+manzanita
+marguerite
+marguerite daisy
+marlberry
+marmalade bush
+marsh andromeda
+marsh mallow
+marsh rosemary
+marsh st-john's wort
+marsh tea
+marum
+mastic
+mastic tree
+matchbush
+matchweed
+matilija poppy
+matrimony vine
+maule's quince
+may
+mayflower
+mayhaw
+meadow beauty
+mealberry
+medinilla magnifica
+medusa's head
+melastoma malabathricum
+menziesia ferruginea
+menziesia pilosa
+mesquit
+mexican fire plant
+mexican flameleaf
+mezereon
+microstrobos niphophilus
+milk thistle
+milkweed
+milkwort
+mimosa pudica
+mimosa sensitiva
+minnie bush
+minniebush
+mock azalia
+mock privet
+mogdad coffee
+mole plant
+moor berry
+moorwort
+morrow's honeysuckle
+moss locust
+mountain andromeda
+mountain avens
+mountain azalea
+mountain blue berry
+mountain blueberry
+mountain box
+mountain cranberry
+mountain devil
+mountain fetterbush
+mountain grape
+mountain heath
+mountain hollyhock
+mountain rimu
+mountain rose
+mountain sumac
+mountain tea
+moxie plum
+mucuna
+mucuna aterrima
+mucuna deeringiana
+mucuna pruriens utilis
+mugwort
+mule fat
+multiflora
+multiflora rose
+mus rose
+musk mallow
+musk rose
+muskwood
+mutisia
+myrica cerifera
+myrica gale
+myrica pensylvanica
+myricaria germanica
+myrtle spurge
+mysore thorn
+naboom
+napaea dioica
+naranjilla
+natal plum
+native cranberry
+native fuchsia
+native holly
+native orange
+native pear
+native pomegranate
+needle furze
+needle palm
+needle-bush
+needle-wood
+needlebush
+needlewood
+nero's crown
+new zealand daisybush
+new zealand wine berry
+night jasmine
+night jessamine
+nitweed
+nut-leaved screw tree
+ochna serrulata
+ocotillo
+old man
+old woman
+old-maid's bonnet
+olearia argophylla
+olearia haastii
+oleaster
+ononis repens
+ononis spinosa
+orange grass
+orange milkwort
+ordeal tree
+oregon grape
+oregon holly grape
+othonna
+our lord's candle
+pachouli
+pachysandra
+pachysandra procumbens
+pachysandra terminalis
+pagoda tree
+paint leaf
+painted leaf
+paliurus spina-christi
+palma christ
+palma christi
+paloverde
+papoose root
+papooseroot
+paprika
+paradise flower
+paris daisy
+parkinsonia aculeata
+parrot's bill
+parry manzanita
+parsley haw
+parsley-leaved thorn
+parthenium argentatum
+parthenium integrifolium
+partridge pea
+patchouli
+patchouly
+pavonia
+pea tree
+pear haw
+pear hawthorn
+pedilanthus bracteatus
+pedilanthus pavonis
+pedilanthus tithymaloides
+pepper
+pepper bush
+pepper shrub
+periwinkle
+peruvian cotton
+petteria ramentacea
+petty morel
+petty spurge
+petty whin
+phalsa
+philadelphus
+philadelphus coronarius
+phlomis
+phlomis fruticosa
+photinia arbutifolia
+phyllodoce breweri
+phyllodoce caerulea
+pichi
+pickeringia montana
+pieris floribunda
+pieris japonica
+pig laurel
+pigeon pea
+pigeon-pea plant
+pimento
+pimiento
+pinckneya pubens
+pincushion hakea
+pine-weed
+pineweed
+pink fivecorner
+pinwheel
+pinwheel flower
+piptadenia macrocarpa
+pistacia lentiscus
+pitcher sage
+pithecellobium unguis-cati
+pixie
+pixy
+platylobium formosum
+playlobium obtusangulum
+plumbago europaea
+plumeria acutifolia
+plumeria alba
+podocarpus nivalis
+pogostemon cablin
+poinciana
+poinciana gilliesii
+poinciana pulcherrima
+poinsettia
+poison arrow plant
+poison bush
+poison pea
+polygala alba
+polygala lutea
+polygala paucifolia
+polygala senega
+polygala vulgaris
+polygonum orientale
+poppy mallow
+port jackson heath
+portuguese heath
+potato tree
+potentilla anserina
+poverty grass
+prairie bird's-foot trefoil
+prairie dock
+prairie lotus
+prairie mallow
+prairie sage
+prairie sagewort
+prairie smoke
+prairie trefoil
+pride of barbados
+primrose jasmine
+prince-of-wales'-heath
+prince's-feather
+prince's-plume
+princess feather
+privet
+privet andromeda
+prosopis glandulosa
+prosopis juliflora
+prosopis juliiflora
+prosopis pubescens
+protea
+protea cynaroides
+protea mellifera
+protea repens
+prunus besseyi
+prunus cuneata
+prunus laurocerasus
+prunus pumila
+prunus pumilla susquehanae
+prunus spinosa
+prunus susquehanae
+pseudowintera colorata
+puckerbush
+purau
+purple avens
+purple heather
+purple loosestrife
+purple pea
+purple poppy mallow
+pyracanth
+pyracantha
+pyxidanthera barbulata
+pyxie
+quail brush
+quail bush
+queensland hemp
+quercus vaccinifolia
+rabbit brush
+rabbit bush
+rabbit-eye blueberry
+rabbit-weed
+rabbiteye
+rabbiteye blueberry
+rabbitweed
+radyera farragei
+raetam
+ramontchi
+rauvolfia
+rauwolfia
+rauwolfia serpentina
+red angel's trumpet
+red bearberry
+red currant
+red false mallow
+red gram
+red haw
+red shrubby penstemon
+red sorrel
+red-berried elder
+red-berry
+red-flowered silky oak
+redberry
+redbird cactus
+redbird flower
+redwood penstemon
+rest-harrow
+restharrow
+retama raetam
+retem
+rhamnus californicus
+rhamnus carolinianus
+rhamnus croceus
+rhamnus frangula
+rhamnus purshianus
+rhododendron
+rhododendron californicum
+rhododendron maxima
+rhododendron maximum
+rhododendron viscosum
+rhus aromatica
+rhus copallina
+rhus glabra
+rhus laurina
+rhus ovata
+rhus trilobata
+rhus typhina
+ribes grossularia
+ribes nigrum
+ribes rubrum
+ribes sanguineum
+ribes sativum
+ribes uva-crispa
+richea dracophylla
+richea pandanifolia
+ricinus communis
+ringworm bush
+ringworm cassia
+ringworm shrub
+robinia hispida
+rock rose
+rockrose
+rocky mountains cherry
+roman wormwood
+romneya coulteri
+rooibos
+ropebark
+rosa banksia
+rosa canina
+rosa chinensis
+rosa damascena
+rosa eglanteria
+rosa laevigata
+rosa moschata
+rosa multiflora
+rosa odorata
+rosa pendulina
+rosa spithamaea
+rose
+rose acacia
+rose mallow
+rose of china
+rose of sharon
+rosebay
+rosebush
+roselle
+rozelle
+ruscus aculeatus
+rush rose
+russian cactus
+russian olive
+russian thistle
+russian tumbleweed
+sabicu
+sage brush
+sagebrush
+saint peter's wreath
+salal
+salsola kali
+salsola kali tenuifolia
+salsola soda
+salt marsh mallow
+salt tree
+saltbush
+saltwort
+sambucus caerulea
+sambucus canadensis
+sambucus ebulus
+sambucus nigra
+sambucus pubens
+sambucus racemosa
+sand berry
+sand cherry
+sand myrtle
+sand sage
+sandberry
+santolina chamaecyparissus
+sapphire berry
+sarcobatus vermiculatus
+sarcocephalus esculentus
+sarcocephalus latifolius
+scarlet bush
+scarlet hamelia
+scarlet haw
+scarlet plume
+scarlet sumac
+schefflera actinophylla
+schizophragma hydrangeoides
+scotch broom
+scotch gale
+scotch laburnum
+scots heather
+screw bean
+screw tree
+screwbean
+screwbean mesquite
+sea eryngium
+sea holly
+sea holm
+sea island cotton
+sea lavender
+sea pink
+sea wormwood
+seashore mallow
+semaphore plant
+seneca snakeroot
+senecio cineraria
+senega
+senega root
+senega snakeroot
+seneka snakeroot
+senga root
+senna
+senna alata
+senna alexandrina
+senna auriculata
+senna obtusifolia
+senna occidentalis
+sensitive pea
+seriphidium canum
+seriphidium maritimum
+seriphidium tridentatum
+shadblow
+shadbush
+shallon
+shame plant
+shining sumac
+shiny lyonia
+shittim
+shittimwood
+shoe black
+shoeblack plant
+shrub
+shrubby st john's wort
+shrublet
+shumac
+siberian pea tree
+sicklepod
+sida hermaphrodita
+sida rhombifolia
+sida spinosa
+sidalcea malviflora
+silk oak
+silky oak
+silver berry
+silver oak
+silver sage
+silver sagebrush
+silver-bush
+silverberry
+silverbush
+silversword
+silverweed
+silvery wormwood
+skunkbush
+sleeping hibiscus
+slender knapweed
+slipper plant
+slipper spurge
+small cranberry
+smoke bush
+smoke tree
+smooth darling pea
+smooth sumac
+snakeweed
+snow-in-summer
+snow-on-the-mountain
+snowbell
+soap tree
+soap-weed
+soapweed
+solandra guttata
+solanum macranthum
+solanum quitoense
+solanum wrightii
+sonchus oleraceus
+sorrel
+southern arrow wood
+southern buckthorn
+southernwood
+sow thistle
+spanish bayonet
+spanish broom
+spanish dagger
+spanish gorse
+spanish heath
+spanish needles
+sparkleberry
+sparmannia africana
+spartium junceum
+sphacele calycina
+sphaeralcea coccinea
+sphaeralcea fasciculata
+sphaeralcea remota
+spice bush
+spiceberry
+spicebush
+spike heath
+spike lavender
+spiked loosestrife
+spindle tree
+spindleberry
+spindleberry tree
+spiraea
+spiraea prunifolia
+spirea
+spoonleaf yucca
+spring heath
+spurge
+spurge laurel
+st andrews's cross
+st john's wort
+st peter's wort
+st. dabeoc's heath
+st. peter's wreath
+staff tree
+stagger bush
+staggerbush
+staghorn sumac
+stanleya pinnata
+star-thistle
+statice
+stephanotis
+stephanotis floribunda
+sticktight
+stingaree-bush
+stinking bean trefoil
+stinking elder
+stinking weed
+stizolobium deeringiana
+strawberry bush
+strawberry shrub
+strawberry tree
+streptosolen jamesonii
+strophanthus
+strophanthus kombe
+sturt pea
+sturt's desert pea
+styphelia humifusum
+styphelia triflora
+styptic weed
+styrax
+styrax japonicum
+styrax obassia
+styrax texana
+subshrub
+suffrutex
+sugar sumac
+sugar-bush
+sulla
+sumac
+sumach
+summer cypress
+summer damask rose
+summer haw
+summer sweet
+sun rose
+sun spurge
+sundial lupine
+sunrose
+swainsona galegifolia
+swainsona grandiflora
+swainsona greyana
+swamp azalea
+swamp blueberry
+swamp candleberry
+swamp fly honeysuckle
+swamp honeysuckle
+swamp mallow
+swamp rose mallow
+swampy beggar-ticks
+sweet bells
+sweet cassava
+sweet elder
+sweet fern
+sweet gale
+sweet pepper
+sweet pepper plant
+sweet pepperbush
+sweet shrub
+sweet vetch
+sweet wormwood
+sweetbriar
+sweetbrier
+switch-ivy
+symphoricarpos orbiculatus
+symplocus paniculata
+syrian bean caper
+syringa
+syringa amurensis japonica
+syringa emodi
+syringa josikaea
+syringa josikea
+syringa persica
+syringa reticulata
+syringa villosa
+syringa vulgaris
+tabasco pepper
+tabasco plant
+tabernaemontana divaricate
+tagasaste
+tall bilberry
+tall mallow
+tamarillo
+tamarisk
+tanglebush
+tanner's cassia
+tapioca plant
+tarragon
+tartarian honeysuckle
+tasman dwarf pine
+tea
+tea rose
+teaberry
+telegraph plant
+telopea oreades
+telopea speciosissima
+temple tree
+templetonia retusa
+tephrosia purpurea
+tephrosia virginiana
+teucrium canadense
+teucrium chamaedrys
+teucrium marum
+teucrium scorodonia
+texas snowbell
+texas snowbells
+thevetia neriifolia
+thevetia peruviana
+thin-leaved bilberry
+thorn apple
+three-seeded mercury
+thrift
+ti
+tick trefoil
+tickseed sunflower
+tinnevelly senna
+tollon
+toothed spurge
+tornillo
+touch-me-not
+toyon
+trailing arbutus
+tramp's spurge
+trapper's tea
+tree cotton
+tree fuchsia
+tree heath
+tree lupine
+tree mallow
+tree poppy
+tree tomato
+tribulus terestris
+tribulus terrestris
+trichostema dichotomum
+trichostema lanatum
+trichostema lanceolatum
+trifid beggar-ticks
+trifid bur marigold
+true heath
+true jasmine
+true senna
+trumpet flower
+trumpet honeysuckle
+trumpet vine
+tumbleweed
+turpentine camphor weed
+turpentine weed
+tutsan
+twinberry
+twinflower
+twist wood
+twistwood
+ulex europaeus
+umbrella plant
+undershrub
+upland cotton
+vaccinium angustifolium
+vaccinium arboreum
+vaccinium ashei
+vaccinium caespitosum
+vaccinium corymbosum
+vaccinium macrocarpon
+vaccinium membranaceum
+vaccinium myrsinites
+vaccinium myrtillus
+vaccinium ovatum
+vaccinium oxycoccus
+vaccinium pallidum
+vaccinium pennsylvanicum
+vaccinium scoparium
+vaccinium stamineum
+vaccinium uliginosum alpinum
+vaccinium vitis-idaea
+velvet bean
+velvet sumac
+velvet-leaf
+velvetleaf
+velvetweed
+venetian sumac
+vernal witch hazel
+viburnum dentatum
+viburnum lantana
+viburnum opulus
+viburnum prunifolium
+viburnum recognitum
+viburnum trilobum
+viminaria denudata
+viminaria juncea
+vinca major
+vinca minor
+vine cactus
+vinegar tree
+vinegarweed
+virginia mallow
+virginian sumac
+virginian witch hazel
+wahoo
+wall germander
+waratah
+wartweed
+wartwort
+water avens
+wax mallow
+waxberry
+waxflower
+waxmallow
+wayfaring tree
+weaver's broom
+weeping tree broom
+weigela
+weigela florida
+west indian jasmine
+west indian snowberry
+western honey mesquite
+western mugwort
+western redbud
+western sand cherry
+whin
+whinberry
+white avens
+white broom
+white cinnamon tree
+white currant
+white heather
+white honeysuckle
+white mallow
+white sage
+white spanish broom
+white thistle
+white titi
+white wax tree
+white-leaved rockrose
+whitethorn
+whortleberry
+wicopy
+wig tree
+wild buckwheat
+wild cotton
+wild cranberry
+wild hollyhock
+wild hydrangea
+wild lupine
+wild olive
+wild peach
+wild quinine
+wild rosemary
+wild sarsaparilla
+wild sarsparilla
+wild sensitive plant
+wild spurge
+wild sweet pea
+wineberry
+winged pigweed
+winged spindle tree
+winter currant
+winter hazel
+winter heath
+winter jasmine
+winter sweet
+wintera colorata
+wintergreen
+witch alder
+witch hazel
+witch hazel plant
+woadwaxen
+wolf's milk
+wood avens
+wood laurel
+wood sage
+wood spurge
+woodbine
+woodruff
+woodwaxen
+woody pear
+woolly manzanita
+wooly blue curls
+wormwood
+wormwood sage
+wych hazel
+wych hazel plant
+xylomelum pyriforme
+xylosma
+xylosma congestum
+yellow avens
+yellow bachelor's button
+yellow honeysuckle
+yellow milkwort
+yellow oleander
+yerba santa
+yucca aloifolia
+yucca baccata
+yucca brevifolia
+yucca carnerosana
+yucca elata
+yucca filamentosa
+yucca glauca
+yucca gloriosa
+yucca smalliana
+yucca whipplei
+zauschneria californica
+ziziphus jujuba
+ziziphus lotus
+zygophyllum fabago

--- a/lists/nature/succulent.yml
+++ b/lists/nature/succulent.yml
@@ -1,0 +1,86 @@
+---
+title: Succulents
+category: nature
+description: "Water-storing plants adapted to dry environments"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acanthocereus pentagonus
+acanthocereus tetragonus
+aloe
+aloe ferox
+aporocactus flagelliformis
+ariocarpus fissuratus
+barrel cactus
+burn plant
+cactus
+cape aloe
+carnegiea gigantea
+carpobrotus edulis
+chichipe
+cholla
+christmas cactus
+coryphantha
+crab cactus
+dorotheanthus bellidiformis
+easter cactus
+echinocactus
+echinocactus grusonii
+epiphyllum
+feather ball
+flowering stone
+garambulla
+garambulla cactus
+golden barrel cactus
+hatiora gaertneri
+hedgehog cactus
+hedgehog cereus
+hottentot fig
+hottentot's fig
+knowlton's cactus
+lemaireocereus chichipe
+lithops
+living granite
+living rock
+living stone
+livingstone daisy
+lophophora williamsii
+mammillaria
+mammillaria plumosa
+mesembryanthemum edule
+mezcal
+mistletoe cactus
+myrtillocactus geometrizans
+nopal
+opuntia cholla
+opuntia lindheimeri
+opuntia tuna
+orchid cactus
+pediocactus knowltonii
+pitahaya
+pitahaya cactus
+prickly pear
+prickly pear cactus
+rainbow cactus
+rat's-tail cactus
+rattail cactus
+saguaro
+sahuaro
+schlumbergera baridgesii
+schlumbergera buckleyi
+schlumbergera gaertneri
+schlumbergera truncatus
+selenicereus grandiflorus
+sour fig
+stone life face
+stone mimicry plant
+stone plant
+stone-face
+stoneface
+thanksgiving cactus
+tuna
+zygocactus truncatus

--- a/lists/nature/tree.yml
+++ b/lists/nature/tree.yml
@@ -2,162 +2,2797 @@
 title: Trees
 category: nature
 description: "Assorted tree species, fruiting trees, and woody plants"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+aalii
+abele
+abies alba
+abies amabilis
+abies balsamea
+abies bracteata
+abies concolor
+abies fraseri
+abies grandis
+abies lasiocarpa
+abies lowiana
+abies venusta
+acacia auriculiformis
+acacia cambegei
+acacia catechu
+acacia dealbata
+acacia farnesiana
+acacia melanoxylon
+acacia pycnantha
+acacia xanthophloea
+acer argutum
+acer campestre
+acer circinatum
+acer glabrum
+acer japonicum
+acer macrophyllum
+acer negundo
+acer negundo californicum
+acer palmatum
+acer pennsylvanicum
+acer platanoides
+acer pseudoplatanus
+acer rubrum
+acer saccharinum
+acer saccharum
+acer spicatum
+achras zapota
+acrocarpus fraxinifolius
+acrocomia aculeata
+acrocomia vinifera
+adansonia digitata
+adansonia gregorii
+adenanthera pavonina
+aegiceras majus
+aesculus hippocastanum
+african mahogany
+african oil palm
+african sandalwood
+african scented mahogany
+african walnut
+african yellowwood
+afrocarpus falcata
+agathis alba
+agathis australis
+agathis dammara
+agathis lanceolata
+agathis robusta
+ailanthus
+ailanthus altissima
+akee
+akee tree
+alaska cedar
+albizia
+albizia julibrissin
+albizia lebbeck
+albizia saman
+albizzia
+albizzia julibrissin
+albizzia lebbeck
 alder
+alder tree
+aleurites fordii
+aleurites moluccana
+alexandrian laurel
+algarroba
+alleghany plum
+allegheny chinkapin
+allegheny plum
+allspice
+allspice tree
 almond
+almond tree
+almond willow
+almond-leaves willow
+alnus crispa
+alnus glutinosa
+alnus incana
+alnus maritima
+alnus rhombifolia
+alnus rubra
+alnus rugosa
+alnus serrulata
+alnus veridis crispa
+alnus viridis
+alnus vulgaris
+alpine ash
+alpine celery pine
+alpine fir
+alstonia scholaris
+amabilis fir
+amarelle
+amboina pine
+amboyna
+amboyna pine
+american arborvitae
+american aspen
+american basswood
+american chestnut
+american crab apple
+american dogwood
+american dwarf birch
+american elm
+american gray birch
+american grey birch
+american hackberry
+american hazel
 american holly
+american hornbeam
+american larch
+american lime
+american mountain ash
+american oil palm
+american olive
+american persimmon
+american plane
+american quaking aspen
+american red plum
+american sweet chestnut
+american sweet gum
 american sweetgum
+american sycamore
+american turkey oak
+american white birch
+american white oak
+american white pine
+amygdalus communis
+amygdalus communis amara
+anacardium occidentale
+anchovy pear
+anchovy pear tree
+ancient pine
+andaman marble
+andelmin
+andira inermis
+angelim
+angiospermous tree
+angiospermous yellowwood
+anise tree
+annona cherimola
+annona diversifolia
+annona glabra
+annona muricata
+annona reticulata
+annona squamosa
 apple
+apple tree
 apricot
+apricot tree
+arabian coffee
+arariba
+araucaria araucana
+araucaria bidwillii
+araucaria columnaris
+araucaria cunninghamii
+araucaria excelsa
+araucaria heterophylla
+arbor
+arborvitae
+arctic willow
+areca
+areca catechu
+areca palm
+arenga pinnata
+arere
+arishth
+arizona ash
 arizona cypress
+arizona sycamore
+arizona white oak
+aroeira blanca
+arolla pine
+arroyo willow
+artocarpus altilis
+artocarpus communis
+artocarpus heterophyllus
+artocarpus odoratissima
 ash
+ash tree
+ash-leaved maple
+asimina triloba
 aspen
+aspen poplar
+assam rubber
+astronium fraxinifolium
+athrotaxis selaginoides
 atlantic white cedar
+atlas cedar
+attalea funifera
+august plum
+australian chestnut
+australian nettle
+australian nettle tree
+australian pine
+australian sumac
+austrocedrus chilensis
+austrotaxus spicata
+averrhoa bilimbi
+averrhoa carambola
+avicennia marina
+avicennia officinalis
+avocado
+avocado tree
+azadirachta indica
+azedarach
+azederach
+babassu
+babassu palm
+babylonian weeping willow
+bahia coquilla
+bahia piassava
+balata
+balata tree
+bald cypress
 baldcypress
+balm of gilead
 balsam fir
+balsam poplar
+balsam willow
 bamboo
+bamboo palm
 banana
+banian
+banian tree
 banyan
+banyan tree
 baobab
+baphia nitida
+barbados pride
+basket ash
+basket oak
+basket willow
 basswood
+bastard lignum vitae
+bastard yellowwood
+bauhinia variegata
+bay laurel
+bay tree
+bay willow
+bay-rum tree
+bayberry
+beach plum
+beach plum bush
+bead tree
+beaked hazelnut
+bean tree
+bear oak
+bearberry
+bearberry willow
+bechtel crab
 beech
+beech tree
+beefwood
+bendy tree
+bergamot
+bergamot orange
+bertholletia excelsa
+betel palm
+betula alleghaniensis
+betula cordifolia
+betula fontinalis
+betula glandulosa
+betula lenta
+betula leutea
+betula neoalaskana
+betula nigra
+betula papyrifera
+betula pendula
+betula populifolia
+betula pubescens
+big shagbark
+big shellbark
+big shellbark hickory
+big-bud hickory
+big-cone douglas fir
+big-cone spruce
+big-leaf maple
+big-toothed aspen
+big-tree plum
+bigarade
+bigtooth aspen
+bigtoothed aspen
+bilimbi
+bilsted
 birch
+birch tree
+bird cherry
+bird cherry tree
+bishop pine
+bishop's pine
+bitter almond
+bitter hickory
+bitter orange
+bitter orange tree
+bitter pecan
+bitter pignut
+bitternut
 bitternut hickory
+bitterwood
+bitterwood tree
+black apricot
 black ash
+black beech
+black birch
 black cherry
+black cherry tree
+black cottonwood
 black gum
+black hemlock
+black hickory
+black hollander
+black larch
+black locust
+black maire
+black mallee
+black mangrove
+black mulberry
+black oak
+black pine
+black poplar
+black sally
+black spruce
 black walnut
+black walnut tree
+black wattle
+black willow
+blackjack
+blackjack oak
+blackwood
+blackwood tree
+blighia sapida
+blood-twig
+bloodwood tree
 blue ash
+blue fig
+blue gum
+bluejack oak
+bo tree
+bocconia
+bocconia frutescens
+bombax ceiba
+bombax malabarica
+bombay ceiba
+bonduc
+bonduc tree
+booyong
+borassus flabellifer
+boswellia carteri
+boswellia serrata
+botany bay fig
+bottle-tree
+bottlebrush buckeye
+bow wood
+box elder
+box white oak
+brachychiton acerifolius
+brachychiton australis
+brachychiton populneus
+brachychiton rupestris
+brachystegia speciformis
+brash oak
+brazil nut
+brazil-nut tree
+brazilian guava
+brazilian ironwood
+brazilian pepper tree
+brazilian rosewood
+brazilwood
+breadfruit
+breadfruit tree
+break-axe
+breakax
+breakaxe
+brewer's spruce
+brisbane quandong
+bristlecone fir
 bristlecone pine
+brittle willow
+broad-leaved bottletree
+broom palm
+broussonetia papyrifera
+brown ash
+brown hickory
+brown oak
+brown pine
+brya ebenus
+buckeye
+buckwheat tree
+bull bay
+bull pine
+bullace
+bullock heart
+bullock's heart
+bullock's heart tree
+bully tree
+bulnesia sarmienti
+bunchberry
+bunji-bunji
+bunya bunya
+bunya bunya tree
+bur oak
+burma padauk
+burmese rosewood
+burr oak
+bursera microphylla
+bursera simaruba
+bush willow
+butea frondosa
+butea monosperma
 butternut
+butternut tree
+button mangrove
+button tree
+buttonwood
+cabbage bark
+cabbage palm
+cabbage palmetto
+cabbage tree
+cabbage-bark tree
+cacao
+cacao tree
+caesalpinia bonduc
+caesalpinia bonducella
+caesalpinia coriaria
+caesalpinia echinata
+caesalpinia ferrea
+caimitillo
+caimito
+calaba
+calabash
+calabash tree
+calabur tree
+calabura
+calamus
+calamus australis
+calamus rotang
 california bay
+california bay tree
+california black oak
+california black walnut
+california box elder
+california laurel
+california live oak
+california nutmeg
+california olive
+california single-leaf pinyon
+california sycamore
+california white fir
+california white oak
+california yew
+calisaya
+calocarpum zapota
+calocedrus decurrens
+calophyllum calaba
+calophyllum candidissimum
+calophyllum inophyllum
+calophyllum longifolium
+calycophyllum candidissimum
+camachile
+campeachy
 camphor
+camphor tree
+camwood
+canada balsam
+canada plum
+canadian aspen
+canadian hemlock
+canadian red pine
+canafistola
+canafistula
+cananga odorata
+canary whitewood
+candlenut
+canistel
+canistel tree
+canoe birch
+canoe cedar
+canyon live oak
+canyon oak
+caoutchouc tree
+cape kafferboom
+cape yellowwood
+caprifig
+capulin
+capulin tree
+caracolito
+carambola
+carambola tree
+caranda
+caranda palm
+caranday
+carib wood
+carica papaya
+carnauba
+carnauba palm
+carob
+carob bean tree
+carob tree
+carolina hemlock
+carpinus betulus
+carpinus caroliniana
+cartagena bark
+carya aquatica
+carya cordiformis
+carya glabra
+carya illinoensis
+carya illinoinsis
+carya laciniosa
+carya myristicaeformis
+carya myristiciformis
+carya ovata
+carya tomentosa
+caryocar nuciferum
+caryota urens
+cashew
+cashew tree
+cassia
+cassia grandis
+cassia javonica
+cassia marginata
+cassia roxburghii
+cassia-bark tree
+cassie
+castanea chrysophylla
+castanea crenata
+castanea dentata
+castanea mollissima
+castanea ozarkensis
+castanea pumila
+castanea sativa
+castanopsis chrysophylla
+casuarina
+casuarina equisetfolia
+catalina cherry
 catalpa
+catalpa bignioides
+catalpa speciosa
+catechu
+cathaya
+cattley guava
+caucasian walnut
+caviuna wood
+cecropia peltata
 cedar
+cedar elm
+cedar mahogany
+cedar of goa
+cedar of lebanon
+cedar tree
+cedrela calantas
+cedrela odorata
+cedrus atlantica
+cedrus deodara
+cedrus libani
+ceiba pentandra
+ceiba tree
+ceibo
+celery pine
+celery top pine
+celery-topped pine
+celtis australis
+celtis laevigata
+celtis occidentalis
+cembra nut tree
+centrolobium robustum
+ceratonia siliqua
+ceratopetalum gummiferum
+cercidiphyllum japonicum
+cercidium floridum
+cercis canadensis
+cercis siliquastrum
+ceroxylon alpinum
+ceroxylon andicola
+ceylon cinnamon
+ceylon cinnamon tree
+ceylon gooseberry
+chamaecyparis lawsoniana
+chamaecyparis nootkatensis
+chamaecyparis thyoides
+chaulmoogra
+chaulmoogra tree
+chaulmugra
+cherimoya
+cherimoya tree
 cherry
+cherry apple
+cherry birch
+cherry crab
+cherry laurel
+cherry plum
+cherry tree
 chestnut
+chestnut oak
+chestnut tree
+chickasaw plum
+chicot
+chile pine
+chilean cedar
+china tree
+chinaberry
+chinaberry tree
+chinchona
+chinese anise
+chinese chestnut
+chinese cork oak
+chinese elm
+chinese magnolia
+chinese parasol
+chinese parasol tree
+chinese scholar tree
+chinese scholartree
+chinkapin oak
+chinquapin
+chinquapin oak
+chionanthus virginicus
+chloroxylon swietenia
+chocolate tree
+chokecherry
+chokecherry tree
+christmas bush
+christmas holly
+christmas tree
+chrysobalanus icaco
+chrysolepis chrysophylla
+chrysophyllum cainito
+chrysophyllum oliviforme
+cider gum
+cinchona
+cinchona calisaya
+cinchona cordifolia
+cinchona lancifolia
+cinchona ledgeriana
+cinchona officinalis
+cinchona pubescens
+cinchona tree
+cinnamomum camphora
+cinnamomum cassia
+cinnamomum loureirii
+cinnamomum zeylanicum
+cinnamon
+circassian walnut
+circis siliquastrum
+citrange
+citrange tree
+citron
+citron tree
+citroncirus webberi
+citrus
+citrus aurantifolia
+citrus aurantium
+citrus bergamia
+citrus decumana
+citrus grandis
+citrus limetta
+citrus limon
+citrus limonia
+citrus maxima
+citrus medica
+citrus nobilis
+citrus paradisi
+citrus reticulata
+citrus sinensis
+citrus tangelo
+citrus tree
+cladrastis kentukea
+cladrastis lutea
+clammy locust
+clementine
+clementine tree
+cliftonia monophylla
+clove
+clove tree
+clusia
+clusia flava
+coast live oak
 coast redwood
+coast white cedar
+cobnut
+cockspur
+coco
+coco de macao
+coco palm
+coco plum
+coco plum tree
+cocoa palm
+cocoa plum
+coconut
+coconut tree
+cocos nucifera
+coffea arabica
+coffea canephora
+coffea liberica
+coffea robusta
+coffee
+coffee tree
+cohune
+cohune palm
+coigue
+cola acuminata
+colorado blue spruce
+colorado fir
+colorado spruce
+combretum appiculatum
+combretum erythrophyllum
+commiphora meccanensis
+commiphora myrrha
+common alder
+common apricot
+common beech
+common birch
+common bird cherry
+common coral tree
+common european ash
+common european dogwood
+common fig
+common fig tree
+common myrtle
+common oak
+common osier
+common plum
+common sickle pine
+common white dogwood
+common winterberry holly
+common yellowwood
+conacaste
 concolor fir
+conessi
+congoo mallee
+conifer
+coniferous tree
+connarus guianensis
+conocarpus erectus
+copernicia alba
+copernicia australis
+copernicia cerifera
+copernicia prunifera
+copper beech
+coral bean
+coral bean tree
+coral tree
+coral-wood
+coralwood
+cordia alliodora
+cordia gerascanthus
+cordyline australis
+cork oak
+cork tree
+cornel
+cornelian cherry
+cornus amomum
+cornus canadensis
+cornus florida
+cornus mas
+cornus obliqua
+cornus sanguinea
+cornus stolonifera
+corozo
+corozo palm
+corylus americana
+corylus avellana
+corylus avellana grandis
+corylus cornuta
+corypha gebanga
+corypha umbraculifera
+corypha utan
 cottonwood
+coumarouna odorata
+courbaril
+cow oak
+coyol
+coyol palm
+crab apple
+crabapple
+crack willow
+crackerberry
+cream-of-tartar tree
+creeping willow
+crescentia cujete
+cricket-bat willow
+crow's foot
+cry-baby tree
+crybaby tree
+cryptomeria japonica
+cuban mahogany
+cucumber tree
+cultivated crab apple
+cumquat
+cupressus abramsiana
+cupressus arizonica
+cupressus goveniana
+cupressus goveniana abramsiana
+cupressus goveniana pigmaea
+cupressus guadalupensis
+cupressus lusitanica
+cupressus macrocarpa
+cupressus pigmaea
+cupressus sempervirens
+currajong
+custard apple
+custard apple tree
+cydonia oblonga
+cypre
 cypress
+cypress pine
+cypress tree
+dacrycarpus dacrydioides
+dacrydium bidwilli
+dacrydium colensoi
+dacrydium cupressinum
+dacrydium franklinii
+dagame
+dak
+dalbergia cearensis
+dalbergia latifolia
+dalbergia nigra
+dalbergia retusa
+dalbergia sissoo
+dalbergia stevensonii
+dammar pine
+damson plum
+damson plum tree
 date
+date plum
 dawn redwood
+deciduous holly
+delonix regia
+deodar
+deodar cedar
+devil tree
+devilwood
+dhak
+dhava
+dhawa
+dika
+dillenia
+dimocarpus longan
+diospyros ebenum
+diospyros kaki
+diospyros kurzii
+diospyros lotus
+diospyros virginiana
+dipterocarp
+dipteryx odorata
+dita
+dita bark
+divi-divi
 dogwood
+dogwood tree
+dominican mahogany
 douglas fir
+douglas hemlock
+douglas pine
+douglas spruce
+dovyalis hebecarpa
+downy ash
+downy birch
+downy poplar
+drimys winteri
+drumstick tree
+dundathu pine
+durian
+durian tree
+durio zibethinus
+durion
+durmast
+dutch elm
+dwarf buckeye
+dwarf chestnut
+dwarf chinkapin oak
+dwarf chinquapin oak
+dwarf cornel
+dwarf elm
+dwarf flowering almond
+dwarf gray willow
+dwarf grey willow
+dwarf maple
+dwarf mountain pine
+dwarf oak
+dwarf russian almond
+dwarf willow
+earleaved umbrella tree
+east india rosewood
+east indian fig tree
+east indian rosewood
+eastern chinquapin
+eastern cottonwood
+eastern flowering dogwood
+eastern hemlock
+eastern hop hornbeam
 eastern redcedar
+eastern spruce
 eastern white pine
 ebony
+ebony tree
+ecuador laurel
+elaeis guineensis
+elaeis oleifera
+elaeocarpus grandis
+elephant tree
+elephant's ear
+elk-wood
+elkwood
 elm
+elm tree
 engelmann spruce
+engelmann's spruce
+english elm
+english oak
+english walnut
+english walnut tree
+english yew
+entandrophragma cylindricum
+enterolobium cyclocarpa
+eriobotrya japonica
+erythrina
+erythrina caffra
+erythrina corallodendrum
+erythrina crista-galli
+erythrina indica
+erythrina lysistemon
+erythrina variegata
+erythrina vespertilio
+eucalypt
+eucalypt grandis
+eucalypt gunnii
+eucalypt ovata
+eucalypt tereticornis
 eucalyptus
+eucalyptus amygdalina
+eucalyptus calophylla
+eucalyptus camaldulensis
+eucalyptus camphora
+eucalyptus citriodora
+eucalyptus coriacea
+eucalyptus delegatensis
+eucalyptus dumosa
+eucalyptus eugenioides
+eucalyptus fraxinoides
+eucalyptus globulus
+eucalyptus maculata
+eucalyptus maculata citriodora
+eucalyptus pauciflora
+eucalyptus regnans
+eucalyptus rostrata
+eucalyptus stellulata
+eucalyptus tree
+eucalyptus viminalis
+eucarya acuminata
+eugenia aromaticum
+eugenia caryophyllatum
+eugenia corynantha
+eugenia dicrana
+eugenia jambos
+eugenia uniflora
+euphorbia litchi
+european ash
+european beech
+european bird cherry
+european black alder
+european chestnut
+european elm
+european field elm
+european hackberry
+european hornbeam
+european larch
+european mountain ash
+european nut pine
+european olive tree
+european quaking aspen
+european silver fir
+european turkey oak
+european white birch
+euterpe oleracea
+evergreen beech
+evergreen cherry
+evergreen magnolia
+evergreen oak
+evergreen winterberry
+fagus americana
+fagus grandifolia
+fagus pendula
+fagus purpurea
+fagus sylvatica
+fagus sylvatica atropunicea
+fagus sylvatica pendula
+fagus sylvatica purpurea
+falcatifolium falciforme
+falcatifolium taxoides
+false dogwood
+feather palm
+fern rhapis
+fever tree
+ficus aurea
+ficus bengalensis
+ficus carica
+ficus carica sylvestris
+ficus deltoidea
+ficus diversifolia
+ficus elastica
+ficus religiosa
+ficus rubiginosa
+ficus sycomorus
+field maple
 fig
+filbert
 fir
+fir tree
+firewheel tree
+firmiana simplex
+fish fuddle
+fishtail palm
+flame durrajong
+flame tree
+flindersia australis
+flindersia schottiana
+flindosa
+flindosy
+flooded gum
+florida strangler fig
+florida yew
+florist's willow
+flowering almond
+flowering ash
+flowering cherry
+flowering crab
+flowering tree
+forest red gum
+fortunella japonica
+fortunella margarita
+frankincense pine
 fraser fir
+fraxinus americana
+fraxinus caroliniana
+fraxinus cuspidata
+fraxinus dipetala
+fraxinus excelsior
+fraxinus latifolia
+fraxinus nigra
+fraxinus oregona
+fraxinus ornus
+fraxinus pennsylvanica
+fraxinus pennsylvanica subintegerrima
+fraxinus quadrangulata
+fraxinus texensis
+fraxinus tomentosa
+fraxinus velutina
+frijolillo
+frijolito
+fringe bush
+fringe tree
+fruit tree
+fuji
+fuji cherry
+full moon maple
+fusanus acuminatus
+gall-berry
+gallberry
+gamboge tree
+garcinia cambogia
+garcinia gummi-gutta
+garcinia hanburyi
+garcinia mangostana
+garland crab
+garry oak
+gean
+gebang palm
+genip
+genipa
+genipa americana
+genipap fruit
+genus manglietia
+georgia holly
+georgia pine
+ghost gum
+giant chinkapin
+giant fir
 giant sequoia
+gidgee
+ginep
+gingko
 ginkgo
+gleditsia aquatica
+gleditsia triacanthos
+gliricidia
+gnetum
+gnetum gnemon
+goat willow
+god tree
+golden chinkapin
+golden fig
+golden larch
+golden shower tree
+golden wattle
+golden willow
+gomuti
+gomuti palm
+goncalo alves
+goora nut
+goose plum
+goosefoot maple
+gopherwood
+gowen cypress
+granadilla tree
+granadillo
 grand fir
 grapefruit
+grass tree
+gray alder
+gray birch
+gray poplar
+gray willow
+great maple
+great-leaved macrophylla
+green alder
 green ash
+green douglas fir
+grey alder
+grey birch
+grey poplar
+grey willow
+grey-leaf pine
+gri-gri
+grias cauliflora
+grugru
+grugru palm
+guadalupe cypress
+guaiacum officinale
+guaiacum sanctum
+guama
+guava
+guava bush
+guernsey elm
+guinea pepper
 gum
+gum tree
+gumbo-limbo
+gutta-percha tree
+gymnocladus dioica
+gymnospermous tree
+gymnospermous yellowwood
 hackberry
+hackmatack
+haematoxylum campechianum
+hagberry tree
+halesia carolina
+halesia tetraptera
+halocarpus bidwilli
+hard beech
+harpulla
+harpullia
+harpullia cupanioides
+harpullia pendula
 hawthorn
+hazel
+hazel alder
+hazel tree
+hazelnut
+hazelnut tree
+heart cherry
 heartnut
+hedge maple
 hemlock
 hemlock spruce
+hemlock tree
+hemp willow
+hercules'-club
+hercules'-clubs
+heritiera littoralis
+heritiera macrophylla
+heritiera trifoliolata
+hevea brasiliensis
+hiba arborvitae
 hickory
+hickory pine
+hickory tree
+himalayan cedar
+hoary willow
+hog plum
+hog plum bush
+hoheria populnea
+holarrhena antidysenterica
+holarrhena pubescens
+holly
+holly-leaf cherry
+holly-leaved cherry
+holly-leaved oak
+holm oak
+holm tree
+honduras mahogany
+honduras rosewood
+honey berry
+honey locust
 honeylocust
+hoop ash
+hoop pine
+hop hornbeam
 hornbeam
+horse cassia
+horse chestnut
+houhere
+huamachil
+huisache
+huntingdon elm
+huntingdon willow
+huon pine
+hydnocarpus kurzii
+hydnocarpus laurifolia
+hydnocarpus wightiana
+hymenaea courbaril
+icaco
+ice-cream bean
+idesia
+idesia polycarpa
+ilama
+ilama tree
+ilang-ilang
+ilex decidua
+ilex glabra
+ilex paraguariensis
+illicium anisatum
+illicium floridanum
+illicium verum
+imbauba
+imou pine
+incense cedar
+incense tree
+india-rubber fig
+india-rubber plant
+india-rubber tree
+indian banyan
+indian bean
+indian beech
+indian blackwood
+indian coral tree
+indian rosewood
+inga
+inga edulis
+inga laurina
+inkberry
 inkberry holly
+interior live oak
+iowa crab
+iowa crab apple
+iron oak
+iron tree
+ironwood tree
+irvingia gabonensis
+islay
+italian cypress
 italian stone pine
+ivory palm
+ivory plant
+ivory tree
+ivory-nut palm
+jaboncillo
+jaboticaba
+jaboticaba tree
 jacaranda
+jack oak
+jack pine
+jackfruit
+jackfruit tree
+jaggery palm
+jagua
+jamaica bayberry
+jamaica dogwood
+jamaica quassia
+jamaican cherry
+jambosa
+japan cedar
+japanese apricot
+japanese beech
+japanese black pine
+japanese cedar
+japanese cherry
+japanese chestnut
+japanese flowering cherry
 japanese holly
+japanese lime
+japanese linden
+japanese medlar
+japanese oak
+japanese pagoda tree
+japanese persimmon
+japanese plum
+japanese red pine
+japanese table pine
+japanese umbrella pine
+japanese varnish tree
+japanese yew
+jatropha curcus
+java olives
+jeffrey pine
+jeffrey's pine
+jersey elm
+jersey pine
+jerusalem thorn
+jocote
+jordan almond
 joshua tree
+judas tree
+juglans californica
+juglans cinerea
+juglans nigra
+juglans regia
+jumbie bead
+jumby bead
+jumby bean
+jumby tree
+juneberry holly
+juniper
+jupati
+jupati palm
+jupaty
+kaffir boom
+kahikatea
+kaki
+kalantas
+kalumpang
 kapok
+katsura tree
+kauri
+kauri pine
+kaury
+kawaka
+kentucky coffee tree
+kentucky yellowwood
+keteleeria
+ketembilla
+ketembilla tree
+keurboom
+key palm
+kiaat
+king nut
+king nut hickory
+king orange
+king william pine
+kingwood
+kingwood tree
+kino
+kirkia wilmsii
+kitambilla
+kitembilla
+kittul
+kitul
+kitul tree
+knobcone pine
+kola
+kola nut
+kola nut tree
+kowhai
+kumquat
+kumquat tree
+kurchee
+kurchi
+kurrajong
+lacebark
+lady palm
+lagarostrobus colensoi
+lagarostrobus franklinii
+lagerstroemia speciosa
+laguncularia racemosa
+lancewood
+lancewood tree
+langsat
+langset
+lanseh tree
+lansium domesticum
 larch
+larch tree
+large tooth aspen
+large-flowering magnolia
+large-leaved cucumber tree
+large-leaved magnolia
+large-toothed aspen
+largeleaf holly
+larix decidua
+larix laricina
+larix lyallii
+larix occidentalis
+larix russica
+larix siberica
+latanier
+latanier palm
+lauhala
+laurel
+laurel cherry
+laurel oak
 laurel sumac
+laurel willow
+laurel-tree
+laurelwood
+laurus nobilis
+lawson's cedar
+lawson's cypress
+lawyer cane
+lead tree
+lemanderin
 lemon
+lemon tree
+lemon-scented gum
+lemon-wood
+lemon-wood tree
+lemonwood
+lemonwood tree
+lepidobotrys
+leucadendron argenteum
+leucaena glauca
+leucaena leucocephala
 leyland cypress
+liberian coffee
+libocedrus bidwillii
+libocedrus decurrens
+libocedrus plumosa
+lichee
+lightwood
+limber pine
 lime
+lime tree
 linden
+linden tree
+liquidambar
+liquidambar styraciflua
+liriodendron tulipifera
+litchi
+litchi chinensis
+litchi tree
+lithocarpus densiflorus
+lithocarpus glaber
+lithocarpus glabra
+little-leaf fig
+live oak
+livistona australis
 loblolly pine
 locust
+locust tree
+lodgepole
 lodgepole pine
+logwood
+logwood tree
+lombardy poplar
+london plane
 london plane tree
+longan
+longanberry
+longar palm
 longleaf pine
+lontar
+looking glass tree
+looking-glass plant
+loquat
+loquat tree
+love tree
+lovoa klaineana
+low gallberry holly
+lowland fir
+lowland white fir
+lungen
+lysiloma bahamensis
+lysiloma latisiliqua
+macadamia
+macadamia integrifolia
+macadamia nut
+macadamia nut tree
+macadamia ternifolia
+macadamia tetraphylla
+macadamia tree
+macamba
+maclura pomifera
 madrone
 magnolia
+magnolia acuminata
+magnolia fraseri
+magnolia grandiflora
+magnolia macrophylla
+magnolia soulangiana
+magnolia stellata
+magnolia tripetala
+magnolia virginiana
 mahogany
+mahogany tree
 mahonia
+maidenhair tree
+mallee
+malus angustifolia
+malus baccata
+malus coronaria
+malus fusca
+malus ioensis
+malus pumila
+malus sylvestris
+mamey
+mammea americana
+mammee
+mammee apple
+mammee tree
+mamoncillo
+mandarin
+mandarin orange
+mandarin orange tree
+mangifera indica
+manglietia
+mango
+mango tree
+mangosteen
+mangosteen tree
+manila tamarind
+manilkara bidentata
+manilkara zapota
+manna ash
+manna gum
 maple
+maple-leaved bayur
+marang
+marang tree
+marasca
+marasca cherry
+maraschino cherry
+marble-wood
+marblewood
+margosa
+maria
+marmalade box
+marmalade orange
+marmalade tree
+marri
+marumi
+marumi kumquat
+marupa
+matai
+mate
+maul oak
+mayeng
+mazzard
+mazzard cherry
+mediterranean cypress
+mediterranean hackberry
+medlar
+medlar tree
+mei
+melia azadirachta
+melia azedarach
+melia azederach
+melicocca bijuga
+melicocca bijugatus
+melon tree
+meryta sinclairii
+mespilus germanica
 mesquite
+mesua ferrea
+metasequoia
+metasequoia glyptostrodoides
+metroxylon sagu
+mexican cypress
+mexican nut pine
+mexican swamp cypress
+millettia
+mimosa
+mimosa bush
+ming tree
+miniature fan palm
+miro
+mistletoe fig
+mistletoe rubber plant
+mock orange
+mockernut
+mockernut hickory
+molle
+mombin
+mombin tree
+monkey pod
 monkey puzzle tree
+monkey-bread tree
+monkeypod
 monterey cypress
+monterey pine
+montezuma
+montezuma cypress
+moose-wood
+moosewood
+morello
+moreton bay chestnut
+moreton bay pine
+moreton bay tulipwood
+morus alba
+morus nigra
+morus rubra
+mossy-cup oak
+mossycup oak
+mountain alder
+mountain ash
+mountain birch
+mountain ebony
 mountain hemlock
 mountain laurel
+mountain maple
+mountain oak
+mountain pine
+mountain swamp gum
+msasa
+mugho pine
+mugo pine
 mulberry
+mulberry fig
+mulberry tree
+muntingia calabura
+mustard tree
+myrciaria cauliflora
+myristica fragrans
+myrobalan
+myrobalan plum
+myroxylon balsamum
+myroxylon balsamum pereirae
+myroxylon pereirae
+myroxylon toluiferum
+myrrh tree
+myrtaceous tree
+myrtle
+myrtle beech
+myrtle oak
+myrtus communis
+nagami
+nagami kumquat
+nageia nagi
+nagi
+nakedwood
+narrow-leaved bottletree
+native beech
+nauclea diderrichii
+necklace poplar
+necklace tree
 nectarine
+nectarine tree
+neem
+neem tree
+nephelium lappaceum
+nephelium litchi
+nephelium longana
+nephelium mutabile
+nettle tree
+new caledonian pine
+new caledonian yew
+new zealand beech
+new zealand dacryberry
+new zealand honeysuckle
+new zealand mountain pine
+new zealand white pine
+newfoundland dwarf birch
+nim tree
+nipa fruticans
+nipa palm
+nitta tree
 noble fir
+nootka cypress
 norfolk island pine
+northern pin oak
+northern pitch pine
+northern red oak
 northern white cedar
+norway maple
 norway spruce
+nothofagus cunninghamii
+nothofagus dombeyi
+nothofagus menziesii
+nothofagus obliqua
+nothofagus procera
+nothofagus solanderi
+nothofagus solandri
+nothofagus truncata
+nut pine
+nut tree
+nutmeg
+nutmeg hickory
+nutmeg tree
+nutmeg-yew
+nuttall oak
+nuttall's oak
+nyssa aquatica
+nyssa sylvatica
 oak
+oak chestnut
+oak tree
+obeche
+obechi
+ochroma lagopus
+ohio buckeye
+oil palm
+old world hop hornbeam
+old world yew
+olea cunninghamii
+olea europaea
+olea lanceolata
 olive
+opepe
+opossum wood
 orange
+orange tree
+orbignya cohune
+orbignya martiana
+orbignya phalerata
+orbignya spesiosa
+orchard apple tree
+orchid tree
+oregon alder
+oregon ash
+oregon cedar
+oregon crab apple
+oregon fir
+oregon larch
+oregon maple
+oregon myrtle
+oregon oak
+oregon pine
+oregon white oak
+orites excelsa
+ormosia coarctata
+ormosia monosperma
+osage orange
+osier
+osmanthus americanus
+ostrya carpinifolia
+ostrya virginiana
+oval kumquat
+overcup oak
+oxandra lanceolata
+oxheart
+oxheart cherry
+oxydendrum arboreum
+ozark chinkapin
+ozark chinquapin
+pacific hemlock
+pacific plum
+pacific silver fir
+pacific yew
+padouk
+pahautea
+palaquium gutta
+palas
 palm
+palm tree
+palmetto
+palmyra
+palmyra palm
+palo santo
+palo verde
+panama redwood
+panama redwood tree
+panama tree
+pandanus
+pandanus tectorius
+papaia
+papaw
+papaw tree
+papaya
+papaya tree
+paper mulberry
+paperbark birch
+para rubber tree
+paradise tree
+paraguay tea
+parkia javanica
+parkinsonia florida
+parry's pinyon
+particolored buckeye
+pawpaw
 peach
+peach tree
+peach-leaved willow
+peach-wood
+peachleaf willow
+peachwood
+peacock flower
+peacock flower fence
+pear
+pear tree
 pecan
+pecan tree
+pedunculate oak
+pedwood
+peepul
+pepper tree
+pepperidge
+peppermint
+peppermint gum
+pepperwood
+pernambuco wood
+persea americana
+persea borbonia
+persian lilac
+persian walnut
 persimmon
+persimmon tree
+peruvian balsam
+peruvian mastic tree
+phellodendron amurense
+philippine cedar
+philippine mahogany
+phoenix dactylifera
+phoenix tree
+phyllocladus alpinus
+phyllocladus asplenifolius
+phyllocladus trichomanoides
+physic nut
+phytelephas macrocarpa
+piassava palm
+picea abies
+picea breweriana
+picea engelmannii
+picea glauca
+picea mariana
+picea obovata
+picea orientalis
+picea pungens
+picea rubens
+picea sitchensis
+picrasma excelsa
+picrasma excelsum
+pignut
+pignut hickory
+pimenta acris
+pimenta dioica
+pimenta officinalis
+pimento tree
+pin cherry
+pin oak
 pine
+pine tree
+pink shower
+pink shower tree
+pinon
+pinon pine
+pinus albicaulis
+pinus aristata
+pinus attenuata
+pinus banksiana
+pinus californiarum
+pinus cembra
+pinus cembroides
+pinus contorta
+pinus contorta murrayana
+pinus densiflora
+pinus echinata
+pinus edulis
+pinus flexilis
+pinus glabra
+pinus jeffreyi
+pinus longaeva
+pinus monophylla
+pinus monticola
+pinus mugo
+pinus muricata
+pinus nigra
+pinus palustris
+pinus parryana
+pinus pinea
+pinus ponderosa
+pinus pungens
+pinus quadrifolia
+pinus radiata
+pinus resinosa
+pinus rigida
+pinus serotina
+pinus strobiformis
+pinus strobus
+pinus sylvestris
+pinus taeda
+pinus thunbergii
+pinus torreyana
+pinus virginiana
+pinyon
+pipal
+pipal tree
+pipturus albidus
+pipul
+piscidia erythrina
+piscidia piscipula
+pisonia aculeata
+pissaba palm
+pistachio
+pistachio tree
+pistacia terebinthus
+pistacia vera
+pitanga
+pitch pine
+pithecellobium dulce
+plagianthus betulinus
+plagianthus regius
+plane tree
+platan
+platanus acerifolia
+platanus occidentalis
+platanus orientalis
+platanus racemosa
+platanus wrightii
+platycladus orientalis
+platymiscium pinnatum
+platymiscium trinitatis
 plum
+plum tree
+plum-fruited yew
+plum-yew
+plumcot
+plumcot tree
+podocarp
+podocarpus amara
+podocarpus coriaceus
+podocarpus dacrydioides
+podocarpus elatus
+podocarpus elongatus
+podocarpus ferruginea
+podocarpus latifolius
+podocarpus spicata
+podocarpus totara
 pohutukawa
+poinciana regia
+pointed-leaf maple
 poison ivy
 poison oak
+pollard
+pomaderris apetala
+pomegranate
+pomegranate tree
+pomelo
+pomelo tree
+poncirus trifoliata
+pond apple
+pond bald cypress
+pond cypress
+pond pine
+pond-apple tree
 pondcypress
+ponderosa
 ponderosa pine
+pongamia glabra
+poon
 poplar
+poplar tree
+populus alba
+populus balsamifera
+populus canescens
+populus deltoides
+populus grandidentata
+populus heterophylla
+populus nigra
+populus nigra italica
+populus tremula
+populus tremuloides
+populus trichocarpa
+port jackson fig
+port orford cedar
+portia tree
+portuguese cypress
+possum haw
+possum oak
+possumwood
+post oak
+pouteria campechiana
+pouteria campechiana nervosa
+pouteria zapota
+prairie crab
+prairie willow
+prickly ash
+prickly custard apple
+prickly pine
+pride of bolivia
+pride-of-india
+prince albert yew
+prince albert's yew
+princewood
+protium guianense
+protium heptaphyllum
+prumnopitys amara
+prumnopitys andina
+prumnopitys elegans
+prumnopitys ferruginea
+prumnopitys taxifolia
+prunus alleghaniensis
+prunus americana
+prunus amygdalus
+prunus angustifolia
+prunus armeniaca
+prunus avium
+prunus capuli
+prunus caroliniana
+prunus cerasifera
+prunus cerasus
+prunus cerasus austera
+prunus cerasus caproniana
+prunus cerasus marasca
+prunus dasycarpa
+prunus demissa
+prunus domestica
+prunus domestica insititia
+prunus dulcis
+prunus dulcis amara
+prunus glandulosa
+prunus ilicifolia
+prunus incisa
+prunus insititia
+prunus japonica
+prunus lyonii
+prunus maritima
+prunus mexicana
+prunus mume
+prunus nigra
+prunus padus
+prunus pensylvanica
+prunus persica
+prunus persica nectarina
+prunus salicina
+prunus serotina
+prunus serrulata
+prunus sieboldii
+prunus subcordata
+prunus subhirtella
+prunus tenella
+prunus triloba
+prunus virginiana
+prunus virginiana demissa
+pseudobombax ellipticum
+pseudolarix amabilis
+pseudotaxus chienii
+pseudotsuga macrocarpa
+pseudotsuga menziesii
+psidium cattleianum
+psidium guajava
+psidium guineense
+psidium littorale
+psidium littorale longipes
+psychotria capensis
+pterocarpus angolensis
+pterocarpus indicus
+pterocarpus macrocarpus
+pterocarpus marsupium
+pterocarpus santalinus
+pterocarya fraxinifolia
+pterospermum acerifolium
+pudding berry
+pudding pipe tree
+puka
+pulasan
+pulasan tree
+pulassan
+pummelo
+pumpkin ash
+punica granatum
+purging cassia
+purple anise
+purple apricot
+purple beech
+purple osier
+purple strawberry guava
+purple willow
+pygmy cypress
+pyrus communis
+quandang
+quandong
+quandong tree
+quassia
+quassia amara
+queen's crape myrtle
+queensland bottletree
+queensland kauri
+queensland nut
+quercitron
+quercitron oak
+quercus agrifolia
+quercus alba
+quercus arizonica
+quercus bicolor
+quercus borealis
+quercus cerris
+quercus chrysolepis
+quercus coccinea
+quercus ellipsoidalis
+quercus falcata
+quercus garryana
+quercus grosseserrata
+quercus ilex
+quercus ilicifolia
+quercus imbricaria
+quercus incana
+quercus kelloggii
+quercus laevis
+quercus laurifolia
+quercus lobata
+quercus lyrata
+quercus macrocarpa
+quercus marilandica
+quercus michauxii
+quercus mongolica
+quercus montana
+quercus muehlenbergii
+quercus myrtifolia
+quercus nigra
+quercus nuttalli
+quercus palustris
+quercus petraea
+quercus phellos
+quercus prinoides
+quercus prinus
+quercus robur
+quercus rubra
+quercus sessiliflora
+quercus shumardii
+quercus stellata
+quercus suber
+quercus texana
+quercus variabilis
+quercus velutina
+quercus virginiana
+quercus wislizenii
+quercus wizlizenii
+quince
+quince bush
+quira
+raffia farinifera
+raffia palm
+raffia ruffia
+raffia taedigera
+raffia vinifera
+rain tree
+rainbow shower
+rambotan
+rambutan
+rambutan tree
+rangpur
+rangpur lime
+rattan palm
+rauli beech
+red alder
+red ash
+red bay
+red beech
+red birch
+red buckeye
 red cedar
+red dogwood
+red elm
+red gum
+red kauri
+red lauan
+red lauan tree
 red maple
+red mulberry
+red oak
+red osier
+red osier dogwood
+red pine
+red sandalwood
+red sanders
+red sanderswood
+red saunders
+red silk-cotton tree
+red silver fir
+red spruce
+red willow
+redbrush
 redbud
 redwood
+reed rhapis
+rewa-rewa
+rhapis excelsa
+rhapis humilis
+rhizophora mangle
+rhodosphaera rhodanthema
+rhus rhodanthema
+ribbon tree
+ribbonwood
+rimu
+rio nunez coffee
+river birch
+river gum
+river red gum
+robinia pseudoacacia
+robinia viscosa
+roble
+roble beech
+robusta coffee
+rock elm
+rock maple
+rockingham podocarp
+rocky mountain bristlecone pine
+rocky mountain pinon
+rocky-mountain maple
+rose apple
+rose chestnut
+rose gum
+rose-apple tree
+rosebud cherry
 rosewood
+rosewood tree
+round kumquat
 rowan
+rowan tree
+royal palm
+roystonea oleracea
+roystonea regia
+rum cherry
+ruptiliocarpon caracolito
+russian almond
+rusty fig
+sabal palmetto
+sabine pine
+sabinea carinalis
+sacred fig
+sage willow
+sago palm
+saigon cinnamon
+salai
+salix alba
+salix alba caerulea
+salix alba sericea
+salix alba vitellina
+salix amygdalina
+salix amygdaloides
+salix arctica
+salix babylonica
+salix blanda
+salix candida
+salix caprea
+salix cinerea
+salix discolor
+salix fragilis
+salix herbacea
+salix humilis
+salix lasiolepis
+salix lucida
+salix nigra
+salix pendulina
+salix pendulina blanda
+salix pentandra
+salix purpurea
+salix pyrifolia
+salix repens
+salix sericea
+salix sitchensis
+salix triandra
+salix tristis
+salix uva-ursi
+salix viminalis
+salix vitellina
+sallow
+salmwood
+salvadora persica
+saman
+samba
 sandalwood
+sandalwood tree
+santa cruz cypress
+santa lucia fir
+santa maria tree
+santalum album
+sapele mahogany
+sapindus drummondii
+sapindus marginatus
+sapindus saponaria
+sapling
+sapodilla
+sapodilla tree
+sapote
+sarcocephalus diderrichii
 sassafras
+sassafras albidum
+sassafras laurel
+sassafras tree
+satin leaf
+satinleaf
+satinwood
+satinwood tree
+satsuma
+satsuma tree
+saucer magnolia
+saw palmetto
+saxe-gothea conspicua
+scarlet maple
 scarlet oak
+scarlet wisteria tree
+scented wattle
+schinus chichita
+schinus molle
+schinus terebinthifolia
+sciadopitys verticillata
+scotch fir
 scotch pine
+scots pine
+scottish maple
+screw pine
+scrub beefwood
+scrub oak
+scrub palmetto
+scrub pine
+sea ash
+seaside alder
+seaside mahoe
+seaside scrub oak
+september elm
 sequoia
+serenoa repens
+service tree
 serviceberry
+sesbania grandiflora
+seville orange
+shaddock
+shade tree
+shagbark
 shagbark hickory
+shaving-brush tree
+she-oak
 sheep laurel
+shellbark
+shellbark hickory
+shingle oak
+shingle tree
+shining willow
+shittah
+shittah tree
+shore pine
+shorea teysmanniana
+short-leaf pine
 shortleaf pine
+shortleaf yellow pine
+shumard oak
+shumard red oak
+siberian crab
+siberian crab apple
+siberian elm
+siberian larch
+siberian spruce
+sierra lodgepole pine
+sierra plum
+silk tree
+silk wood
+silk-cotton tree
+silkwood
+silky cornel
+silky dogwood
+silky elm
+silky willow
+silver ash
+silver beech
+silver bell
+silver fir
+silver lime
+silver linden
+silver maple
+silver pine
+silver quandong tree
+silver spruce
+silver thatch
+silver tree
+silver wattle
+silver willow
+silver-bell tree
+silver-leaved poplar
 silverbell
+silverbell tree
+silvertop palmetto
+simal
+simarouba amara
+simarouba glauca
+single-leaf
+single-leaf pine
+single-leaf pinyon
+siris
+siris tree
+sisham
+sissoo
+sissu
 sitka spruce
+sitka willow
 slash pine
+slender lady palm
+slippery elm
+sloanea jamaicensis
+sloe
+small-leaved lime
+small-leaved linden
+smooth alder
+smooth bark kauri
+smooth winterberry holly
+smooth-leaved elm
+smoothbark
+snag
+snake wood
+snap willow
+snow gum
+snowdrop tree
+soapberry
+soapberry tree
 soft maple
+soledad pine
+sophora japonica
+sophora secundiflora
+sophora sinensis
+sophora tetraptera
+sorb apple
+sorb apple tree
+sorbus americana
+sorbus aucuparia
+sorbus domestica
+sorbus sitchensis
+sorbus torminalis
+sorrel tree
+souari
+souari nut
+souari tree
+sour cherry
+sour cherry tree
+sour gourd
+sour gum
+sour orange
+soursop
+soursop tree
+sourwood
+south-african yellowwood
+southern beech
+southern crab apple
+southern cypress
+southern live oak
+southern magnolia
+southern red oak
 southern redcedar
+southern white cedar
+southern yellow pine
+southwestern white pine
+spanish cedar
+spanish cedar tree
+spanish chestnut
+spanish elm
+spanish lime
+spanish lime tree
+spanish oak
+spanish tamarind
+speckled alder
+spice tree
+spondias mombin
+spondias purpurea
+spotted gum
 spruce
+spruce pine
+star anise
+star apple
+star magnolia
+stave wood
+stenocarpus salignus
+stenocarpus sinuatus
+sterculia
+sterculia acerifolia
+sterculia apetala
+sterculia foetida
+sterculia rupestris
+stinking cedar
+stinking wattle
+stinking yew
+stone pine
+strangler fig
+strawberry guava
+stringybark
+striped dogwood
+striped maple
 subalpine fir
+subalpine larch
 sugar maple
+sugar palm
 sugar pine
+sugarberry
+sugi
+sundacarpus amara
+surinam cherry
+swamp ash
+swamp bay
+swamp birch
+swamp chestnut oak
+swamp cottonwood
+swamp cypress
+swamp gum
+swamp hickory
+swamp laurel
+swamp locust
+swamp maple
+swamp oak
+swamp pine
+swamp poplar
+swamp red oak
+swamp white oak
+swamp willow
+sweet acacia
+sweet almond
+sweet bay
+sweet birch
+sweet buckeye
+sweet cherry
+sweet chestnut
+sweet gum
+sweet gum tree
+sweet lemon
+sweet lime
+sweet orange
+sweet orange tree
+sweet wattle
 sweetgum
+sweetleaf
+sweetsop
+sweetsop tree
+swietinia macrophylla
+swietinia mahogani
+swiss mountain pine
+swiss pine
+swiss stone pine
 sycamore
+sycamore fig
+symplocus tinctoria
+syzygium aromaticum
+syzygium jambos
+table-mountain pine
+tacamahac
+talipot
+talipot palm
+tall gallberry holly
 tamarack
+tamarind
+tamarind tree
+tamarindo
+tamarindus indica
+tanbark oak
+tanekaha
+tangelo
+tangelo tree
 tangerine
+tangerine tree
+tangor
+tar-wood
+taraktagenos kurzii
+taraktogenos kurzii
+tarrietia argyrodendron
+tarwood
+taxodium ascendens
+taxodium distichum
+taxodium mucronatum
+taxus baccata
+taxus brevifolia
+taxus cuspidata
+taxus floridana
 teak
+tectona grandis
+temple orange
+temple orange tree
+terebinth
+terrietia trifoliolata
+textile screw pine
+thatch palm
+thatch tree
+theobroma cacao
+thespesia populnea
+thin-leaved stringybark
+thrinax keyensis
+thrinax microcarpa
+thrinax morrisii
+thrinax parviflora
+thuja occidentalis
+thuja orientalis
+thuja plicata
+thujopsis dolobrata
+tilia americana
+tilia cordata
+tilia heterophylla
+tilia japonica
+tilia tomentosa
+timber tree
+tipu
+tipu tree
+titi
+toddy palm
+tolu balsam tree
+tolu tree
+tonka bean
+tonka bean tree
+toona calantas
+toothache tree
+toothbrush tree
+torrey pine
+torrey tree
+torrey's pine
+torreya californica
+torreya taxifolia
+totara
+transvaal kafferboom
+tree celandine
+tree of heaven
+tree of knowledge
+tree of the gods
+treelet
+trifoliata
+trifoliate orange
+triplochiton scleroxcylon
+triplochiton scleroxylon
+true cedar
+true fir
+true guava
+true laurel
+true mahogany
+true pine
+true sago palm
+true sandalwood
+trumpet tree
+trumpet-wood
+trumpetwood
+tsuga canadensis
+tsuga caroliniana
+tsuga heterophylla
+tsuga mertensiana
 tulip poplar
+tulipwood tree
+tung
+tung tree
+tung-oil tree
+tupelo
+tupelo tree
+turkey oak
+turraea
+ugli fruit
+ulmus alata
+ulmus americana
+ulmus campestris sarniensis
+ulmus campestris wheatleyi
+ulmus carpinifolia
+ulmus crassifolia
+ulmus glabra
+ulmus hollandica
+ulmus hollandica vegetata
+ulmus laevis
+ulmus parvifolia
+ulmus procera
+ulmus pumila
+ulmus rubra
+ulmus sarniensis
+ulmus serotina
+ulmus thomasii
+umbellularia californica
+umbrella magnolia
+umbrella pine
+valley oak
+valley white oak
+vangueria infausta
+vangueria madagascariensis
+varnish tree
+vegetable hummingbird
+velvet osier
+vine maple
+virgilia capensis
+virgilia divaricata
+virgilia oroboides
 virginia creeper
+virginia pine
 walnut
+walnut tree
+water birch
+water bitternut
+water elm
+water gum
+water hickory
+water locust
+water oak
+wattle
 wax myrtle
+wax palm
+weeping beech
+weeping spruce
+west coast hemlock
+west indian satinwood
+western balsam poplar
+western birch
+western chokecherry
+western crab apple
+western hemlock
+western larch
+western mountain ash
+western paper birch
 western redcedar
+western tamarack
 western white pine
+western yellow pine
+western yew
+westland pine
+weymouth pine
+wheately elm
+wheel tree
+white alder
 white ash
+white aspen
+white basswood
+white beech
+white birch
 white cedar
+white cypress
+white elm
 white fir
+white maire
+white mallee
+white mangrove
+white mountain ash
+white mulberry
 white oak
+white pine
+white popinac
+white poplar
+white silk-cotton tree
+white spruce
+white stringybark
+white walnut
+white willow
+white-berry yew
+white-heart hickory
 whitebark pine
+whitebarked pine
+wild apple
+wild cherry
+wild cherry tree
+wild china tree
+wild cinnamon
+wild crab
+wild fig
+wild mango
+wild mango tree
+wild medlar
+wild medlar tree
+wild orange
+wild plum
+wild plum tree
+wild service tree
+wild tamarind
 willow
 willow oak
+willow tree
+wine palm
+wing elm
+wing nut
+winged elm
+winter flowering cherry
+winter's bark
+winter's bark tree
+winterberry
 winterberry holly
+wisconsin weeping willow
+witch elm
+wollemi pine
+wych elm
+xylopia aethiopica
+yacca
+yacca podocarp
 yaupon holly
+yellow birch
+yellow cattley guava
+yellow cedar
+yellow chestnut oak
+yellow cypress
+yellow jacaranda
+yellow locust
+yellow mombin
+yellow mombin tree
+yellow oak
+yellow pine
+yellow spruce
+yellow-leaf sickle pine
 yellow-poplar
+yellowwood
+yellowwood tree
 yew
+ylang-ylang
+yukon white birch
+zaman
+zamang
+zanthoxylum americanum
+zanthoxylum clava-herculis
+zanthoxylum flavum
+zanthoxylum fraxineum
+zebrawood tree

--- a/lists/nature/vine.yml
+++ b/lists/nature/vine.yml
@@ -1,0 +1,558 @@
+---
+title: Vines and climbers
+category: nature
+description: "Climbing, twining, trailing, and creeping plants"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acorn squash
+actinidia arguta
+actinidia chinensis
+actinidia deliciosa
+actinidia polygama
+adlumia fungosa
+air potato
+alehoof
+allamanda
+allamanda cathartica
+allegheny vine
+american bittersweet
+american hop
+american ivy
+american wisteria
+amphicarpa bracteata
+amphicarpaea bracteata
+angled loofah
+apios americana
+apios tuberosa
+araujia sericofera
+aristolochia clematitis
+aristolochia durior
+aristolochia macrophylla
+aristolochia serpentaria
+ashanti pepper
+asparagus asparagoides
+australian pea
+autumn pumpkin
+balloon vine
+balsam apple
+balsam pear
+banana passion fruit
+barbados gooseberry
+barbados-gooseberry vine
+beach morning glory
+beaumontia grandiflora
+belle de nuit
+betel
+betel pepper
+bignonia capreolata
+bindweed
+bine
+birthwort
+bittersweet
+black bindweed
+black bryony
+black pea
+black pepper
+black-eyed susan vine
+blue jasmine
+blue jessamine
+blue pea
+bomarea edulis
+bomarea salsilla
+bonavist
+boston ivy
+bottle gourd
+bougainvillea
+bougainvillea glabra
+bower actinidia
+boxberry
+briony
+broad-leaved everlasting pea
+bryonia alba
+bryonia dioica
+bryony
+buffalo gourd
+bullbrier
+buttercup squash
+butterfly pea
+butternut squash
+cabernet sauvignon grape
+calabar-bean vine
+calabazilla
+calystegia sepium
+canada moonseed
+canavalia ensiformis
+canavalia gladiata
+cantaloup
+cantaloup vine
+cantaloupe
+cantaloupe vine
+cardiospermum grandiflorum
+cardiospermum halicacabum
+carolina jasmine
+carolina moonseed
+catbrier
+celastrus orbiculatus
+celastrus scandens
+centrosema virginianum
+ceriman
+chardonnay
+chardonnay grape
+chenin blanc
+chilean jasmine
+china fleece vine
+chinese gooseberry
+chinese wistaria
+chinese yam
+cinnamon vine
+citrullus vulgaris
+clematis
+clematis baldwinii
+clematis crispa
+clematis lasiantha
+clematis ochreleuca
+clematis tangutica
+clematis texensis
+clematis versicolor
+clematis verticillaris
+clematis viorna
+clematis virginiana
+clematis vitalba
+climber
+climbing bittersweet
+climbing boneset
+climbing corydalis
+climbing fern
+climbing fumitory
+climbing hemp-vine
+climbing hempweed
+climbing maidenhair
+climbing maidenhair fern
+clitoria mariana
+clitoria ternatea
+cocculus carolinus
+cocozelle
+common allamanda
+common grape vine
+common hop
+common hops
+common ivy
+common moonseed
+common morning glory
+common pepper
+confederate jasmine
+convolvulus
+convolvulus arvensis
+convolvulus scammonia
+convolvulus sepium
+coral pea
+coral vine
+corydalis claviculata
+courgette
+creeping fern
+cross vine
+cruel plant
+cubeb
+cubeb vine
+cucumber
+cucumber vine
+cucumis melo
+cucumis melo cantalupensis
+cucumis melo inodorus
+cucumis melo reticulatus
+cucumis sativus
+cucurbit
+cucurbita argyrosperma
+cucurbita foetidissima
+cucurbita maxima
+cucurbita maxima turbaniformis
+cucurbita mixta
+cucurbita moschata
+cucurbita pepo
+cucurbita pepo melopepo
+curly clematis
+curly-heads
+cuscuta gronovii
+cush-cush
+cushaw
+cymling
+cynanchum
+cynancum
+cypress vine
+delairea odorata
+derris elliptica
+derris root
+devil's darning needle
+devil's turnip
+dichondra
+dichondra micrantha
+dioscorea alata
+dioscorea batata
+dioscorea bulbifera
+dioscorea elephantipes
+dioscorea paniculata
+dioscorea trifida
+dipladenia boliviensis
+dipogon lignosus
+dishcloth gourd
+dodder
+dolichos lablab
+dolichos lignosus
+dutchman's-pipe
+earth-nut pea
+earthnut pea
+easter lily vine
+ecballium elaterium
+egyptian bean
+emerald creeper
+epipremnum aureum
+euonymus fortunei radicans
+euonymus radicans vegetus
+european hop
+evening trumpet flower
+evergreen bittersweet
+everlasting pea
+exploding cucumber
+false bittersweet
+field bindweed
+fox grape
+fumaria claviculata
+fumaria fungosa
+gelsemium sempervirens
+german ivy
+giant granadilla
+giant potato creeper
+giant stock bean
+gill-over-the-ground
+glechoma hederacea
+glechoma hederaceae
+goa bean
+goa bean vine
+golden clematis
+golden pothos
+golden trumpet
+gourd
+gourd vine
+granadilla
+grape
+grape vine
+grapevine
+grass pea
+grass vetch
+grass vetchling
+greenbrier
+ground ivy
+groundnut
+groundnut vine
+haoma
+hardenbergia comptoniana
+hartford fern
+heart pea
+heartseed
+heath pea
+hedera helix
+hedge bindweed
+hog peanut
+honey plant
+honeydew melon
+hop
+hops
+horse brier
+hottentot bread vine
+hottentot's bread vine
+hoya carnosa
+hubbard squash
+humulus americanus
+humulus japonicus
+humulus lupulus
+hyacinth bean
+imperial japanese morning glory
+indian pea
+ipomoea alba
+ipomoea batatas
+ipomoea coccinea
+ipomoea fastigiata
+ipomoea imperialis
+ipomoea leptophylla
+ipomoea nil
+ipomoea orizabensis
+ipomoea panurata
+ipomoea pes-caprae
+ipomoea purpurea
+ipomoea quamoclit
+ipomoea tricolor
+italian vegetable marrow
+ivy
+ivy arum
+jack bean
+jamaica honeysuckle
+japan bittersweet
+japanese bittersweet
+japanese hop
+japanese ivy
+japanese morning glory
+japanese wistaria
+java pepper
+kennedia coccinea
+kennedia prostrata
+khesari
+kiwano
+kiwi
+kiwi vine
+kudzu
+kudzu vine
+lablab purpureus
+lagenaria siceraria
+lathyrus latifolius
+lathyrus niger
+lathyrus nissolia
+lathyrus odoratus
+lathyrus sativus
+lathyrus sylvestris
+lathyrus tuberosus
+lathyrus vernus
+leather flower
+liana
+loofah
+love vine
+luffa
+luffa acutangula
+luffa cylindrica
+lygodium microphyllum
+lygodium palmatum
+madagascar pepper
+malvasia
+man-of-the-earth
+mandevilla boliviensis
+mandevilla laxa
+manila bean
+manroot
+marrow
+marrow squash
+marsh clematis
+maypop
+melon
+melon vine
+menispermum canadense
+merlot
+mikania scandens
+missouri gourd
+mitchella repens
+momordica balsamina
+momordica charantia
+monstera deliciosa
+moonflower
+moonseed
+morning glory
+mountain clematis
+muscadet
+muscadine
+muscat
+muskat
+muskmelon
+narrow-leaved everlasting pea
+nepal trumpet flower
+nepeta hederacea
+nepeta hederaceae
+net melon
+netted melon
+nutmeg melon
+old man's beard
+pachyrhizus erosus
+pachyrhizus tuberosus
+paper flower
+parthenocissus quinquefolia
+parthenocissus tricuspidata
+partridgeberry
+passiflora edulis
+passiflora foetida
+passiflora incarnata
+passiflora laurifolia
+passiflora ligularis
+passiflora maliformis
+passiflora mollissima
+passiflora quadrangularis
+passionflower
+passionflower vine
+pattypan squash
+pepper vine
+perennial pea
+pereskia aculeata
+periploca graeca
+persian melon
+physostigma venenosum
+pine hyacinth
+pinot
+pinot blanc
+pinot grape
+pinot noir
+pipe vine
+piper betel
+piper cubeba
+piper longum
+piper nigrum
+pipestem clematis
+polygonum aubertii
+potato
+potato bean
+potato vine
+prairie gourd
+prairie gourd vine
+psophocarpus tetragonolobus
+pueraria lobata
+pumpkin
+pumpkin vine
+purple clematis
+purple granadillo
+purple virgin's bower
+quamoclit pennata
+quarter-vine
+quartervine
+rag gourd
+railroad vine
+red bryony
+red morning-glory
+riesling
+root climber
+rough bindweed
+runaway robin
+running pop
+running postman
+russian vine
+salpichroa organifolia
+salpichroa rhomboidea
+salsilla
+sarcostemma acidum
+sarsaparilla
+sauvignon blanc
+sauvignon grape
+scammony
+scammonyroot
+scarlet clematis
+scindapsus aureus
+semi-climber
+senecio milkanioides
+shrubby bittersweet
+silk vine
+silky wisteria
+silver lace vine
+silver vine
+silvervine
+sing-kwa
+smilax
+smilax aspera
+smilax rotundifolia
+snake fern
+soapberry vine
+solanum commersonii
+solanum crispum
+solanum jamesii
+solanum jasmoides
+solanum tuberosum
+solanum wendlandii
+soma
+spaghetti squash
+sponge gourd
+spring vetchling
+squash
+squash vine
+squirting cucumber
+staff vine
+star ipomoea
+star jasmine
+star-glory
+strainer vine
+strongylodon macrobotrys
+summer squash
+summer squash vine
+sweet calabash
+sweet granadilla
+sweet melon
+sweet melon vine
+sweet pea
+sweet potato
+sweet potato vine
+sweetpea
+sword bean
+tamus communis
+tara vine
+thunbergia alata
+tortoise plant
+trachelospermum jasminoides
+traveler's joy
+traveller's joy
+true pepper
+tuba root
+tuberous vetch
+turban squash
+uruguay potato
+uruguay potato vine
+vase-vine
+vegetable marrow
+vegetable sponge
+verdicchio
+vetchling
+vincetoxicum hirsutum
+vincetoxicum negrum
+vine
+vinifera
+vinifera grape
+viorna baldwinii
+virgin's bower
+virginia serpentaria
+virginia serpentary
+virginia snakeroot
+vitis labrusca
+vitis rotundifolia
+vitis vinifera
+water yam
+watermelon
+watermelon vine
+wax plant
+waxwork
+western australia coral pea
+white bryony
+white dipladenia
+white pepper
+white potato
+white potato vine
+white yam
+wild bean
+wild climbing hempweed
+wild hop
+wild morning-glory
+wild peanut
+wild potato
+wild potato vine
+wild pumpkin
+wild sweet potato vine
+wild water lemon
+wild yam
+winged bean
+winter crookneck
+winter crookneck squash
+winter melon
+winter melon vine
+winter squash
+winter squash plant
+wistaria
+wisteria chinensis
+wisteria floribunda
+wisteria frutescens
+wisteria venusta
+wonder bean
+yam
+yam bean
+yam plant
+yellow granadilla
+yellow jasmine
+yellow jessamine
+yellow parilla
+yellow squash
+zinfandel
+zucchini

--- a/lists/nature/weed.yml
+++ b/lists/nature/weed.yml
@@ -1,0 +1,148 @@
+---
+title: Weeds
+category: nature
+description: "Wild, volunteer, and aggressively spreading plants"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+agrostemma githago
+alligator grass
+alligator weed
+alternanthera philoxeroides
+ambrosia
+ambrosia artemisiifolia
+ambrosia psilostachya
+ambrosia trifida
+artillery plant
+barbarea vulgaris
+barnaby's thistle
+bastard feverfew
+benweed
+bitterweed
+boar thistle
+bristly oxtongue
+brook thistle
+bull thistle
+california dandelion
+canada thistle
+canadian fleabane
+capeweed
+carduus crispus
+carduus nutans
+carlina acaulis
+carlina vulgaris
+carline thistle
+carpetweed
+centaurea solstitialis
+cirsium arvense
+cirsium discolor
+cirsium eriophorum
+cirsium flodmanii
+cirsium helenioides
+cirsium heterophylum
+cirsium lanceolatum
+cirsium rivulare
+cirsium vulgare
+clearweed
+cnicus benedictus
+cockle-bur
+cockle-burr
+cockleburr
+common carline thistle
+common ragweed
+conyza canadensis
+corn campion
+corn cockle
+corn spurrey
+corn spurry
+cotton thistle
+creeping thistle
+crown-of-the-field
+erechtites hieracifolia
+erigeron canadensis
+erysimum cheiranthoides
+european woolly thistle
+fanweed
+field pennycress
+field thistle
+french weed
+friendship plant
+golden thistle
+gosmore
+great ragweed
+groundsel
+hieracium aurantiacum
+hieracium praealtum
+hypochaeris radicata
+indian chickweed
+jointed charlock
+king devil
+knawe
+knawel
+laportea canadensis
+melancholy thistle
+mithridate mustard
+molluga verticillata
+musk thistle
+nettle
+nodding thistle
+onopordon acanthium
+onopordum acanthium
+orange hawkweed
+oxtongue
+panamica
+panamiga
+parthenium hysterophorus
+penny grass
+pennycress
+perennial ragweed
+picris echioides
+pilea involucrata
+pilea microphylla
+pilea pumilla
+pilosella aurantiaca
+plume thistle
+plumed thistle
+ragweed
+ragwort
+raphanus raphanistrum
+rocket cress
+roman nettle
+runch
+sand spurry
+scleranthus annuus
+scolymus hispanicus
+scotch thistle
+sea spurry
+senecio douglasii
+senecio jacobaea
+senecio vulgaris
+sisymbrium barbarea
+spanish oyster plant
+spear thistle
+spergula arvensis
+spergularia rubra
+stemless carline thistle
+stinging nettle
+stinkweed
+tansy ragwort
+thistle
+thlaspi arvense
+threadleaf groundsel
+urtica dioica
+urtica pipulifera
+weed
+welted thistle
+western ragweed
+wild radish
+wild rape
+wood nettle
+woolly thistle
+wormseed mustard
+yellow hawkweed
+yellow rocket
+yellow star-thistle


### PR DESCRIPTION
## Summary

- add 12,099 moderated, category-unique flora terms from Open English WordNet 2025
- expand the existing tree, flower, fungus, and plant lists
- add focused shrub, grass, herb, vine, fern, aquatic-plant, bulbous-plant, succulent, weed, moss-and-lichen, and plant-part lists
- remove the pre-existing outdated common name `the gypsy mushroom`
- grow the nature category from 3,214 to 15,312 unique entries

## Distribution

| List | Additions |
| --- | ---: |
| tree | 2,629 |
| shrub | 2,032 |
| flower | 971 |
| grass | 463 |
| herb | 2,279 |
| vine | 547 |
| fern | 424 |
| aquatic plant | 298 |
| bulbous plant | 428 |
| succulent | 75 |
| weed | 137 |
| moss and lichen | 39 |
| fungus | 455 |
| plant part | 495 |
| general plant | 827 |

## Source and method

The vocabulary is adapted from the plant hierarchy in [Open English WordNet 2025](https://en-word.net/downloads), using its common-noun release rather than the separate proper-name edition. The source repository is pinned at release commit [`dc343f2`](https://github.com/globalwordnet/english-wordnet/commit/dc343f2683279ecbb13fab4e2fd778d7b162d287).

Source archive SHA-256: `38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93`

Terms were assigned from explicit WordNet branches to the nearest useful visual-prompt list, normalized to lowercase prompt phrases, and deduplicated against every existing nature list. Specific forms win before the general plant bucket, so one term is not introduced into several new lists.

A moderation filter removes adult, drug, slur-shaped, and deprecated surface forms. The pass also removes the existing outdated fungus name noted above. Botanical names containing unrelated substrings, such as Latin `orientalis`, remain intact.

Open English WordNet is published by the Open English WordNet Community under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) and derives from Princeton WordNet 3.1. The 11 new files carry primary source metadata; the four expanded mixed-source files carry the OEWN details under `additionalSource*` fields.

## Validation

- 12,099 additions / 12,099 exact and punctuation-normalized unique terms
- all 12,099 added terms resolve to members of the pinned OEWN plant source
- zero exact or punctuation-normalized collisions with the existing nature category
- nature category: 3,214 to 15,312 punctuation-normalized unique entries
- all entries lowercase and non-empty
- moderation-token audit clean across every added line
- all 11 new list keys present after an isolated build
- isolated `npm run sanitise`, `npm run build`, and `npm run lint` succeed
- sanitizer produces no source diff
- `git diff --check` clean

Generated indexes are intentionally omitted per the repository content-PR contract; the post-merge workflow regenerates them.
