### PR TITLE
Expand visual phenomena and forms with 1,309 sourced terms

### DIFF
--- a/lists/art/form-and-shape.yml
+++ b/lists/art/form-and-shape.yml
@@ -1,0 +1,119 @@
+---
+title: Forms and shapes
+category: art
+description: "Contours, silhouettes, folds, reliefs, and spatial forms"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+accordion fold
+amorphous shape
+angular shape
+angularity
+ball
+barrel
+bead
+bend
+bifurcation
+blob
+bolus
+buckle
+bulb
+cavity
+coil
+columella
+column
+concertina fold
+cone
+cone shape
+conglobation
+conglomeration
+conoid
+contortion
+convolution
+crease
+crimp
+crookedness
+curl
+curlicue
+cylinder
+dewdrop
+disc
+disk
+distorted shape
+distortion
+drop
+drum
+ellipsoid of revolution
+emptiness
+enclosed space
+flair
+flare
+flexure
+fold
+forking
+funnel
+funnel shape
+furcation
+globe
+gnarl
+gyre
+hole
+hollow
+hoodoo
+jog
+kink
+knot
+leaf form
+leaf shape
+natural shape
+orb
+pearl
+pellet
+pillar
+pipe
+plication
+pocket
+point
+pore
+pouch
+pucker
+ringlet
+roll
+round shape
+ruck
+sac
+sack
+saucer
+shapelessness
+space
+sphere
+spheroid
+spherule
+square
+teardrop
+toroid
+torsion
+tortuosity
+tortuousness
+torus
+tower
+triangle
+tube
+twirl
+twist
+vacancy
+vacuum
+verticil
+void
+vortex
+warp
+whirl
+whorl
+z-fold
+zag
+zig
+zig-zag fold

--- a/lists/nature/natural-phenomenon.yml
+++ b/lists/nature/natural-phenomenon.yml
@@ -2,49 +2,154 @@
 title: Natural Phenomena
 category: nature
 description: "Rare atmospheric, meteorological, and natural optical phenomena"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+abiogenesis
+aerobiosis
 afterglow
+alluvial cone
+alluviation
+alluvion
+alpha rhythm
+alpha wave
+alternation of generations
+annual ring
+apoptosis
 aurora australis
 aurora borealis
+autogenesis
+autogeny
 ball lightning
+beta rhythm
+beta wave
+bioelectricity
+biology
 bioluminescence
 bioluminescent waves
 blue jets
+brain death
+brain wave
+brainwave
+caspase-mediated cell death
+cataclysm
+catastrophe
 catatumbo lightning
+cell death
+cerebral death
+champion lode
+circulation
 circumhorizontal arch
+continental drift
+cortical potential
 crepuscular rays
+cyclosis
+death
+debacle
+decay
+decomposition
+dehiscence
+delta rhythm
+delta wave
+deposit
+desquamation
+diapedesis
+digenesis
+dimorphism
+dominance
 double rainbow
 dust devil
 elves
+endogeny
+exfoliation
+facilitation
 fata morgana
 fire rainbow
 fire whirl
+flash flood
+flashflood
+floodhead
 fog bow
+food chain
+food cycle
+food pyramid
+food web
 frost flowers
+frost heave
+frost heaving
+gangrene
+gene expression
+geological phenomenon
 geyser
 green flash
+greening
+growth ring
 halo
+heterogenesis
+histocompatibility
 ice circle
+inundation
 lenticular cloud glow
+life
+life cycle
 light pillar
+load
+lode
 lunar eclipse
+metagenesis
 milky seas
 mirage
 moon dog
 moonbow
+mortification
+mother lode
 murmuration
+myonecrosis
+necrobiosis
+necrosis
+noachian deluge
+noah and the flood
+noah's flood
+nuclear winter
+organic phenomenon
 parhelion
+peeling
 penitentes
+pleomorphism
+polymorphism
+programmed cell death
+pulmonary circulation
 rainbow
+recognition
 red tide
+rejection
+rejuvenation
 sailing stones
+sedimentation
+shedding
+single nucleotide polymorphism
 solar eclipse
+sphacelus
+spontaneous generation
 sprites
 st. elmo's fire
+streaming
 sun dog
 superbloom
+systemic circulation
+the flood
+theta rhythm
+theta wave
 tidal bore
+transgression
+vitelline circulation
 volcanic lightning
