### PR TITLE
Add an exhaustive web design aesthetics list

### DIFF
--- a/lists/art/web-design-aesthetic.yml
+++ b/lists/art/web-design-aesthetic.yml
@@ -1,0 +1,362 @@
+---
+title: Web design aesthetics
+category: art
+description: "Visual aesthetics, interface styles, and art directions for website design"
+---
+1990s internet
+2000s glossy web
+2010s startup minimalism
+3d clay illustration
+3d product showcase
+8-bit interface
+abstract expressionist
+academic hypertext
+accessible high contrast
+acid graphics
+afrofuturist
+agency experimental
+airbrush gradient
+album-cover editorial
+alpine modern
+ambient gradient
+analog computer
+analog film
+animated collage
+animated gradient
+animated line art
+anime-inspired
+anti-design
+anti-grid
+apple-inspired minimalism
+architectural grid
+architectural minimalism
+architecture portfolio
+archive catalogue
+art deco
+art gallery
+art nouveau
+arts and crafts
+ascii art
+asymmetric editorial
+atompunk
+aurora gradient
+aurora interface
+avant-garde editorial
+bauhaus
+beauty editorial
+bento grid
+big-type minimalism
+biomorphic
+biophilic
+black and white editorial
+blackletter gothic
+blob gradient
+blobmorphism
+blueprint technical
+bold geometric
+bold minimalism
+bold serif editorial
+bookish literary
+border-heavy
+botanical illustration
+branded utility
+bright pop
+broken grid
+brutalist
+brutalist editorial
+brutalist typography
+bubblegum pop
+cabincore
+calm technology
+camp
+card-based modular
+cartoon interface
+cassette futurism
+cel-shaded
+chalkboard
+chrome y2k
+cinematic dark
+cinematic fullscreen
+claymorphism
+clean corporate
+clean saas
+clean-room clinical
+clockpunk
+cloudscape
+coastal minimalism
+code editor
+collage
+color-blocked
+comic book
+conceptual art
+constructivist
+contemporary gallery
+conversational interface
+corporate memphis
+cosmic
+cosy minimalism
+cottagecore
+craft paper
+crayon drawing
+cursor-reactive
+cut-paper collage
+cyber minimalism
+cyberdelic
+cyberpunk
+dark academia
+dark luxury
+dark mode
+darkroom photography
+data-dense dashboard
+data-visualization led
+de stijl
+desert modernism
+desktop metaphor
+developer-tool dark mode
+digital bauhaus
+digital maximalism
+digital scrapbook
+digital skeuomorphism
+digital zine
+dithered bitmap
+documentary editorial
+dopamine design
+dot-com era
+double-exposure photography
+dreamcore
+duotone
+e-commerce editorial
+early macintosh
+early web
+eco brutalism
+editorial brutalism
+editorial grid
+editorial minimalism
+electric gradients
+encyclopedic
+enterprise saas
+etched engraving
+ethereal
+experimental navigation
+expressionist
+expressive typography
+fairycore
+fashion editorial
+fauvist
+feminine luxury
+film grain
+fintech minimalism
+flat design
+fluent design
+folk art
+food editorial
+forestpunk
+frosted glass
+frutiger aero
+full-bleed photography
+full-screen video
+functional minimalism
+futurist
+game interface
+generative art
+geocities
+geometric minimalism
+gilded luxury
+glassmorphism
+glitch art
+glossy futurism
+gothic
+gouache illustration
+gradient maximalism
+gradient mesh
+graphic novel
+greek revival
+grid-based modernism
+gridless
+grunge
+hand-drawn
+handmade craft
+handwritten journal
+healthcare clarity
+high fashion minimalism
+high-contrast monochrome
+high-tech industrial
+hollywood regency
+holographic
+horizontal scrolling
+hospitality luxury
+humanist
+hypercolor
+hyperpop
+illustrated editorial
+illustrated interface
+immersive 3d
+indie sleaze
+industrial
+ink illustration
+interactive 3d
+international typographic style
+iridescent
+isometric illustration
+japandi
+japanese minimalism
+junglecore
+kawaii
+kidcore
+kinetic typography
+layered paper
+letterpress
+light academia
+lightweight utility
+line-art minimalism
+liquid glass
+lo-fi
+low-poly 3d
+luxury editorial
+luxury minimalism
+magazine editorial
+mallgoth
+masonry collage
+material design
+maximalist
+mcbling
+medieval manuscript
+memphis
+metallic chrome
+metro design
+micro-animation
+mid-century modern
+minimalist
+mixed-media collage
+modernist
+modular grid
+monochromatic
+monochrome
+monospace technical
+motion-first
+museum archive
+music-festival maximalism
+muted natural
+navigation-free
+neo-brutalist
+neo-grotesk
+neo-memphis
+neo-noir
+neo-retro
+neon noir
+neumorphism
+new ugly
+newspaper editorial
+nightclub flyer
+no-interface
+noise texture
+nonprofit humanist
+nostalgic software
+notebook sketch
+objective modernism
+oceanic
+organic modern
+organic shapes
+outdoor adventure
+oversized typography
+paper cutout
+paper texture
+paperback pulp
+parallax cinematic
+pastel goth
+pastel gradient
+pastel minimalism
+photocopy zine
+photographic minimalism
+photorealistic product
+pixel art
+playful geometry
+playful minimalism
+polaroid collage
+pop art
+post-internet
+postmodernist
+premium automotive
+product-led minimalism
+psychedelic
+punk zine
+quiet luxury
+radical typography
+raw html
+real-estate luxury
+responsive editorial
+restaurant editorial
+retro computing
+retro futurism
+retro gaming
+retro print
+risograph
+rococo
+romantic
+rounded saas
+scandinavian minimalism
+scientific journal
+scrapbook
+scroll-driven cinematic
+scrollytelling
+seapunk
+soft brutalism
+soft gradient
+soft minimalism
+solarized terminal
+solarpunk
+space age
+spatial interface
+split-screen editorial
+sport energy
+stained glass
+startup gradient
+steampunk
+sticker collage
+storybook illustration
+streamline moderne
+streetwear editorial
+surrealist
+sustainable brand
+swiss grid
+swiss modernism
+synthwave
+tactile digital
+technical documentation
+techno minimalism
+terminal interface
+text-first
+textile pattern
+theatrical
+tiling window manager
+traditional editorial
+translucent layers
+transparent interface
+travel editorial
+tropical modernism
+typewriter manuscript
+typographic maximalism
+ultra-minimal
+underground rave
+utopian futurism
+vaporwave
+variable typography
+vector illustration
+vibrant gradients
+victorian
+vintage advertising
+vintage botanical
+vintage computing
+warm minimalism
+watercolor illustration
+web 1.0
+web 2.0
+web3 iridescence
+weirdcore
+wellness minimalism
+western
+windows 95
+wireframe aesthetic
+woodblock print
+y2k futurism
+zen minimalism


### PR DESCRIPTION
## Why this change is needed

Prompt authors need web-specific visual directions for generating interfaces and websites. The existing general aesthetics list does not cover the breadth of web eras, interface treatments, layouts, or sector art directions.

## What changed

- Added `art.webDesignAesthetic` with 357 prompt-ready entries.
- Covered historical movements, internet eras, contemporary UI treatments, typography, illustration, layout, interaction, subcultures, and common sector aesthetics.

## Why this approach

A single flat, alphabetised list works with the package's existing random-list and composition APIs without tooling changes. Entries are concise visual directions rather than implementation instructions, so they combine cleanly with subjects, layouts, and other prompt lists.

## Verification

- `npm run sanitise` normalised the source list.
- `npm run build` completed successfully.
- `npm run lint` passed.
- Focused validation confirmed 357 unique, lowercase, locale-sorted entries.
- `git diff --check` passed.
- Generated JSON was deliberately excluded; the repository rebuilds it automatically after merge.
