### PR TITLE
Expand material vocabulary with 815 sourced terms

### DIFF
--- a/lists/architecture/building-materials.yml
+++ b/lists/architecture/building-materials.yml
@@ -11,12 +11,23 @@ attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet
 ---
 adobe brick
 ashlar
+autoclaved aerated concrete
+autoclaved cellular concrete
+autoclaved concrete
+autoclaved lightweight concrete
 batten
+board
 breeze block
+bricks and mortar
 building block
+building material
 calcium-silicate brick
 capstone
+cellular concrete
+cement
+chipboard
 cinder block
+clapboard
 cleat
 clinker
 clinker block
@@ -29,48 +40,102 @@ cope
 copestone
 coping
 coping stone
+corkboard
 cornerstone
+covering material
 curbstone
+deal
+fencing material
+ferroconcrete
+fibreglass
 fingerboard
 firebrick
 flagstone
 flintlime brick
+flooring
+foamed concrete
 foundation stone
 furring
 furring strip
 garboard
 garboard plank
 garboard strake
+grout
 gun rest
+gunite
 gunnel
 gunwale
+hardboard
 hearthstone
+hip tile
+hipped tile
 hone
+hydraulic cement
 impost
+insulant
+insulation
 jackstraw
 kerbstone
 lag
+lagging
 lath
+lath and plaster
+lightweight aerated concrete
+lightweight concrete
+lino
+linoleum
 louver
 louvre
+lumber
 matchboard
 millstone
 monolith
+mortar
 oilstone
 pale
+pantile
+parget
+pargeting
+pargetting
 paving stone
 picket
+plank
+planking
+porous concrete
+portland cement
+puddle
+render
+ridge tile
+roofing material
+roofing paper
+roofing tile
+roughcast
 sand-lime brick
 sett
+shake
+siding
 slat
+slating
+spackle
+spackling compound
 spillikin
 splat
 spline
 springer
+staff
 stela
 stele
+sticks and stone
 strake
 stretcher
+structural concrete
+tar paper
+thatch
+tile
 toothpick
+ultra-lightweight concrete
+variable density concrete
 wale
+weatherboard
+weatherboarding
 whetstone

--- a/lists/art/pigment-and-dye.yml
+++ b/lists/art/pigment-and-dye.yml
@@ -1,0 +1,132 @@
+---
+title: Pigments and dyes
+category: art
+description: "Natural and synthetic pigments, dyes, inks, stains, and colorants"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+acid dye
+alizarin
+alizarin carmine
+alizarin crimson
+alizarin red
+alizarin yellow
+alizarine
+anil
+aniline dye
+antimony potassium tartrate
+archil
+azo dye
+basic color
+basic colour
+basic dye
+bister
+bleu vegetal pour les veines
+blue
+blueing
+bluing
+bole
+burnt sienna
+burnt umber
+cadmium orange
+cadmium yellow
+cadmium yellow pale
+cerulean blue
+ceruse
+chinese white
+chrome alum
+chrome green
+chrome yellow
+cobalt blue
+cobalt ultramarine
+cochineal
+color
+coloring material
+colour
+colouring material
+cudbear
+cupric acetate
+cyanine dye
+direct dye
+dye
+dyestuff
+earth color
+fluorescein isocyanate
+fluorescein isothiocyanate
+fluorochrome
+french blue
+french ultramarine
+french ultramarine blue
+hair coloring
+hair dye
+henna
+hooker's green
+indian red
+indigo
+indigotin
+iron blue
+ivory black
+kendal
+kendal green
+lac dye
+lake
+lead acetate
+lead carbonate
+metallized dye
+mordant
+mosaic gold
+ocher
+ochre
+orange
+orchil
+paris green
+payne's gray
+payne's grey
+pheno-safranine
+pigment
+prussian blue
+quercitron
+radiopaque dye
+raw sienna
+raw umber
+rinse
+saffranine
+safranin
+safranine
+sepia
+sienna
+sinoper
+sinopia
+sinopis
+sodium bichromate
+sodium dichromate
+stannic sulfide
+substantive dye
+sugar of lead
+tartar emetic
+tincture
+tint
+titania
+titanic oxide
+titanium dioxide
+titanium oxide
+tyrian purple
+ultramarine
+ultramarine blue
+umber
+vat color
+vat dye
+verdigris
+water-color
+water-colour
+watercolour
+white lead
+windsor green
+woad
+yellow ocher
+yellow ochre
+zinc white