+volcanism
 waterspout
 whirlpool
 white rainbow
+xenogenesis

--- a/lists/nature/weather.yml
+++ b/lists/nature/weather.yml
@@ -2,24 +2,56 @@
 title: Weather
 category: nature
 description: "Meteorological events, cloud types, and severe weather conditions"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 acid rain
+air
+air current
+air hole
+air pocket
+airstream
 altocumulus clouds
 altostratus clouds
+antitrade
+antitrade wind
+antitrades
 asperitas clouds
+atmospheric condition
+atmospheric electricity
+atmospheric phenomenon
 aurora australis
 aurora borealis
 avalanche
 balmy
+bise
+bize
 black frost
 black ice
+blast
 blizzard
+blow
+blue jet
+bluster
 blustery
 boiling
+bolt
+bolt of lightning
+boreas
+breath
+breeze
 breezy
 brisk
 calm
+calm air
+catabatic wind
+chain lightning
 chilly
+chinook
 chinook wind
 cirrocumulus clouds
 cirrostratus clouds
@@ -30,50 +62,89 @@ cloudy
 cold
 cold front
 cold snap
+cold wave
+cold weather
+condensate
+condensation
+conditions
 cool
 crepuscular rays
 crisp
+crosswind
 cumulonimbus clouds
 cumulus clouds
+current of air
 cyclone
 damp
 deluge
 derecho
 diamond dust
+doldrums
 downburst
+downdraft
+downfall
 downpour
+draft
+draught
 drizzle
 drought
 dry
 dust storm
+duster
+east wind
+easter
+easterly
+electric storm
+electrical storm
+elements
+equinoctial storm
+fair weather
+fine spray
 fire rainbow
+firestorm
 flood
 flurry
+foehn
 fog
 fogbow
 foggy
+fohn
+forked lightning
+freeze
 freezing
 freezing rain
+fresh breeze
+fresh gale
 frigid
+front
 frost
 frosty
 frozen drizzle
 frozen rain
 funnel cloud
 gale
+gentle breeze
+gentle wind
 glaze
 graupel
+greenhouse effect
+greenhouse warming
+gust
 gusts of wind
 haboob
 hail
 hailstorm
 halo around the moon
+harmattan
 haze
 hazy
+headwind
 heat lightning
+heat wave
 heatwave
 heavy rain
 heavy snow
+high wind
 hoarfrost
 hot
 humid
@@ -83,52 +154,118 @@ ice storm
 icicles
 icy
 indian summer
+inversion
+jet
+jet stream
+katabatic wind
 kelvin-helmholtz clouds
+khamsin
 lake-effect snow
 landspout
+languor
 lenticular clouds
+levanter
+light air
+light breeze
 light pillar
 light snow
 lightning
 lightning bolt
 lightning storm
+line squall
+line storm
 mammatus clouds
+meteor shower
+meteor stream
 microburst
+midnight sun
 mild
 mist
+mistral
 mistral wind
 misty
+mizzle
+moderate breeze
+moderate gale
 monsoon
 moonbow
 muggy
 nacreous clouds
+near gale
 nimbostratus clouds
 noctilucent clouds
 nor'easter
+noreaster
+north wind
+northeaster
+norther
+northerly
+northern lights
+northwest wind
+northwester
 occluded front
+occlusion
 overcast
+parhelic circle
+parhelic ring
 partly cloudy
+pelter
+pocket
+polar front
 polar vortex
 powder snow
+precipitation
+prevailing westerly
+prevailing wind
+puff
+puff of air
 rain shower
 rainbow
+rainfall
+rainstorm
 rainy
+red sprites
 refreshing
+reverse lightning
+samiel
+sandblast
 sandstorm
+santa ana
+scattering
+scorcher
 scorching
+sea breeze
+shower
+silver storm
+simoom
+simoon
+sirocco
 sirocco wind
 sizzling
 sleet
 smattering
 smog
 smoggy
+snow
+snow eater
 snow flurry
 snow squall
 snowdrift
 snowfall
 snowstorm
 snowy
+soaker
+solar halo
+sou'easter
+sou'wester
+south wind
+southeaster
+souther
+southerly
+southern lights
+southwester
 sprinkle
+sprinkling
 squall
 squall line
 stationary front
@@ -136,26 +273,59 @@ storm surge
 stormy
 stratocumulus clouds
 stratus clouds
