### PR TITLE
Enable Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # npm: js-yaml, lodash, standard (build/sanitise tooling)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  # Actions used by .github/workflows/build.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly update checks for the two ecosystems this repo actually has: the three npm tooling dependencies (`js-yaml`, `lodash`, `standard`) and the actions used by `.github/workflows/build.yml`. Open npm PRs capped at five.

Note for reviewers: Dependabot's npm PRs will legitimately touch `package-lock.json` — the AGENTS.md rule against committing it applies to content contributions, not dependency updates.

Requested by fofr (M5P-005).