--- a/lists/fashion/textile.yml
+++ b/lists/fashion/textile.yml
@@ -10,8 +10,15 @@ sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
 attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 aba
+abaca
+absorbent cotton
 acetate rayon
+acrylic
+acrylic fiber
 aertex
+alpaca
+animal fiber
+animal fibre
 bagging
 baize
 balbriggan
@@ -25,9 +32,11 @@ bobbin lace
 bombazine
 book cloth
 boucle
+bowstring hemp
 broadcloth
 brussels lace
 buckram
+buntal
 bunting
 cambric
 camel's hair
@@ -37,6 +46,7 @@ camo
 canton crepe
 canton flannel
 canvass
+cashmere
 cerecloth
 challis
 chambray
@@ -48,7 +58,10 @@ chino
 cleaning cloth
 cloth
 cobweb
+cotton
+cotton fiber
 cotton flannel
+cotton wool
 courtelle
 crape
 crepe de chine
@@ -81,9 +94,13 @@ fag end
 faille
 fiber
 fibre
+fibril
+filament
 filet
 fillet
 flannelette
+flax
+fleece
 flying jib
 fore staysail
 fore-and-aft sail
@@ -117,6 +134,7 @@ hankie
 hanky
 harris tweed
 headsail
+hemp
 homespun
 hopsack
 hopsacking
@@ -129,6 +147,8 @@ inset
 jaconet
 jean
 jib
+jute
+kapok
 khaddar
 khadi
 khaki
@@ -139,6 +159,7 @@ leatherette
 lining
 linsey-woolsey
 lint
+long-staple cotton
 longyi
 lugsail
 lungi
@@ -150,6 +171,9 @@ macrame
 main course
 main-topsail
 mainsail
+man-made fiber
+manila hemp
+manilla hemp
 marocain
 marseille
 material
@@ -169,9 +193,13 @@ mousseline de sole
 nainsook
 nankeen
 narrow wale
+natural fiber
+natural fibre
 netting
 network
 ninon
+nylon
+oakum
 oddment
 oilcloth
 olive drab
@@ -192,6 +220,8 @@ pillow lace
 pilot cloth
 pique
 placket
+plant fiber
+plant fibre
 plush
 pocket-handkerchief
 point lace
@@ -200,7 +230,13 @@ poplin
 press of canvas
 press of sail
 quilting
+raffia
 rag
+raphia
+raveling
+ravelling
+raw wool
+red silk cotton
 remainder
 remnant
 rep
@@ -226,12 +262,19 @@ shag
 shantung
 sheet
 sheeting
+shetland wool
 shirting
 shirttail
+shoddy
+short-staple cotton
 shoulder patch
 shred
 silesia
+silk
+silk cotton
 silk serge
+sisal
+sisal hemp
 skysail
 snood
 spanker
@@ -242,13 +285,20 @@ sponge cloth
 spritsail
 square sail
 stammel
+staple
+staple fiber
+staple fibre
 staysail
 stockinet
 stockinette
+strand
+straw
+string
 suede cloth
 suiting
 swan's down
 swatch
+synthetic fiber
 tag
 tag end
 tammy
@@ -273,12 +323,14 @@ ultrasuede
 upholstery material
 valenciennes
 valenciennes lace
+vegetable silk
 veiling
 velcro
 velour
 velours
 velveteen
 vicuna
+virgin wool
 viscose rayon
 viyella
 vulcanized fiber
@@ -293,6 +345,7 @@ winceyette
 wiping cloth
 wire cloth
 wirework
+wool
 woolen
 woollen
 worsted

--- a/lists/nature/mineral.yml
+++ b/lists/nature/mineral.yml
@@ -2,22 +2,41 @@
 title: Minerals
 category: nature
 description: "Specific mineral specimens, crystals, and semi-precious stones"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 actinolite
 adamite
+ader wax
+adesite
 aegirine
 agate
+agglomerate
 alabaster
 albite
 alexandrite
 almandine
+almandite
+alumina
+aluminium oxide
+aluminum oxide
+alundum
 amazonite
 amber
 amethyst
+amphibole
+amphibole group
+amphibolite
+amygdaloid
 analcime
 anatase
 andalusite
 andesine
+andesite
 andradite
 anglesite
 anhydrite
@@ -28,9 +47,16 @@ anorthoclase
 anthophyllite
 antigorite
 apatite
+aphanite
+aplite
 apophyllite
 aquamarine
 aragonite