+strong breeze
+strong gale
+sultriness
 sultry
 sun dog
 sun halo
 sunny
+sunrise
+sunset
+sunshine
 sunshower
+supertwister
+sweat
 sweltering
+tailwind
+temperateness
 tempest
+thaw
+thawing
+thermal
 thunder
 thunder snow
 thunderbolt
+thundershower
 thunderstorm
 tornado
+torrent
 torrential rain
+trade
+trade wind
+tramontana
+tramontane
 twister
 typhoon
+updraft
+violent storm
 virga
 warm
 warm front
+warming
 waterspout
+wave
+weather
+weather condition
+west wind
+wester
+westerly
+whiff
+whirlwind
 white frost
 whiteout
+whole gale
+wind
 windstorm
 windy
+zephyr

--- a/lists/photography/optical-phenomenon.yml
+++ b/lists/photography/optical-phenomenon.yml
@@ -1,0 +1,41 @@
+---
+title: Optical phenomena
+category: photography
+description: "Light, color, reflection, refraction, and optical effects"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+aberration
+absorption band
+annual parallax
+apparent motion
+apparent movement
+dichroism
+diffraction
+distortion
+diurnal parallax
+fata morgana
+fringe
+geocentric parallax
+heliocentric parallax
+horizontal parallax
+incidence
+interference fringe
+mirage
+motion
+optical aberration
+optical illusion
+optical phenomenon
+parallax
+pleochroism
+polarisation
+polarization
+solar parallax
+stellar parallax
+trichroism
+tyndall effect
+x-ray diffraction

--- a/lists/science/geometry.yml
+++ b/lists/science/geometry.yml
@@ -2,121 +2,542 @@
 title: Geometrical and mathematical terms
 category: science
 description: "Advanced mathematical shapes, fractals, attractors, and geometric concepts"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+acute angle
+acute triangle
+acute-angled triangle
+anchor ring
+angle
+angle of attack
+angle of dip
+angle of extinction
+angle of incidence
+angle of inclination
+angle of reflection
+angle of refraction
+angle of view
+angular distance
 annulus
 apollonian gasket
+arch
 archimedean
 archimedean solids
+asterism
+asymptote
+azimuth
 barnsley fern
+base
+bell
+bell shape
+belly
+bend
+bias
+bifurcation
+bight
+block
+border
+bound
+boundary
+bow
+bowl
+box
+brachistochrone
+brachium
+branch
 bravais lattice
+brink
 buckminster fullerene
 bucky ball
+bulge
+bump
 calabi-yau manifold
+camber
+campana
 cantor set
+caput
+cardioid
+cartesian plane
+cast
+catacaustic
+catenary
 catenoid
+caustic
 cellular automaton
+center line
+centerline
+channel
 chaos theory
 chaotic system
+chap
+chord
+circle
+circlet
+cladogram
+cleft
 clifford attractor
+closed curve
+complementary angles
+complex plane
+concave polygon
+concave polyhedron
+concave shape
+concavity
+conchoid
+conchoid of nicomedes
+conic
 conic section
+convex polygon
+convex polyhedron
+convex shape
+convexity
 conway's game of life
+corner
+corrugation
+cosine curve
+cotangent curve
+crack
+cranny
+crease
+crenation
+crenature
+crenel
+crenelle
+crescent
+crevice
+crinkle
+critical angle
+crook
+crotchet
+crow's feet
+crow's foot
 crystal lattice
 crystallographic
 crystallographic symmetry
 cube
 cuboctahedron
+cuboid
+cuneus
+cup
+cupid's bow
+curtate cycloid
+curve
+curved shape
+cutting angle
+cycloid
 cylinder
 de jong attractor
+decagon
+decahedron
+delta
 deltoidal icositetrahedron
+demand curve
+dent
+depression
+dermatoglyphic
+diagonal
+diameter
+diamond
+dihedral angle
+dimple
+dip
 directrix
 disdyakis dodecahedron
+dodecagon
 dodecahedron
+dogleg
+dome
+double helix
+doughnut
 dragon curve
+droop
+edge
+element
+element of a cone
+element of a cylinder
+ellipse
 ellipsoid
+entasis
+envelope
+epicycle
+epicycloid
+equator
+equiangular triangle
+equilateral
+equilateral triangle
 euclidean geometry
+excrescence
+exterior angle
+external angle
+extinction angle
+extrados
+extrusion
+face angle
+facet
+facet plane
 fibonacci spiral
+figure
+figure 8
+figure eight
+figure of eight
+fissure
+flank
+fork
+fossa
+foursquare
 fractal
 fractal art
 fractal circle
 fractal curve
 fractal dimension
 fractal pattern
+fringe
+frown line
+frustum
+furrow
+geodesic
 geodesic dome
+geodesic line
+geofence
 geometric
+gibbosity
+gibbousness
 golden ratio
 golden spiral
+gooseneck
 graph theory
+groove
 group theory
+halo
+head line
+heart
+heart line
 helicoid
+helix
+helix angle
+hemicycle
+hemisphere
 henon attractor
+heptagon
+hexagon
+hexagram
+hexahedron
 hexecontahedron
 hilbert curve
+hip
+hook
+hour angle
+hump
 hyperbola
 hyperbolic geometry
+hyperboloid
 hypercube
+hypocycloid
+hypotenuse
 icosahedron
 icosidodecahedron
+ideal solid
+impression
+imprint
+incidence angle
+incision
+incisura
+incisure
+inclination
+inclination of an orbit
+incurvation
+incurvature
+indentation
+indenture
+indifference curve
+interior angle
+internal angle
+intrados
+isogon
 isometric
+isosceles triangle
+jordan curve
 julia 3d fractal
 julia fractal
 julia set
 julia set fractal
+jut
+keel
 kite hexecontahedron
 klein bottle
+knife
+knob
 knot theory
 koch curve
 l-systems
 lattice
+laugh line
+leg
+lemniscate
+life line
+lifeline
+line of destiny
+line of fate
+line of heart
+line of life
+line of saturn
+line roulette
+loop
 lorenz attractor
 lorenz system
+love line
+lower bound
+magnetic declination
+magnetic dip
+magnetic inclination
+magnetic variation
 mandelbox
 mandelbrot set
 mandelbulb
+margin
 menger sponge
 menger sponge fractal
+mensal line
+midline
+midplane
 mobius strip
 moebius transformation
+mogul
+mold
+mould
+niche
+node
 non-crystallographic symmetry
 non-euclidean geometry
 non-orientable surface
+nonagon
+notch
+nub
+nubble
+oblique angle
+oblique triangle
+oblong
+obtuse angle
+obtuse triangle
+obtuse-angled triangle
+octagon
 octahedron
+orbital plane
+outer boundary
+oval
+ovoid
 parabola
+paraboloid
+parallel
 parallelepiped
+parallelepipedon
+parallelogram
+parallelopiped
+parallelopipedon
+peak
+pedal curve
+pencil
 penrose stairs
 penrose tiling
 penrose triangle
+pentacle
+pentagon
 pentagonal
 pentagonal hexecontahedron
+pentagram
+pentahedron
+pentangle
+perigon
+perimeter
+periphery
+perpendicular
+picture plane
+pit
+plane
+plane angle
+plane figure
+platonic body
 platonic solid
+pocket
 poincare disk
+point
+polygon
+polygonal chain
+polygonal shape
 polyhedra
+polyhedral angle
+polyhedron
+prism
+prismatoid
+prismoid
 projective geometry
+prolate cycloid
+prominence
+protrusion
+protuberance
 pseudosphere
+pyramid
+pythagorean triangle
+quadrangle
+quadrangular prism
+quadrate
+quadric
+quadric surface
+quadrilateral
 quasicrystals
+radius
+ramification
+recess
+recession
+rectangle
+reentering angle
+reentering polygon
+reentrant angle
+reentrant polygon
+reflex angle
+regular convex polyhedron
+regular convex solid
+regular dodecahedron
+regular hexagon
+regular hexahedron
+regular icosahedron
+regular octahedron
+regular pentagon
+regular polygon
+regular polyhedron
+regular prism
+regular pyramid
+regular tetrahedron
+rhomb
 rhombicuboctahedron
+rhombohedron
+rhomboid
+rhombus
+ridge
 riemann hypothesis
+right angle
+right prism
+right triangle
+right-angled triangle
+rim
+ring
 rossler attractor
+roulette
+round angle
+rut
+s-shape
 sacred geometry