+arenaceous rock
+argentite
+argillaceous rock
+argillite
+argyrodite
 arsenopyrite
 asbestos
 astrophyllite
@@ -40,22 +66,47 @@ aurichalcite
 autunite
 axinite
 azurite
+baddeleyite
+balas
+balas ruby
+ballast
+bank gravel
+barium sulphate
 baryte
+barytes
+bastnaesite
 bastnasite
+batholite
+batholith
 bavenite
 benitoite
 beryl
 biotite
+bitter spar
 bixbyite
+blende
+bluestone
 borax
 bornite
 boulangerite
 bournonite
+breccia
 brookite
+brown goldstone
+brownstone
 brucite
+burnt sienna
+burnt umber
 bytownite
 cacoxenite
+cadmium sulphide
+cairngorm
+calamine
+calc-tufa
+calcedony
 calcite
+caliche
+carbuncle
 carnallite
 carnelian
 carnotite
@@ -63,10 +114,15 @@ cassiterite
 celestine
 celestite
 cerussite
+ceylonite
+chabasite
 chabazite
 chalcanthite
 chalcedony
 chalcopyrite
+chalk
+chalybite
+chamosite
 charoite
 chiastolite
 chlorite
@@ -74,96 +130,195 @@ chondrodite
 chromite
 chrysoberyl
 chrysocolla
+chrysolite
 chrysoprase
 chrysotile
 cinnabar
+cinnamon stone
 citrine
+claystone
 clinoclase
 clinozoisite
+cobalt bloom
 cobaltite
 coesite
 colemanite
+coltan
 columbite
+columbite-tantalite
+common topaz
+concentrate
+conglomerate
 cooperite
 copiapite
+copper glance
+copper pyrites
 cordierite
+cornelian
+corundom
 corundum
 covellite
 creedite
 cristobalite
 crocoite
+crushed rock
 cryolite
 cuprite
+cyanite
+dacite
+damourite
 danburite
 datolite
+demantoid
 descloizite
 diaspore
 diopside
 dioptase
+diorite
 dolomite
 dravite
+dressed ore
 dumortierite
+earth color
+earth wax
 elbaite
 emerald
+emery
+emery rock
+emery stone
 enstatite
 epidote
 epsomite
 erythrite
+essonite
 ettringite
 euxenite
+false topaz
 fayalite
 feldspar
+felspar
 ferberite
+fergusonite
+fieldstone
+fluor
 fluorapatite
 fluorite
+fluorspar
 forsterite
 franklinite
+french chalk
+gabbro
 gadolinite
 gahnite
 galena
 garnet
+garnierite
+germanite
+gesso
 gibbsite
+glauconite
 glaucophane
+gneiss
 goethite
+goldstone
+gothite
+graphic tellurium
+green lead ore
+greenland spar
 greenockite
+greensand
+greisen
+grit
+gritrock
+gritstone
 grossular
+groundmass
 grunerite
 gypsum
+haematite
 halite
+harlequin opal
+hausmannite
 hauyne
+heavy spar
 hedenbergite
 heliodor
 hematite
 hemimorphite
+hessonite
 heulandite
 hiddenite
+hornblende
+hornfels
+hornstone
 howlite
+humic shale
 humite
+iceland spar
+igneous rock
 illite
 ilmenite
 iolite
+iridosmine
+iron manganese tungsten
+iron ore
+iron pyrite
+isinglass
+jacinth
 jade
 jadeite
+jargon
+jargoon
 jarosite
 jasper
+kainite
+kernite
+kieserite
+kimberlite
+krennerite
 kunzite
 kyanite
 labradorite
+langbeinite
 lapis lazuli
+lava
 lazulite
 lazurite
+lead ore
 lepidolite
+lepidomelane
 leucite
+limonite
 linarite
 lizardite
+magma
+magnesia
 magnesite
+magnesium oxide
+magnetic iron-ore
+magnetic pyrites
 magnetite
 malachite
+maltha
 manganite
 marcasite
+marlite
+marlstone
+massicot
+massicotite
+matrix
+meerschaum
+metamorphic rock
+mexican onyx
 mica
 microcline
+millerite
 mimetite
+mineral
+mineral pitch
+mineral tar
+mineral wax
+mispickel
 molybdenite
 monazite
 montmorillonite
@@ -173,30 +328,65 @@ morganite
 muscovite
 natrolite
 nepheline
+nephelinite
+nephelite
 nephrite
 neptunite
+niobite
 niter
+nitrocalcite
 nosean
 obsidian
+ocher
+ochre
+oil shale
 oligoclase
+olivenite
 olivine
+onyx marble
 opal
+ore
+oriental alabaster
 orpiment
 orthoclase
+osmiridium
+ozocerite
+ozokerite
+pahoehoe
 painite
+paragneiss
+paragonite
+pay dirt
 pectolite
+pegmatite
 pentlandite
 periclase
 peridot
+peridotite
 petalite
 phenakite
+phillipsite
 phlogopite
 phosgenite
 pigeonite
+pillow lava
+pinite
+pit run
+pit-run gravel
+pitchblende
+pitchstone
+plagioclase
+plasma
+pleonaste
+pluton
+plutonic rock
 pollucite
+porphyritic rock
+porphyry
 prehnite
 proustite
 psilomelane
+pudding stone
 pumpellyite
 purpurite
 pyrargyrite
@@ -207,32 +397,77 @@ pyromorphite
 pyrope
 pyrophyllite
 pyroxene
+pyrrhotine
 pyrrhotite
 quartz
+quartzite
+raddle
+raw sienna
+raw umber
 realgar
+red clay
+reddle
+rensselaerite
+rhinestone
 rhodochrosite
+rhodolite
 rhodonite
+rhyolite
+road metal
+rock
+rock crystal
+rock salt
+rottenstone
+rubicelle
 ruby
+ruby spinel
+rudaceous rock
+ruddle
 rutile
+samarskite
 sanidine
 sapphire
+sapphirine
+sard
+sardine
+sardius
 scapolite
 scheelite
+schist
 schorl
 scolecite
+sedimentary rock
 selenite
+sepiolite
 serpentine
+shale
 shattuckite
+shingle
+shingling
+sial
 siderite
+sienna
 sillimanite
+siltstone
+sima
+sinoper
+sinopia
+sinopis
+smaltite
 smithsonite
+soap-rock
+soaprock
+soapstone
 sodalite
+spar
 sperrylite
 spessartine
 sphalerite
 spinel
+spinel ruby
 spodumene
 staurolite
+steatite
 stibnite
 stichtite
 stilbite
@@ -240,41 +475,75 @@ stishovite
 strontianite
 struvite
 sulfur
+sylvanite
+sylvine
 sylvite
 taaffeite
+tachylite
+taconite
 talc
+talcum
 tantalite
 tanzanite
 tennantite
 tenorite
+terra alba
 tetrahedrite
 thenardite
 thomsonite
+thorite
+thortveitite
 thulite
+tin pyrites
 titanite
 topaz
 tourmaline
+transparent quartz
 tremolite
 tridymite
 triphylite
+tripoli
 troilite
 trona
+tufa
+tuff
 tugtupite
 turquoise
 ulexite
+umber
 uraninite
+uranium ore
 vanadinite
 variscite
+verd antique
+verde antique
+vermiculite
+vesuvian
 vesuvianite
 vivianite
+volcanic glass
+volcanic rock
+water sapphire
 wavellite
+white asbestos
+white feldspar
+white lead ore
 willemite
 witherite
 wolframite
 wollastonite
 wulfenite
+wurtzite
 xenotime
+yellow ocher
+yellow ochre
+ytterbite
 zeolite
+zinc blende
+zinc spar
 zincite
+zinkenite
+zinnwaldite
 zircon
+zirconium silicate
 zoisite

--- a/lists/nature/soil.yml
+++ b/lists/nature/soil.yml
@@ -1,0 +1,80 @@
+---
+title: Soils and earths
+category: nature
+description: "Soils, clays, earths, sediments, and ground materials"
+source: "Open English WordNet 2025"
+sourceUrl: "https://en-word.net/downloads"
+sourceLicense: "CC BY 4.0"
+sourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+sourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+attribution: "Adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
+---
+adobe
+alluvial soil
+argil
+bentonite
+bleaching clay
+bleaching earth
+bog soil
+boulder clay
+chernozemic soil
+china clay
+china stone
+clay
+clunch
+daub
+desert soil
+desertic soil
+diatomaceous earth
+diatomite
+dirt
+earth
+engobe
+fireclay
+fuller's earth
+gilgai soil
+ground
+gumbo soil
+hardpan
+humus
+indian red
+indurated clay
+kaolin
+kaoline
+kieselguhr
+laterite
+leaf mold
+leaf mould
+leaf soil
+loam
+loess
+marl
+mire
+mud
+pipeclay
+podsol
+podsol soil
+podsolic soil
+podzol
+podzol soil
+porcelain clay
+potter's clay
+potter's earth
+prairie soil
+quartz sand
+regosol
+regur
+regur soil
+residual clay
+residual soil
+saprolite
+sedimentary clay
+silt
+soil
+subsoil
+surface soil
+till
+topsoil
+tundra soil
+undersoil
+wiesenboden