+sag
+salient angle
+scalene triangle
+scallop
+scoop
+score
+scotch
+scratch
+seam
+secant
+sector
+semicircle
+sheet
 sierpinski
 sierpinski carpet
 sierpinski triangle
+simple closed curve
+sine curve
+sinuosity
+sinuousness
+sinusoid
+slit
+snag
+solid angle
+solid figure
 sphere
+spherical angle
 spherical geometry
+spherical polygon
+spherical triangle
+spine
+spiral
+spur
+square
+square pyramid
+stamp
+stemma
+straight line
 strange attractor
+stria
+striation
+subfigure
 superellipse
 superellipsoid
+supply curve
+swelling
 symmetry
+tail
+tail end
+tangent
+tangent curve
+tangent plane
+taper
 tessellating
 tesseract
+tetragon
 tetrahedron
+thalweg
+thickening
+three-dimensional figure
+threshold
 tiling
+tilt angle
+tip
+tongue
 topological
 topology
+toroid
+torsion angle
 torus
+trapezium
+trapezohedron
+trapezoid
+tree
+tree diagram
 triakis octahedron
+triangle
+triangular prism
+trigon
+trilateral
+trough
+true anomaly
+truncated cone
 truncated cuboctahedron
 truncated icosahedron
 truncated icosidodecahedron
 truncated octahedron
+truncated pyramid
 truncated tetrahedron
+turn
+twist
+two-dimensional figure
+uncus
+undecagon
+undulation
+upper bound
+variation
+vector
+verge
+vertical angle
+view angle
 voronoi diagram
+wart
+washout
+wave
+wave angle
+wedge
+wedge shape
+wrinkle

--- a/lists/science/physical-phenomenon.yml
+++ b/lists/science/physical-phenomenon.yml
@@ -1,0 +1,504 @@
+---
+title: Physical phenomena
+category: science
+description: "Chemical, electrical, acoustic, energetic, and physical effects"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+abrasion
+acoustic impedance
+acoustic phenomenon
+acoustic projection
+acoustic reactance
+acoustic resistance
+actinic radiation
+actinic ray
+activation energy
+active power
+adhesive friction
+adiabaticity
+aerodynamic force
+aerodynamic lift
+aerosol
+affinity
+air pressure
+allotropism
+allotropy
+alpha radiation
+alpha ray
+alternating current
+alternating electric current
+alternative energy
+amperage
+amplitude distortion
+antiferromagnetism
+arc
+arterial pressure
+atmospheric pressure
+atomic energy
+atomic power
+attraction
+attractive force
+attrition
+aureole
+autofluorescence
+ballistic trajectory
+ballistics
+barometric pressure
+beam
+beam of light
+beta radiation
+beta ray
+binding energy
+bioelectric potential
+bioluminescence
+birefringence
+black-body radiation
+blackbody radiation
+blood pressure
+bloom
+bolide
+bond
+boundary layer
+breaking point
+brush discharge
+candle flame
+candlelight
+capacitance
+capacity
+capillarity
+capillary action
+carrier
+carrier wave
+cathode ray
+centrifugal force
+centripetal force
+charge
+chemical attraction
+chemical bond
+chemical energy
+chemical phenomenon
+chemiluminescence
+chop
+cloud
+cohesion
+color force
+compartment pressure
+conductance
+conduction
+conductivity
+coordinate bond
+coriolis force
+corona
+corona discharge
+corposant
+corpuscular-radiation pressure
+cosmic background radiation
+cosmic dust
+cosmic microwave background radiation
+cosmic radiation
+counterglow
+covalent bond
+cross-link
+cross-linkage
+crystallisation
+crystallization
+crystallizing
+current
+current electricity
+dative bond
+daylight
+decalescence
+detrition
+diamagnetism
+diastolic pressure
+dielectric heating
+dimorphism
+dipole moment
+direct current
+direct electric current
+discharge
+dissociation energy
+distortion
+doppler effect
+doppler shift
+double bond
+double refraction
+drag
+drift
+dust cloud
+dynamic electricity
+efflorescence
+elan vital
+elastance
+elastic energy
+elastic potential energy
+electric arc
+electric charge
+electric current
+electric dipole moment
+electric discharge
+electric energy
+electric field
+electric glow
+electric potential
+electric power
+electric resistance
+electrical capacity
+electrical conduction
+electrical disturbance
+electrical elastance
+electrical energy
+electrical phenomenon
+electrical power
+electrical resistance
+electricity
+electromagnetic interaction
+electromagnetic radiation
+electromagnetic wave
+electromagnetism
+electromotive force
+electron beam
+electron radiation
+electrostatic bond
+electrostatic charge
+electrostatic field
+electrovalent bond
+energy
+energy level
+energy of activation
+energy state
+event
+evoked potential
+exchange
+exchange energy
+ferrimagnetism
+ferromagnetism
+field
+field of force
+fireball
+firelight
+flare
+flashover
+flight
+floatation
+flotation
+fluorescence
+flux
+fog
+fogbank
+force
+force field
+force per unit area
+free energy
+friar's lantern
+friction
+fume
+fundamental interaction
+galvanism
+gamma radiation
+gamma ray
+gas pressure
+gaslight
+gegenschein
+geothermal energy
+glow
+glowing
+gravitation
+gravitational attraction
+gravitational field
+gravitational force
+gravitational interaction
+gravity
+gravity-assist
+grinding
+grip
+ground effect
+ground wave
+gun smoke
+half-light
+haze
+head
+heat
+heat energy
+heat of condensation
+heat of dissociation
+heat of formation
+heat of fusion
+heat of solidification
+heat of solution
+heat of sublimation
+heat of transformation
+heat of vaporisation
+heat of vaporization
+heat ray
+hertzian wave
+high beam
+hydroelectricity
+hydrogen bond
+hydrostatic head
+hysteresis
+ice fog
+ignis fatuus
+impedance
+impetus
+impulsion
+incandescence
+inductance
+induction
+inertia
+infrared
+infrared emission
+infrared light
+infrared radiation
+infrared ray
+insolation
+instantaneous sound pressure
+interaction
+interfacial surface tension
+interfacial tension
+interreflection
+interrupt
+intraocular pressure
+ion beam
+ionic beam
+ionic bond
+ionizing radiation
+ionospheric wave
+irradiation
+jack-o'-lantern
+jet propulsion
+juice
+k.e
+kinetic energy
+lamplight
+laser beam
+latent heat
+leverage
+life force
+lift
+light
+light beam
+line
+load
+long wave
+lorentz force
+low beam
+luminescence
+luminous energy
+magnetic attraction
+magnetic dipole moment
+magnetic energy
+magnetic field
+magnetic flux
+magnetic force
+magnetic moment
+magnetic resonance
+magnetism
+magnetomotive force
+magnetosphere
+mechanical energy
+mechanical phenomenon
+mechanical power
+mechanical stress
+medium wave
+metallic bond
+microwave
+mist
+moment
+moment of a couple
+moment of a magnet
+moment of inertia
+moon ray
+moonbeam
+moonlight
+moonshine
+mushroom
+mushroom cloud
+mushroom-shaped cloud
+mutual induction
+natural phenomenon
+negative charge
+neutron radiation
+nonlinear distortion
+nonparticulate radiation
+nuclear energy
+nuclear magnetic resonance
+nuclear power
+nuclear propulsion
+nuclear resonance
+ohmage
+ohmic resistance
+oil pressure
+opacity
+optical opacity
+osmotic pressure
+overpressure
+p.e
+paramagnetism
+particle beam
+pea soup
+pea-souper
+peptide bond
+peptide linkage
+phosphorescence
+photochemical exchange
+photoconduction
+photoconductivity
+photoelectricity
+physical phenomenon
+piezo effect
+piezoelectric effect
+piezoelectricity
+pleomorphism
+pogonip
+polymorphism
+positive charge
+potential
+potential difference
+potential drop
+potential energy
+power
+pressure
+pressure level
+projection
+propagation
+propulsion
+proton magnetic resonance
+pull
+purchase
+push
+pyroelectricity
+radiance
+radiant energy
+radiation
+radiation field
+radiation pressure
+radio emission
+radio radiation
+radio signal
+radio wave
+radio-opacity
+radiopacity
+rated voltage
+ray
+ray of light
+reactance
+reaction
+reaction propulsion
+real power
+red shift
+redshift
+reflection
+reflexion
+refraction
+reluctance
+repulsion
+repulsive force
+resistance
+resistivity
+resolution
+resolving power
+resonance
+rest energy
+resting potential
+retarding force
+rocket propulsion
+roentgen ray
+rubbing
+saint elmo's fire
+saint elmo's light
+saint ulmo's fire
+saint ulmo's light
+scintillation
+sea-level pressure
+self-induction
+separation energy
+shaft
+shaft of light
+shooting star
+short wave
+signal
+skin effect
+sky glow
+sky wave
+smoke
+smother
+solar energy
+solar gravity
+solar magnetic field
+solar power
+solar prominence
+solar radiation
+sonic barrier
+sound
+sound barrier
+sound pressure
+sound projection
+spark
+specific heat
+st. elmo's fire
+starlight
+static electricity
+streamer
+stress
+strong force
+strong interaction
+suction
+sun
+sun-ray
+sunbeam
+sunburst
+sunlight
+sunray
+sunshine
+superconductivity
+surface tension
+systolic pressure
+syzygy
+tension
+thermal conductivity
+thermionic current
+thermoelectricity
+thrust
+torchlight
+torque
+torsion
+traction
+trajectory
+transparence
+transparency
+turbulence
+turbulency
+twilight
+ultraviolet
+ultraviolet illumination
+ultraviolet light
+ultraviolet radiation
+valency
+van der waal's forces
+vapor pressure
+vapour pressure
+venous pressure
+virtual image
+visible light
+visible radiation
+vital force
+vitality
+voltage
+waterpower
+wattage
+wave front
+weak force
+weak interaction
+will-o'-the-wisp
+wind generation
+wind power
+windage
+work
+x-radiation
+zodiacal light