--- a/lists/nature/wood.yml
+++ b/lists/nature/wood.yml
@@ -2,6 +2,12 @@
 title: Types of wood
 category: nature
 description: "Specific types of hardwood and softwood timber materials"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
 alder
 amendoim
@@ -15,7 +21,9 @@ birch
 bloodwood
 bocote
 brazilian cherry
+brushwood
 butternut
+cabinet wood
 cedar
 cherry
 chestnut
@@ -23,10 +31,14 @@ cocobolo
 cork
 cumaru
 curly maple
+deal
 douglas fir
+driftwood
+dyewood
 ebony
 elm
 figured bubinga
+hardwood
 hemlock
 hevea
 hickory
@@ -34,15 +46,20 @@ ipe
 iroko
 ironwood
 jatoba
+knot
 koa
 lacewood
 larch
 lauan
 lignum vitae
+log
 macassar ebony
 mahogany
 maple
+matchwood
 merbau
+myall wood
+nurse log
 oak
 olive wood
 padauk
@@ -50,15 +67,21 @@ pau ferro
 pine
 pink ivory
 poplar
+pulpwood
 purpleheart
 quartersawn oak
+raw wood
 redwood
 rift sawn oak
 rosewood
 santos mahogany
 sapele
+saw log
+sawdust
 sheesham
 snakewood
+softwood
+splinters
 spruce
 sycamore
 teak

--- a/lists/thing/material.yml
+++ b/lists/thing/material.yml
@@ -2,44 +2,200 @@
 title: Materials
 category: thing
 description: "Various raw materials, plastics, stones, and crafting substances"
+additionalSource: "Open English WordNet 2025"
+additionalSourceUrl: "https://en-word.net/downloads"
+additionalSourceLicense: "CC BY 4.0"
+additionalSourceLicenseUrl: "https://creativecommons.org/licenses/by/4.0/"
+additionalSourceSha256: "38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93"
+additionalSourceAttribution: "Contains terms adapted from Open English WordNet 2025 by the Open English WordNet Community, derived from Princeton WordNet 3.1"
 ---
+abrasive
+abrasive material
+absorbate
+absorbent
+absorbent material
+absorber
 acrylic
 acrylic plastic
+adhesive
+adhesive agent
+adhesive material
+adsorbate
+adsorbent
+adsorbent material
+aggregate
 alabaster
 amber
+antiferromagnet
+art paper
 asphalt
 bakelite
 bamboo
 basalt
+bathroom tissue
 beeswax
+bimetal
+binder board
+binder's board
+birdlime
+blister copper
+blotter
+blotting paper
+blueprint paper
+bond paper
+bran
 brass
 bronze
 bronze material
+brown coal
+builder
+butcher paper
 carbon fiber
+carbon paper
+carborundum
+cardboard
+cartridge paper
+casein glue
 cast iron
+caulk
+caulking
 celluloid
 cement
 ceramic
+chad
+chalk dust
+coin silver
+composite material
+composition board
+computer paper
 concrete
+construction paper
+contaminant
+contamination
 copper
 copper material
 cork
+corrugated board
+corrugated cardboard
+crepe paper
+curl paper
+cutin
+denture adhesive
+detergent builder
+detritus
+diamagnet
+dielectric
+dimple
+dimpled chad
+drawing paper
+dust
+elastomer
+electroceramic material
+emery cloth
+emery paper
+excelsior
+facial tissue
+feedstock
+ferroelectric material
+ferromagnet
+fill
+filler
+filter paper
+flimsy
+floc
+floccule
+fluff
+flypaper
+foam
 frosted glass
+germanium
+gift wrap
 glass
+glass wool
+glue
 gold
 granite
+graph paper
+greaseproof paper
+gum
+hanging chad
+homogenate
+humate
+husk
+hyalin
+hyaline
+impregnation
+india paper
+insulator
 iron
+iron putty
+jet
+keratohyalin
+kleenex
+kraft
+kraft paper
+laid paper
 leather
 leather material