### PR DESCRIPTION
## Summary

- add 1,309 moderated, source-backed visual terms from Open English WordNet 2025
- expand weather, natural phenomena, and mathematical geometry
- add focused optical-phenomenon, physical-phenomenon, and form-and-shape lists
- route each branch to its semantic category instead of adding everything to `thing`

## Distribution

| Category/list | Additions |
| --- | ---: |
| nature/weather | 164 |
| nature/natural-phenomenon | 99 |
| photography/optical-phenomenon | 30 |
| science/physical-phenomenon | 493 |
| science/geometry | 415 |
| art/form-and-shape | 108 |

Category totals after the change:

- nature: 15,312 to 15,575 unique terms
- photography: 2,717 to 2,747
- science: 1,263 to 2,171
- art: 1,605 to 1,713

## Source and method

The vocabulary is adapted from explicit taxonomy branches in [Open English WordNet 2025](https://en-word.net/downloads), using its common-noun release at pinned source commit [`dc343f2`](https://github.com/globalwordnet/english-wordnet/commit/dc343f2683279ecbb13fab4e2fd778d7b162d287).

Source archive SHA-256: `38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93`

Placement follows the source hierarchy but respects prompt-list semantics:

- atmospheric descendants go to nature/weather
- geological and organic phenomena go to nature/natural-phenomenon
- optical descendants go to photography/optical-phenomenon
- remaining chemical, electrical, acoustic, energetic, and physical descendants go to science/physical-phenomenon
- mathematical figures, solids, planes, lines, and angles go to science/geometry
- curated natural, amorphous, distorted, rounded, folded, and spatial forms go to art/form-and-shape

Extraction is restricted to the source noun.phenomenon and noun.shape lexicographer files, preventing cross-taxonomy edges such as botanical shapes from leaking into geometry. Terms are normalized to lowercase prompt phrases and punctuation-normalized-deduplicated across their destination category. A moderation filter excludes adult, drug, slur-shaped, and deprecated surface forms.

Open English WordNet is published by the Open English WordNet Community under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) and derives from Princeton WordNet 3.1. New files carry primary source metadata; expanded mixed-source files carry the OEWN details under `additionalSource*` fields.

## Validation

- 1,309 additions / 1,309 category-unique normalized terms
- all 1,309 additions resolve to members of the pinned OEWN source
- zero removals or normalized collisions in any destination category
- all entries lowercase and non-empty
- moderation-token audit clean across every added line
- all three new list keys present after an isolated build
- isolated `npm run sanitise`, `npm run build`, and `npm run lint` succeed
- sanitizer produces no source diff
- `git diff --check` clean

Generated indexes are intentionally omitted per the repository content-PR contract; the post-merge workflow regenerates them.

The broader OEWN material/substance taxonomy is intentionally left for a separate category-splitting PR; it needs a careful architecture/fashion/science/thing assignment rather than a bulk import.