+ledger paper
+letter paper
+library paste
+lignite
+lime
 limestone
+linen paper
+litmus paper
+luting
 mahogany
+manifold paper
+manila
+manila paper
+manilla
+manilla paper
 marble
+marine glue
+mastic
+message pad
+millboard
+mineral wool
 mirrored glass
+mucilage
+mural wallpaper
+music paper
+newsprint
+nonconductor
+notepad
 oak
 obsidian
 obsidian glass
+oilpaper
+ola
+olla
+onionskin
 onyx material
+packing
+packing material
+pad
+pad of paper
+paper tape
+paper toweling
+paper-mache
+paperboard
+papier-mache
+papyrus
+parchment
+particulate
+particulate matter
+paste
+pasteboard
+peat
 pewter
+photo mural
+photo wallpaper
+piezoelectric material
+plant material
+plant product
+plant substance
 plaster
 plaster material
 plastic
@@ -47,27 +203,104 @@ platinum
 platinum material
 plexiglass
 polished concrete
+polycarboxylate cement
 porcelain
+poster board
+posterboard
+precursor
+pregnant chad
+putty
+pyroelectric material
+rag paper
+raw material
+recycling
+red-lead putty
 resin
+rice paper
+rock wool
+roofing paper
 rubber
+rubber cement
 sandstone
+score paper
+scratch pad
+scratch paper
+scribbling block
+sealant
+sealer
+sealing material
+semiconducting material
+shuck
+silicon
 silicone
 silver
+size
+sizing
 slate
+sodium pyrophosphate
+sodium tripolyphosphate
+sorbent
+sorbent material
+spirit gum
 stained glass
 stained glass material
 stainless steel
+stalk
 steel
+steel wool
 sterling silver
+strawboard
+stubble
 stucco
 suede
 suede material
+swinging chad
+tar paper
 teak
 terracotta
 terracotta material
+tetrasodium pyrophosphate
+textolite
+thickener
+thickening
+ticker tape
+tissue
+tissue paper
 titanium
 titanium material
+toilet paper
+toilet tissue
+toner
+tracing paper
+transfer paper
+translucent substance
+transparent substance
 travertine
+tri-chad
+tribasic sodium phosphate
+trisodium orthophosphate
+trisodium phosphate
+typewriter paper
+typing paper
+undercut
+vegetable tallow
+vellum
 velvet
+wad
+wadding
+wafer
+wall mural
+wallpaper
+waste paper
+wax paper
+wire wool
 wood
+wood coal
+wood shavings
+wove paper
+wrapping paper
+writing pad
+writing paper
 wrought iron
+zinc phosphate cement
+zinc phosphate dental cement


### PR DESCRIPTION
## Summary

- Add 815 curated material list entries from Open English WordNet 2025, representing 564 unique terms not previously present anywhere in the repository.
- Route each term to its most appropriate prompt category instead of expanding `thing.material` indiscriminately:
  - architecture/building-materials: +65
  - nature/mineral: +263
  - nature/soil: +69 (new list)
  - nature/wood: +17
  - art/pigment-and-dye: +121 (new list)
  - fashion/textile: +53
  - thing/material: +227
- Increase unique category vocabulary by architecture +65, nature +349, art +121, fashion +53, and thing +227.
- Deliberately exclude the bulk-chemical, drug, radioactive/WMD, animal-product, body/waste, and other poor-default branches from the prompt surface.

## Source and provenance

- Open English WordNet 2025 common-noun edition: https://en-word.net/downloads
- Source repository commit: `dc343f2683279ecbb13fab4e2fd778d7b162d287`
- Download archive SHA-256: `38b16326159f51853626b7d24a44c453fa88ab33f06fce5ec8fc5996d1c2be93`
- License: CC BY 4.0
- Attribution: Open English WordNet Community, derived from Princeton WordNet 3.1

Extraction is constrained to the `noun.substance` lexicographer source, then taxonomy-routed and manually moderated.

## Validation

- `npm run sanitise`
- `npm run build`
- `npm run lint`
- isolated build matches the committed source YAML exactly
- both new keys (`nature.soil`, `art.pigmentAndDye`) appear in generated `lists.json`
- all 815 list-entry additions resolve to the pinned `noun.substance` source
- moderation scan and `git diff --check` pass

Generated `lists.json` and `list-metadata.json` are intentionally omitted per repository policy; the post-merge workflow rebuilds them.
